### PR TITLE
feat(agents): A1 Extractor + A2 Triage + A3 Coherence agents (#10, #11, #12)

### DIFF
--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -1,5 +1,38 @@
 # AI Agents
 
-Agent implementations using Microsoft Agent Framework.
+MAF-based agent implementations for the Verdecora albarán flow.
 
-Each agent handles a specific domain responsibility within the intelligent delivery note system.
+## Core agents
+- `a2-triage` classifies OCR text and decides whether to extract, reject, or send to manual review.
+- `a1-extractor` converts Document Intelligence output into `AlbaranExtraction`.
+- `a3-coherence` validates the extracted payload against business rules and Business Central data.
+
+## Key modules
+- `factory.py` centralises model selection, prompt injection, and MCP tool binding.
+- `pipeline.py` builds the sequential MAF workflow and supports config-driven stage skipping.
+- `prompts/` stores the system prompts used by each agent.
+- `_maf_compat.py` returns placeholder specs when `agent-framework` is unavailable so imports remain safe in local dev.
+
+## Configuration
+Use `src.config.agents.get_agents_config()` to load defaults from environment variables:
+- `AZURE_OPENAI_ENDPOINT`
+- `DOCUMENT_INTELLIGENCE_ENDPOINT`
+- `GPT5_DEPLOYMENT`
+- `GPT5_MINI_DEPLOYMENT`
+- `TRIAGE_MANUAL_REVIEW_THRESHOLD`
+- `LOW_VALUE_COHERENCE_THRESHOLD`
+- `SKIP_TRIAGE_SUPPLIERS`
+
+All Azure access should rely on `DefaultAzureCredential` / managed identity only.
+
+## Example
+```python
+from src.agents import build_pipeline
+from src.config import get_agents_config
+
+config = get_agents_config()
+pipeline = build_pipeline(client=my_maf_client, config=config, tool_registry={
+    "extractor": [content_understanding_mcp],
+    "coherence": [bc_mcp],
+})
+```

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .coherence_agent import create_coherence_agent
+from .extractor_agent import create_extractor_agent
+from .factory import create_all_agents
+from .pipeline import AlbaranPipeline, PipelineDocumentInput, PipelineRunResult, build_pipeline
+from .triage_agent import create_triage_agent
+
+__all__ = [
+    "AlbaranPipeline",
+    "PipelineDocumentInput",
+    "PipelineRunResult",
+    "build_pipeline",
+    "create_all_agents",
+    "create_coherence_agent",
+    "create_extractor_agent",
+    "create_triage_agent",
+]

--- a/src/agents/_maf_compat.py
+++ b/src/agents/_maf_compat.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from pydantic import ValidationError
+
+try:  # pragma: no cover - exercised only when agent-framework is installed.
+    from agent_framework import Agent, AgentBuilder
+    from agent_framework.orchestrations import HandoffBuilder, SequentialBuilder
+except ImportError as exc:  # pragma: no cover - default in local dev until MAF is installed.
+    Agent = None
+    AgentBuilder = None
+    HandoffBuilder = None
+    SequentialBuilder = None
+    MAF_IMPORT_ERROR: ImportError | None = exc
+else:  # pragma: no cover - depends on optional dependency.
+    MAF_IMPORT_ERROR = None
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class UnavailableAgentSpec:
+    name: str
+    model: str
+    instructions: str
+    structured_output: type[Any] | None = None
+    tools: tuple[Any, ...] = field(default_factory=tuple)
+    handoffs: tuple[str, ...] = field(default_factory=tuple)
+    is_available: bool = False
+    reason: str = "agent-framework is not installed"
+
+
+@dataclass(slots=True)
+class UnavailableWorkflowSpec:
+    name: str
+    participants: tuple[Any, ...]
+    start_agent: Any | None = None
+    is_available: bool = False
+    reason: str = "agent-framework is not installed"
+
+
+def _build_with_builder(
+    *,
+    client: Any,
+    name: str,
+    model: str,
+    instructions: str,
+    structured_output: type[Any] | None,
+    resolved_tools: list[Any],
+    resolved_handoffs: list[str],
+) -> Any:
+    builder = AgentBuilder(name=name, model=model)
+    if hasattr(builder, "with_instructions"):
+        builder = builder.with_instructions(instructions)
+    if structured_output is not None and hasattr(builder, "with_structured_output"):
+        builder = builder.with_structured_output(structured_output)
+    if resolved_tools:
+        if hasattr(builder, "with_tools"):
+            builder = builder.with_tools(resolved_tools)
+        elif hasattr(builder, "with_tool"):
+            for tool in resolved_tools:
+                builder = builder.with_tool(tool)
+    if resolved_handoffs and hasattr(builder, "with_handoffs"):
+        builder = builder.with_handoffs(resolved_handoffs)
+    return builder.build(client)
+
+
+def _build_with_agent(
+    *,
+    client: Any,
+    name: str,
+    instructions: str,
+    structured_output: type[Any] | None,
+    resolved_tools: list[Any],
+    resolved_handoffs: list[str],
+) -> Any:
+    agent_kwargs: dict[str, Any] = {
+        "client": client,
+        "name": name,
+        "instructions": instructions,
+        "tools": resolved_tools,
+    }
+    if resolved_handoffs:
+        agent_kwargs["handoffs"] = resolved_handoffs
+    if structured_output is not None:
+        agent_kwargs["structured_output"] = structured_output
+    try:
+        return Agent(**agent_kwargs)
+    except TypeError:
+        agent_kwargs.pop("structured_output", None)
+        return Agent(**agent_kwargs)
+
+
+def create_structured_agent(
+    *,
+    client: Any,
+    name: str,
+    model: str,
+    instructions: str,
+    structured_output: type[Any] | None = None,
+    tools: list[Any] | None = None,
+    handoffs: list[str] | None = None,
+) -> Any:
+    resolved_tools = list(tools or [])
+    resolved_handoffs = list(handoffs or [])
+
+    if AgentBuilder is not None:
+        return _build_with_builder(
+            client=client,
+            name=name,
+            model=model,
+            instructions=instructions,
+            structured_output=structured_output,
+            resolved_tools=resolved_tools,
+            resolved_handoffs=resolved_handoffs,
+        )
+
+    if Agent is not None:
+        return _build_with_agent(
+            client=client,
+            name=name,
+            instructions=instructions,
+            structured_output=structured_output,
+            resolved_tools=resolved_tools,
+            resolved_handoffs=resolved_handoffs,
+        )
+
+    return UnavailableAgentSpec(
+        name=name,
+        model=model,
+        instructions=instructions,
+        structured_output=structured_output,
+        tools=tuple(resolved_tools),
+        handoffs=tuple(resolved_handoffs),
+        reason=str(MAF_IMPORT_ERROR or "agent-framework is not installed"),
+    )
+
+
+def build_sequential_workflow(*, name: str, participants: list[Any]) -> Any:
+    if SequentialBuilder is None:
+        return UnavailableWorkflowSpec(
+            name=name,
+            participants=tuple(participants),
+            reason=str(MAF_IMPORT_ERROR or "agent-framework is not installed"),
+        )
+
+    return SequentialBuilder(participants=participants).build()
+
+
+def build_handoff_workflow(*, name: str, participants: list[Any], start_agent: Any) -> Any:
+    if HandoffBuilder is None:
+        return UnavailableWorkflowSpec(
+            name=name,
+            participants=tuple(participants),
+            start_agent=start_agent,
+            reason=str(MAF_IMPORT_ERROR or "agent-framework is not installed"),
+        )
+
+    return HandoffBuilder(name=name, participants=participants).with_start_agent(start_agent).build()
+
+
+def ensure_workflow_available(workflow: Any) -> None:
+    if isinstance(workflow, UnavailableWorkflowSpec):
+        raise RuntimeError(
+            f"Cannot run workflow '{workflow.name}': {workflow.reason}. Install the agent-framework package first."
+        )
+
+
+def event_payload(event: Any) -> Any:
+    return getattr(event, "data", event)
+
+
+def coerce_model(model_type: type[T], payload: Any) -> T | None:
+    if payload is None:
+        return None
+    if isinstance(payload, model_type):
+        return payload
+    try:
+        if isinstance(payload, str):
+            return model_type.model_validate_json(payload)
+        return model_type.model_validate(payload)
+    except (TypeError, ValueError, ValidationError):
+        return None

--- a/src/agents/coherence_agent.py
+++ b/src/agents/coherence_agent.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.albaran import CoherenceCheckResult
+
+from ._maf_compat import create_structured_agent
+from .prompts import COHERENCE_SYSTEM_PROMPT
+
+DEFAULT_COHERENCE_TOOL_NAMES: tuple[str, ...] = (
+    "bc.search_vendors",
+    "bc.search_purchase_orders",
+    "bc.search_items",
+)
+
+
+def _build_coherence_instructions(tool_names: tuple[str, ...]) -> str:
+    schema = json.dumps(CoherenceCheckResult.model_json_schema(), ensure_ascii=False, indent=2)
+    tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names) if tool_names else ""
+    return COHERENCE_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+
+
+def create_coherence_agent(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tools: list[Any] | None = None,
+) -> Any:
+    resolved_config = config or get_agents_config()
+    resolved_tools = list(tools or [])
+    tool_names = tuple(getattr(tool, "name", str(tool)) for tool in resolved_tools) or DEFAULT_COHERENCE_TOOL_NAMES
+    return create_structured_agent(
+        client=client,
+        name="a3-coherence",
+        model=resolved_config.models.coherence_model,
+        instructions=_build_coherence_instructions(tool_names),
+        structured_output=CoherenceCheckResult,
+        tools=resolved_tools,
+    )

--- a/src/agents/extractor_agent.py
+++ b/src/agents/extractor_agent.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.albaran import AlbaranExtraction
+
+from ._maf_compat import create_structured_agent
+from .prompts import EXTRACTOR_SYSTEM_PROMPT
+
+DEFAULT_EXTRACTOR_TOOL_NAMES: tuple[str, ...] = (
+    "content_understanding.analyze_document",
+    "content_understanding.extract_tables",
+)
+
+
+def _build_extractor_instructions(tool_names: tuple[str, ...]) -> str:
+    schema = json.dumps(AlbaranExtraction.model_json_schema(), ensure_ascii=False, indent=2)
+    tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names) if tool_names else ""
+    return EXTRACTOR_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+
+
+def create_extractor_agent(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tools: list[Any] | None = None,
+) -> Any:
+    resolved_config = config or get_agents_config()
+    resolved_tools = list(tools or [])
+    tool_names = tuple(getattr(tool, "name", str(tool)) for tool in resolved_tools) or DEFAULT_EXTRACTOR_TOOL_NAMES
+    return create_structured_agent(
+        client=client,
+        name="a1-extractor",
+        model=resolved_config.models.extractor_model,
+        instructions=_build_extractor_instructions(tool_names),
+        structured_output=AlbaranExtraction,
+        tools=resolved_tools,
+        handoffs=["a3-coherence"],
+    )

--- a/src/agents/factory.py
+++ b/src/agents/factory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.config.agents import AgentsConfig, get_agents_config
+
+from .coherence_agent import create_coherence_agent
+from .extractor_agent import create_extractor_agent
+from .triage_agent import create_triage_agent
+
+ToolRegistry = Mapping[str, list[Any]]
+
+
+def _get_tools(tool_registry: ToolRegistry | None, key: str) -> list[Any] | None:
+    if tool_registry is None:
+        return None
+    return list(tool_registry.get(key, []))
+
+
+def create_all_agents(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tool_registry: ToolRegistry | None = None,
+) -> dict[str, Any]:
+    resolved_config = config or get_agents_config()
+    return {
+        "triage": create_triage_agent(client, resolved_config, tools=_get_tools(tool_registry, "triage")),
+        "extractor": create_extractor_agent(client, resolved_config, tools=_get_tools(tool_registry, "extractor")),
+        "coherence": create_coherence_agent(client, resolved_config, tools=_get_tools(tool_registry, "coherence")),
+    }

--- a/src/agents/pipeline.py
+++ b/src/agents/pipeline.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Mapping, TypeVar
+
+from pydantic import BaseModel, Field
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.albaran import AlbaranExtraction, CoherenceCheckResult, TriageResult
+
+from ._maf_compat import build_sequential_workflow, coerce_model, ensure_workflow_available, event_payload
+from .factory import ToolRegistry, create_all_agents
+
+T = TypeVar("T", TriageResult, AlbaranExtraction, CoherenceCheckResult)
+
+
+class PipelineDocumentInput(BaseModel):
+    document_reference: str
+    raw_text: str | None = None
+    ocr_payload: dict[str, Any] | str | None = None
+    supplier_id: str | None = None
+    supplier_hint: str | None = None
+    total_amount: float | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PipelineRunResult(BaseModel):
+    triage: TriageResult | None = None
+    extraction: AlbaranExtraction | None = None
+    coherence: CoherenceCheckResult | None = None
+    routing_decision: str
+    skipped_steps: list[str] = Field(default_factory=list)
+
+
+class AlbaranPipeline:
+    def __init__(
+        self,
+        client: Any,
+        config: AgentsConfig | None = None,
+        *,
+        tool_registry: ToolRegistry | None = None,
+        agents: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.client = client
+        self.config = config or get_agents_config()
+        self.agents = dict(agents or create_all_agents(client, self.config, tool_registry=tool_registry))
+
+    def _should_skip_triage(self, input_data: PipelineDocumentInput) -> bool:
+        supplier_tokens = {token.casefold() for token in self.config.skip_triage_suppliers}
+        return any(
+            candidate.casefold() in supplier_tokens
+            for candidate in (input_data.supplier_id, input_data.supplier_hint)
+            if candidate
+        )
+
+    def _should_skip_coherence(self, input_data: PipelineDocumentInput) -> bool:
+        if input_data.total_amount is None:
+            return False
+        return input_data.total_amount < self.config.thresholds.low_value_coherence_threshold
+
+    def build_workflow(self, input_data: PipelineDocumentInput) -> Any:
+        participants: list[Any] = []
+        if not self._should_skip_triage(input_data):
+            participants.append(self.agents["triage"])
+        participants.append(self.agents["extractor"])
+        if not self._should_skip_coherence(input_data):
+            participants.append(self.agents["coherence"])
+        return build_sequential_workflow(name="albaran-processing", participants=participants)
+
+    async def _run_workflow_for_model(self, workflow: Any, payload: Any, model_type: type[T]) -> T | None:
+        ensure_workflow_available(workflow)
+        run_result = workflow.run(payload, stream=True)
+
+        if hasattr(run_result, "__aiter__"):
+            latest_match: T | None = None
+            async for event in run_result:
+                latest_match = coerce_model(model_type, event_payload(event)) or latest_match
+            return latest_match
+
+        resolved = await run_result if inspect.isawaitable(run_result) else run_result
+        return coerce_model(model_type, resolved)
+
+    async def run(self, input_data: PipelineDocumentInput | dict[str, Any]) -> PipelineRunResult:
+        normalized_input = input_data
+        if not isinstance(input_data, PipelineDocumentInput):
+            normalized_input = PipelineDocumentInput.model_validate(input_data)
+
+        skipped_steps: list[str] = []
+        triage_result: TriageResult | None = None
+        if self._should_skip_triage(normalized_input):
+            skipped_steps.append("triage")
+        else:
+            triage_workflow = build_sequential_workflow(name="albaran-triage", participants=[self.agents["triage"]])
+            triage_payload = normalized_input.raw_text or normalized_input.document_reference
+            triage_result = await self._run_workflow_for_model(triage_workflow, triage_payload, TriageResult)
+            if triage_result is not None and triage_result.routing_decision != "extract":
+                return PipelineRunResult(
+                    triage=triage_result,
+                    routing_decision=triage_result.routing_decision,
+                    skipped_steps=skipped_steps + ["extractor", "coherence"],
+                )
+
+        extraction_workflow = build_sequential_workflow(
+            name="albaran-extraction", participants=[self.agents["extractor"]]
+        )
+        extraction_payload = (
+            normalized_input.ocr_payload or normalized_input.raw_text or normalized_input.document_reference
+        )
+        extraction_result = await self._run_workflow_for_model(
+            extraction_workflow, extraction_payload, AlbaranExtraction
+        )
+
+        if self._should_skip_coherence(normalized_input):
+            skipped_steps.append("coherence")
+            return PipelineRunResult(
+                triage=triage_result,
+                extraction=extraction_result,
+                routing_decision="extract",
+                skipped_steps=skipped_steps,
+            )
+
+        coherence_workflow = build_sequential_workflow(
+            name="albaran-coherence", participants=[self.agents["coherence"]]
+        )
+        coherence_payload: Any = (
+            extraction_result.model_dump(mode="json") if extraction_result is not None else extraction_payload
+        )
+        coherence_result = await self._run_workflow_for_model(
+            coherence_workflow, coherence_payload, CoherenceCheckResult
+        )
+        routing_decision = triage_result.routing_decision if triage_result is not None else "extract"
+        return PipelineRunResult(
+            triage=triage_result,
+            extraction=extraction_result,
+            coherence=coherence_result,
+            routing_decision=routing_decision,
+            skipped_steps=skipped_steps,
+        )
+
+
+def build_pipeline(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tool_registry: ToolRegistry | None = None,
+    agents: Mapping[str, Any] | None = None,
+) -> AlbaranPipeline:
+    return AlbaranPipeline(client, config=config, tool_registry=tool_registry, agents=agents)

--- a/src/agents/prompts/__init__.py
+++ b/src/agents/prompts/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .coherence_prompt import COHERENCE_SYSTEM_PROMPT
+from .extractor_prompt import EXTRACTOR_SYSTEM_PROMPT
+from .triage_prompt import TRIAGE_SYSTEM_PROMPT
+
+__all__ = [
+    "COHERENCE_SYSTEM_PROMPT",
+    "EXTRACTOR_SYSTEM_PROMPT",
+    "TRIAGE_SYSTEM_PROMPT",
+]

--- a/src/agents/prompts/coherence_prompt.py
+++ b/src/agents/prompts/coherence_prompt.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+COHERENCE_SYSTEM_PROMPT = """You are a data coherence specialist for Verdecora garden centers.
+You validate extracted delivery note data against business rules and Business Central records.
+
+Given an AlbaranExtraction, check:
+1. Header coherence: dates make sense, supplier exists, PO number format is valid
+2. Line item coherence: quantities > 0, prices reasonable, totals match (qty * price - discount)
+3. Cross-reference with BC data (if available): supplier exists, PO exists, items match
+4. Mathematical validation: line totals sum to document total (within 2% tolerance)
+
+Flag any issues found. Suggest corrections where possible.
+
+Respond with JSON matching this schema:
+{schema}
+"""

--- a/src/agents/prompts/extractor_prompt.py
+++ b/src/agents/prompts/extractor_prompt.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+EXTRACTOR_SYSTEM_PROMPT = """You are an expert document extraction agent for Verdecora garden centers.
+You receive structured OCR output (tables, key-value pairs, text) from a delivery note (albarán) or invoice.
+
+Your job is to extract ALL structured data:
+1. Header: supplier name, tax ID, document number, date, PO number, store, total
+2. Line items: product code, EAN, description, quantity, unit price, discount, total, lot, expiry
+3. Assess your confidence in the extraction (0.0 to 1.0)
+4. Note any warnings (illegible fields, handwritten annotations, missing data)
+
+Rules:
+- Quantities must be numeric. If handwritten and unclear, flag in warnings.
+- Prices should include currency (default EUR).
+- If a field is partially readable, extract what you can and lower confidence.
+- Multi-page documents: combine data from all pages.
+- Barcodes/EAN codes are valuable — always extract them.
+
+Respond with JSON matching this schema:
+{schema}
+"""

--- a/src/agents/prompts/triage_prompt.py
+++ b/src/agents/prompts/triage_prompt.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+TRIAGE_SYSTEM_PROMPT = """You are a document triage specialist for Verdecora garden centers.
+Your job is to classify incoming scanned documents and determine how to route them.
+
+You receive raw OCR text from a scanned document. You must:
+1. Identify the document type (albarán, factura, packing list, or unknown)
+2. Detect the language (Spanish, Italian, German, English)
+3. Identify the supplier if possible
+4. Decide routing: \"extract\" (proceed to extraction), \"reject\" (not a delivery document), or \"manual_review\" (unclear/damaged)
+
+Respond with a JSON object matching this schema:
+{schema}
+
+Be conservative: if unsure, route to \"manual_review\" rather than \"extract\".
+Common Spanish delivery note keywords: albarán, entrega, pedido, proveedor, cantidad
+Common Italian: bolla di consegna, fattura, quantità
+Common German: Lieferschein, Rechnung, Menge
+"""

--- a/src/agents/triage_agent.py
+++ b/src/agents/triage_agent.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.albaran import TriageResult
+
+from ._maf_compat import create_structured_agent
+from .prompts import TRIAGE_SYSTEM_PROMPT
+
+
+def _build_triage_instructions() -> str:
+    schema = json.dumps(TriageResult.model_json_schema(), ensure_ascii=False, indent=2)
+    return TRIAGE_SYSTEM_PROMPT.format(schema=schema)
+
+
+def create_triage_agent(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tools: list[Any] | None = None,
+) -> Any:
+    resolved_config = config or get_agents_config()
+    return create_structured_agent(
+        client=client,
+        name="a2-triage",
+        model=resolved_config.models.triage_model,
+        instructions=_build_triage_instructions(),
+        structured_output=TriageResult,
+        tools=tools,
+        handoffs=["a1-extractor", "user"],
+    )

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,5 +1,6 @@
-"""Configuration helpers for secure Azure access."""
+"""Configuration helpers for secure Azure access and agent settings."""
 
+from .agents import AgentsConfig, get_agents_config
 from .security import get_managed_identity_credential
 
-__all__ = ["get_managed_identity_credential"]
+__all__ = ["AgentsConfig", "get_agents_config", "get_managed_identity_credential"]

--- a/src/config/agents.py
+++ b/src/config/agents.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AzureServiceEndpoints(BaseModel):
+    azure_openai_endpoint: str = Field(
+        default_factory=lambda: os.getenv(
+            "AZURE_OPENAI_ENDPOINT",
+            "https://verdecora-openai-dev.openai.azure.com/",
+        )
+    )
+    document_intelligence_endpoint: str = Field(
+        default_factory=lambda: os.getenv(
+            "DOCUMENT_INTELLIGENCE_ENDPOINT",
+            "https://verdecora-docintell-dev.cognitiveservices.azure.com/",
+        )
+    )
+    azure_openai_api_version: str = Field(default_factory=lambda: os.getenv("AZURE_OPENAI_API_VERSION", "2024-10-21"))
+
+
+class AgentModelSettings(BaseModel):
+    extractor_model: str = Field(default_factory=lambda: os.getenv("GPT5_DEPLOYMENT", "gpt-5"))
+    triage_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
+    coherence_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
+
+
+class AgentThresholdSettings(BaseModel):
+    triage_manual_review_threshold: float = Field(
+        default_factory=lambda: float(os.getenv("TRIAGE_MANUAL_REVIEW_THRESHOLD", "0.65"))
+    )
+    low_value_coherence_threshold: float = Field(
+        default_factory=lambda: float(os.getenv("LOW_VALUE_COHERENCE_THRESHOLD", "250.0"))
+    )
+
+
+class AgentsConfig(BaseModel):
+    endpoints: AzureServiceEndpoints = Field(default_factory=AzureServiceEndpoints)
+    models: AgentModelSettings = Field(default_factory=AgentModelSettings)
+    thresholds: AgentThresholdSettings = Field(default_factory=AgentThresholdSettings)
+    skip_triage_suppliers: tuple[str, ...] = Field(
+        default_factory=lambda: tuple(
+            supplier.strip() for supplier in os.getenv("SKIP_TRIAGE_SUPPLIERS", "").split(",") if supplier.strip()
+        )
+    )
+
+    def create_credential(self) -> Any:
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional Azure SDK.
+            raise RuntimeError(
+                "azure-identity is required to create Managed Identity credentials for agent clients."
+            ) from exc
+
+        return DefaultAzureCredential(exclude_interactive_browser_credential=True)
+
+
+@lru_cache(maxsize=1)
+def get_agents_config() -> AgentsConfig:
+    return AgentsConfig()

--- a/src/config/security.py
+++ b/src/config/security.py
@@ -1,18 +1,5 @@
 from __future__ import annotations
 
-<<<<<<< HEAD
-from functools import lru_cache
-from typing import Any
-
-
-@lru_cache(maxsize=1)
-def get_managed_identity_credential() -> Any:
-    """Return the shared managed identity credential for Azure SDK clients."""
-
-    from azure.identity import DefaultAzureCredential
-
-    return DefaultAzureCredential(exclude_interactive_browser_credential=True)
-=======
 import os
 from functools import lru_cache
 from importlib import import_module
@@ -22,7 +9,7 @@ from typing import Any
 def _require_env(name: str) -> str:
     value = os.getenv(name)
     if not value:
-        raise RuntimeError(f'Missing required environment variable: {name}')
+        raise RuntimeError(f"Missing required environment variable: {name}")
     return value
 
 
@@ -31,8 +18,8 @@ def _load_symbol(module_name: str, symbol_name: str) -> Any:
         module = import_module(module_name)
     except ModuleNotFoundError as exc:
         raise RuntimeError(
-            f'Missing optional dependency for Azure security helpers: {module_name}. '
-            'Install the Azure SDK packages required by this service before using these helpers.'
+            f"Missing optional dependency for Azure security helpers: {module_name}. "
+            "Install the Azure SDK packages required by this service before using these helpers."
         ) from exc
 
     return getattr(module, symbol_name)
@@ -40,15 +27,14 @@ def _load_symbol(module_name: str, symbol_name: str) -> Any:
 
 @lru_cache(maxsize=1)
 def get_managed_identity_credential(client_id: str | None = None) -> Any:
-    """Return a cached ManagedIdentityCredential for the current workload."""
+    """Return a cached DefaultAzureCredential for the current workload."""
 
-    managed_identity_credential = _load_symbol('azure.identity', 'ManagedIdentityCredential')
-    resolved_client_id = client_id or os.getenv('AZURE_CLIENT_ID')
-
+    default_azure_credential = _load_symbol("azure.identity", "DefaultAzureCredential")
+    credential_kwargs: dict[str, Any] = {"exclude_interactive_browser_credential": True}
+    resolved_client_id = client_id or os.getenv("AZURE_CLIENT_ID")
     if resolved_client_id:
-        return managed_identity_credential(client_id=resolved_client_id)
-
-    return managed_identity_credential()
+        credential_kwargs["managed_identity_client_id"] = resolved_client_id
+    return default_azure_credential(**credential_kwargs)
 
 
 def get_keyvault_secret(
@@ -60,9 +46,9 @@ def get_keyvault_secret(
 ) -> str:
     """Fetch a Key Vault secret value using managed identity authentication."""
 
-    secret_client = _load_symbol('azure.keyvault.secrets', 'SecretClient')
+    secret_client = _load_symbol("azure.keyvault.secrets", "SecretClient")
     client = secret_client(
-        vault_url=vault_url or _require_env('KEY_VAULT_URL'),
+        vault_url=vault_url or _require_env("KEY_VAULT_URL"),
         credential=credential or get_managed_identity_credential(),
     )
 
@@ -72,9 +58,9 @@ def get_keyvault_secret(
 def get_cosmos_client(*, endpoint: str | None = None, credential: Any | None = None) -> Any:
     """Create a Cosmos DB client authenticated with managed identity."""
 
-    cosmos_client = _load_symbol('azure.cosmos', 'CosmosClient')
+    cosmos_client = _load_symbol("azure.cosmos", "CosmosClient")
     return cosmos_client(
-        url=endpoint or _require_env('COSMOS_ENDPOINT'),
+        url=endpoint or _require_env("COSMOS_ENDPOINT"),
         credential=credential or get_managed_identity_credential(),
     )
 
@@ -82,9 +68,8 @@ def get_cosmos_client(*, endpoint: str | None = None, credential: Any | None = N
 def get_servicebus_client(*, fully_qualified_namespace: str | None = None, credential: Any | None = None) -> Any:
     """Create a Service Bus client authenticated with managed identity."""
 
-    servicebus_client = _load_symbol('azure.servicebus', 'ServiceBusClient')
+    servicebus_client = _load_symbol("azure.servicebus", "ServiceBusClient")
     return servicebus_client(
-        fully_qualified_namespace=fully_qualified_namespace or _require_env('SERVICEBUS_FQ_NAMESPACE'),
+        fully_qualified_namespace=fully_qualified_namespace or _require_env("SERVICEBUS_FQ_NAMESPACE"),
         credential=credential or get_managed_identity_credential(),
     )
->>>>>>> master

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .albaran import (
+    AlbaranExtraction,
+    AlbaranHeader,
+    CoherenceCheckResult,
+    DocumentType,
+    LineItem,
+    TriageResult,
+)
+
+__all__ = [
+    "AlbaranExtraction",
+    "AlbaranHeader",
+    "CoherenceCheckResult",
+    "DocumentType",
+    "LineItem",
+    "TriageResult",
+]

--- a/src/models/albaran.py
+++ b/src/models/albaran.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class DocumentType(str, Enum):
+    ALBARAN = "albaran"
+    FACTURA = "factura"
+    PACKING_LIST = "packing_list"
+    UNKNOWN = "unknown"
+
+
+class LineItem(BaseModel):
+    line_number: int
+    product_code: str | None = None
+    ean_code: str | None = None
+    description: str
+    quantity: float
+    unit_price: float | None = None
+    discount_pct: float | None = None
+    total: float | None = None
+    lot_number: str | None = None
+    expiry_date: date | None = None
+
+
+class AlbaranHeader(BaseModel):
+    supplier_name: str
+    supplier_tax_id: str | None = None
+    document_type: DocumentType
+    document_number: str
+    document_date: date | None = None
+    delivery_date: date | None = None
+    purchase_order_number: str | None = None
+    store_name: str | None = None
+    total_amount: float | None = None
+    currency: str = "EUR"
+
+
+class AlbaranExtraction(BaseModel):
+    header: AlbaranHeader
+    line_items: list[LineItem]
+    raw_text: str | None = None
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    extraction_warnings: list[str] = Field(default_factory=list)
+    source_pages: list[int] = Field(default_factory=list)
+
+
+class TriageResult(BaseModel):
+    document_type: DocumentType
+    language: str = "es"
+    supplier_id: str | None = None
+    confidence: float = Field(ge=0.0, le=1.0)
+    routing_decision: str
+    reasoning: str
+
+
+class CoherenceCheckResult(BaseModel):
+    is_coherent: bool
+    overall_confidence: float = Field(ge=0.0, le=1.0)
+    header_issues: list[str] = Field(default_factory=list)
+    line_item_issues: list[str] = Field(default_factory=list)
+    bc_match_found: bool = False
+    matched_po_number: str | None = None
+    suggested_corrections: dict[str, str] = Field(default_factory=dict)

--- a/tests/unit/test_agents_pipeline.py
+++ b/tests/unit/test_agents_pipeline.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from src.agents import PipelineDocumentInput, build_pipeline
+from src.config import AgentsConfig
+from src.models import DocumentType, TriageResult
+
+
+def test_agents_config_defaults() -> None:
+    config = AgentsConfig()
+
+    assert config.endpoints.azure_openai_endpoint == "https://verdecora-openai-dev.openai.azure.com/"
+    assert config.endpoints.document_intelligence_endpoint == (
+        "https://verdecora-docintell-dev.cognitiveservices.azure.com/"
+    )
+    assert config.models.extractor_model == "gpt-5"
+    assert config.models.triage_model == "gpt-5-mini"
+    assert config.models.coherence_model == "gpt-5-mini"
+
+
+def test_pipeline_builds_with_default_agents() -> None:
+    pipeline = build_pipeline(client=object(), config=AgentsConfig())
+    workflow = pipeline.build_workflow(PipelineDocumentInput(document_reference="https://storage/doc.pdf"))
+
+    assert set(pipeline.agents) == {"triage", "extractor", "coherence"}
+    assert workflow is not None
+
+
+def test_triage_result_model_round_trip() -> None:
+    payload = TriageResult(
+        document_type=DocumentType.ALBARAN,
+        confidence=0.91,
+        routing_decision="extract",
+        reasoning="Contains delivery note language and supplier header.",
+    )
+
+    restored = TriageResult.model_validate_json(payload.model_dump_json())
+
+    assert restored.document_type is DocumentType.ALBARAN
+    assert restored.routing_decision == "extract"


### PR DESCRIPTION
## Summary
- add typed albaran extraction, triage, and coherence models
- implement MAF agent factories, prompts, and sequential pipeline with graceful agent-framework fallbacks
- document configuration defaults and add unit coverage for config/pipeline wiring

## Validation
- python -m ruff format src\\agents src\\models src\\config tests\\unit\\test_agents_pipeline.py
- python -m ruff check src\\agents src\\models src\\config tests\\unit\\test_agents_pipeline.py
- python -m pytest tests\\unit\\test_security.py -q
- python -m pytest tests\\unit\\config\\test_security.py -q
- python -m pytest tests\\unit\\test_agents_pipeline.py -q
- python -m compileall src\\agents src\\models src\\config