### PR TITLE
feat(infra+mcp): Azure OpenAI Bicep + MCP servers (#13, #14, #15, #19)

### DIFF
--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -21,13 +21,7 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
   kind: 'GlobalDocumentDB'
   properties: {
     databaseAccountOfferType: 'Standard'
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
     disableLocalAuth: true
->>>>>>> master
->>>>>>> master
     publicNetworkAccess: 'Disabled'
     locations: [
       {

--- a/infra/modules/docintell.bicep
+++ b/infra/modules/docintell.bicep
@@ -1,0 +1,36 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for Document Intelligence resources.')
+param location string
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  'managed-by': 'bicep'
+}
+
+var docIntellAccountName = 'verdecora-docintell-${environment}'
+var docIntellCustomSubdomainName = 'verdecora-docintell-${environment}'
+
+resource docIntellAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: docIntellAccountName
+  location: location
+  tags: tags
+  kind: 'FormRecognizer'
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    customSubDomainName: docIntellCustomSubdomainName
+    disableLocalAuth: true
+  }
+}
+
+@description('Document Intelligence account id.')
+output docIntellId string = docIntellAccount.id
+
+@description('Document Intelligence endpoint.')
+output docIntellEndpoint string = 'https://${docIntellCustomSubdomainName}.cognitiveservices.azure.com/'

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -21,6 +21,12 @@ param keyVaultName string
 @description('Name of the Azure Communication Services resource used for HITL email.')
 param communicationServiceName string
 
+@description('Optional Azure OpenAI account name for granting data-plane access to the ACA identity.')
+param openAiAccountName string = ''
+
+@description('Optional Document Intelligence account name for granting data-plane access to the ACA identity.')
+param docIntellAccountName string = ''
+
 @description('Optional suffix appended to the managed identity names.')
 param nameSuffix string = ''
 
@@ -30,6 +36,8 @@ var serviceBusDataReceiverRoleDefinitionId = subscriptionResourceId('Microsoft.A
 var storageBlobDataReaderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1')
 var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
 var communicationServicesContributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2495237a-0d06-4fc0-b5ef-8a60a7cb5773')
+var cognitiveServicesOpenAIUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+var cognitiveServicesUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
 
 var agenticOrchestratorIdentityName = empty(nameSuffix) ? 'agentic-orchestrator' : 'agentic-orchestrator-${nameSuffix}'
 var communicationAgentIdentityName = empty(nameSuffix) ? 'communication-agent' : 'communication-agent-${nameSuffix}'
@@ -54,6 +62,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 
 resource communicationService 'Microsoft.Communication/communicationServices@2023-04-01' existing = {
   name: communicationServiceName
+}
+
+resource openAiAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = if (!empty(openAiAccountName)) {
+  name: openAiAccountName
+}
+
+resource docIntellAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = if (!empty(docIntellAccountName)) {
+  name: docIntellAccountName
 }
 
 resource agenticOrchestratorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -249,6 +265,26 @@ resource communicationAgentCommunicationServicesContributorRoleAssignment 'Micro
     principalId: communicationAgentIdentity.properties.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: communicationServicesContributorRoleDefinitionId
+  }
+}
+
+resource agenticOrchestratorOpenAiUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(openAiAccountName)) {
+  name: guid(openAiAccount.id, agenticOrchestratorIdentity.name, cognitiveServicesOpenAIUserRoleDefinitionId)
+  scope: openAiAccount
+  properties: {
+    principalId: agenticOrchestratorIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: cognitiveServicesOpenAIUserRoleDefinitionId
+  }
+}
+
+resource agenticOrchestratorDocIntellUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(docIntellAccountName)) {
+  name: guid(docIntellAccount.id, agenticOrchestratorIdentity.name, cognitiveServicesUserRoleDefinitionId)
+  scope: docIntellAccount
+  properties: {
+    principalId: agenticOrchestratorIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: cognitiveServicesUserRoleDefinitionId
   }
 }
 

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -89,6 +89,30 @@ module monitoring './monitoring.bicep' = {
   ]
 }
 
+module openAi './openai.bicep' = {
+  name: 'openAi'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
+module docIntell './docintell.bicep' = {
+  name: 'docIntell'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
 @description('Resource group id.')
 output resourceGroupId string = resourceGroup.outputs.resourceGroupId
 
@@ -112,3 +136,18 @@ output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspace
 
 @description('Application Insights id.')
 output applicationInsightsId string = monitoring.outputs.applicationInsightsId
+
+@description('Azure OpenAI account id.')
+output openaiAccountId string = openAi.outputs.openaiAccountId
+
+@description('Azure OpenAI endpoint.')
+output openaiEndpoint string = openAi.outputs.openaiEndpoint
+
+@description('Azure OpenAI principal id.')
+output openaiPrincipalId string = openAi.outputs.openaiPrincipalId
+
+@description('Document Intelligence account id.')
+output docIntellId string = docIntell.outputs.docIntellId
+
+@description('Document Intelligence endpoint.')
+output docIntellEndpoint string = docIntell.outputs.docIntellEndpoint

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -114,7 +114,7 @@ module docIntell './docintell.bicep' = {
 }
 
 @description('Resource group id.')
-output resourceGroupId string = resourceGroup.outputs.resourceGroupId
+output resourceGroupId string = rg.outputs.resourceGroupId
 
 @description('Virtual network id.')
 output virtualNetworkId string = network.outputs.virtualNetworkId

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -36,13 +36,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   properties: {
     Application_Type: 'web'
     WorkspaceResourceId: logAnalytics.id
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
     disableLocalAuth: true
->>>>>>> master
->>>>>>> master
     publicNetworkAccessForIngestion: 'Disabled'
     publicNetworkAccessForQuery: 'Disabled'
   }

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -1,0 +1,77 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for Azure OpenAI resources.')
+param location string
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  'managed-by': 'bicep'
+}
+
+var openAiAccountName = 'verdecora-openai-${environment}'
+var openAiCustomSubdomainName = 'verdecora-openai-${environment}'
+
+resource openAiAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: openAiAccountName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  kind: 'OpenAI'
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    customSubDomainName: openAiCustomSubdomainName
+    disableLocalAuth: true
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource gpt5Deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: openAiAccount
+  name: 'gpt-5'
+  sku: {
+    name: 'GlobalStandard'
+    capacity: 10
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: 'gpt-5'
+      version: '2025-08-07'
+    }
+    versionUpgradeOption: 'NoAutoUpgrade'
+  }
+}
+
+resource gpt5MiniDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: openAiAccount
+  name: 'gpt-5-mini'
+  sku: {
+    name: 'GlobalStandard'
+    capacity: 10
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: 'gpt-5-mini'
+      version: '2025-08-07'
+    }
+    versionUpgradeOption: 'NoAutoUpgrade'
+  }
+}
+
+@description('Azure OpenAI account id.')
+output openaiAccountId string = openAiAccount.id
+
+@description('Azure OpenAI endpoint.')
+output openaiEndpoint string = 'https://${openAiCustomSubdomainName}.openai.azure.com/'
+
+@description('Azure OpenAI system-assigned managed identity principal id.')
+output openaiPrincipalId string = openAiAccount.identity.principalId

--- a/infra/modules/servicebus.bicep
+++ b/infra/modules/servicebus.bicep
@@ -23,13 +23,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview
     tier: 'Standard'
   }
   properties: {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
     disableLocalAuth: true
->>>>>>> master
->>>>>>> master
     publicNetworkAccess: 'Disabled'
   }
 }

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -26,13 +26,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   properties: {
     accessTier: 'Hot'
     allowBlobPublicAccess: false
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
     allowSharedKeyAccess: false
->>>>>>> master
->>>>>>> master
     minimumTlsVersion: 'TLS1_2'
     publicNetworkAccess: 'Disabled'
     supportsHttpsTrafficOnly: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ authors = [
     { name = "Kiko de Angel", email = "kiko@verdecora.example.com" }
 ]
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "azure-ai-documentintelligence>=1.0.2",
+    "azure-cosmos>=4.9.0",
+    "azure-identity>=1.20.0",
+    "mcp>=1.12.4",
+    "pydantic>=2.11.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/config/security.py
+++ b/src/config/security.py
@@ -52,7 +52,10 @@ def get_keyvault_secret(
         credential=credential or get_managed_identity_credential(),
     )
 
-    return client.get_secret(secret_name, version=version).value
+    secret_value = client.get_secret(secret_name, version=version).value
+    if secret_value is None:
+        raise RuntimeError(f"Secret '{secret_name}' has no value.")
+    return str(secret_value)
 
 
 def get_cosmos_client(*, endpoint: str | None = None, credential: Any | None = None) -> Any:

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,5 +1,73 @@
 # Custom MCP Servers
 
-Custom MCP (Model Context Protocol) server implementations.
+Custom MCP (Model Context Protocol) server implementations for the Verdecora AI Agents project.
 
-Evaluated and implemented only when necessary. See squad decisions for context.
+## Shared conventions
+
+- Python 3.12+
+- `mcp.server.fastmcp.FastMCP`
+- Azure Managed Identity via `DefaultAzureCredential`
+- No shared keys or connection strings
+
+## Servers
+
+### `cosmos_mcp`
+
+Cosmos DB read/write server backed by `azure-cosmos`.
+
+**Configuration**
+- `COSMOS_ENDPOINT`
+
+**Tools**
+- `read_document(database, container, document_id, partition_key)`
+- `query_documents(database, container, query, parameters)`
+- `upsert_document(database, container, document)`
+- `delete_document(database, container, document_id, partition_key)`
+
+Run with:
+
+```bash
+python -m src.mcp.cosmos_mcp.server
+```
+
+### `content_understanding_mcp`
+
+Document Intelligence wrapper backed by `azure-ai-documentintelligence`.
+
+**Configuration**
+- `DOCINTELL_ENDPOINT`
+
+**Tools**
+- `analyze_document(document_url_or_base64, model_id='prebuilt-layout')`
+- `analyze_invoice(document_url_or_base64)`
+- `extract_tables(document_url_or_base64)`
+- `extract_key_value_pairs(document_url_or_base64)`
+
+Run with:
+
+```bash
+python -m src.mcp.content_understanding_mcp.server
+```
+
+### `feature_flags_mcp`
+
+Cosmos-backed feature flag and supplier configuration server.
+
+**Configuration**
+- `COSMOS_ENDPOINT`
+
+**Storage**
+- Database: `verdecora-config`
+- Container: `feature-flags`
+
+**Tools**
+- `get_flag(flag_name, context=None)`
+- `set_flag(flag_name, value, description=None)`
+- `list_flags(prefix=None)`
+- `get_supplier_config(supplier_id)`
+
+Run with:
+
+```bash
+python -m src.mcp.feature_flags_mcp.server
+```

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Custom MCP server packages for Verdecora AI Agents."""

--- a/src/mcp/common.py
+++ b/src/mcp/common.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from urllib.parse import urlparse
+
+from azure.identity import DefaultAzureCredential
+
+
+class MCPServerError(Exception):
+    """Base error for custom MCP server failures."""
+
+
+class MCPConfigurationError(MCPServerError):
+    """Raised when required configuration is missing."""
+
+
+class MCPValidationError(MCPServerError):
+    """Raised when a tool input cannot be processed."""
+
+
+@lru_cache(maxsize=1)
+def get_default_credential() -> DefaultAzureCredential:
+    """Return the shared Azure credential used by custom MCP servers."""
+
+    return DefaultAzureCredential(exclude_interactive_browser_credential=True)
+
+
+def require_env(name: str) -> str:
+    """Return a required environment variable or raise a configuration error."""
+
+    value = os.getenv(name)
+    if not value:
+        raise MCPConfigurationError(f"Missing required environment variable: {name}")
+    return value
+
+
+def is_http_url(value: str) -> bool:
+    """Return whether the provided value is an HTTP or HTTPS URL."""
+
+    parsed = urlparse(value.strip())
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/src/mcp/content_understanding_mcp/README.md
+++ b/src/mcp/content_understanding_mcp/README.md
@@ -1,0 +1,22 @@
+# Document Intelligence MCP Server
+
+FastMCP wrapper around Azure AI Document Intelligence using Azure Managed Identity.
+
+## Configuration
+
+- `DOCINTELL_ENDPOINT`: Document Intelligence endpoint.
+
+## Tools
+
+- `analyze_document(document_url_or_base64, model_id='prebuilt-layout')`
+- `analyze_invoice(document_url_or_base64)`
+- `extract_tables(document_url_or_base64)`
+- `extract_key_value_pairs(document_url_or_base64)`
+
+The document input can be an HTTPS URL or a base64-encoded payload.
+
+## Run locally
+
+```bash
+python -m src.mcp.content_understanding_mcp.server
+```

--- a/src/mcp/content_understanding_mcp/__init__.py
+++ b/src/mcp/content_understanding_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Document Intelligence MCP server package."""

--- a/src/mcp/content_understanding_mcp/models.py
+++ b/src/mcp/content_understanding_mcp/models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TableCell(BaseModel):
+    """A single extracted table cell."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_index: int
+    column_index: int
+    content: str
+    kind: str | None = None
+    page_number: int | None = None
+
+
+class Table(BaseModel):
+    """A normalized representation of a Document Intelligence table."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_count: int
+    column_count: int
+    cells: list[TableCell] = Field(default_factory=list)
+
+
+class KVPair(BaseModel):
+    """A normalized key-value pair extracted from a document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    value: str | None = None
+    confidence: float | None = None
+
+
+class AnalysisResult(BaseModel):
+    """A simplified document analysis result."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_id: str
+    content: str
+    page_count: int
+    tables: list[Table] = Field(default_factory=list)
+    key_value_pairs: list[KVPair] = Field(default_factory=list)
+
+
+class InvoiceField(BaseModel):
+    """A normalized invoice field value."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    value: Any = None
+    content: str | None = None
+    confidence: float | None = None
+
+
+class InvoiceResult(BaseModel):
+    """A simplified invoice analysis payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vendor_name: str | None = None
+    customer_name: str | None = None
+    invoice_id: str | None = None
+    invoice_date: str | None = None
+    due_date: str | None = None
+    total_amount: float | None = None
+    currency: str | None = None
+    fields: list[InvoiceField] = Field(default_factory=list)
+    line_items: list[dict[str, Any]] = Field(default_factory=list)

--- a/src/mcp/content_understanding_mcp/server.py
+++ b/src/mcp/content_understanding_mcp/server.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from functools import lru_cache
+from typing import Any
+
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import (
+    AnalyzeDocumentRequest,
+    AnalyzeResult,
+    DocumentAnalysisFeature,
+    DocumentField,
+)
+from azure.core.exceptions import HttpResponseError
+from mcp.server.fastmcp import FastMCP
+
+from src.mcp.common import MCPServerError, MCPValidationError, get_default_credential, is_http_url, require_env
+from src.mcp.content_understanding_mcp.models import AnalysisResult as MCPAnalysisResult
+from src.mcp.content_understanding_mcp.models import InvoiceField, InvoiceResult, KVPair, Table, TableCell
+
+mcp = FastMCP("verdecora-content-understanding-mcp", json_response=True)
+
+
+class ContentUnderstandingMCPError(MCPServerError):
+    """Base error for Document Intelligence MCP failures."""
+
+
+class ContentUnderstandingOperationError(ContentUnderstandingMCPError):
+    """Raised when the Document Intelligence service call fails."""
+
+
+@lru_cache(maxsize=1)
+def get_document_intelligence_client() -> DocumentIntelligenceClient:
+    """Create a cached Document Intelligence client authenticated with managed identity."""
+
+    return DocumentIntelligenceClient(endpoint=require_env("DOCINTELL_ENDPOINT"), credential=get_default_credential())
+
+
+def build_analyze_request(document_url_or_base64: str) -> AnalyzeDocumentRequest:
+    """Create an AnalyzeDocumentRequest from a URL or a base64-encoded payload."""
+
+    candidate = document_url_or_base64.strip()
+    if not candidate:
+        raise MCPValidationError("document_url_or_base64 must not be empty")
+
+    if is_http_url(candidate):
+        return AnalyzeDocumentRequest(url_source=candidate)
+
+    try:
+        document_bytes = base64.b64decode(candidate, validate=True)
+    except binascii.Error as exc:
+        raise MCPValidationError("document_url_or_base64 must be a valid HTTP(S) URL or base64 string") from exc
+
+    return AnalyzeDocumentRequest(bytes_source=document_bytes)
+
+
+def run_analysis(document_url_or_base64: str, model_id: str, *, include_key_value_pairs: bool = True) -> AnalyzeResult:
+    """Execute a document analysis request and return the raw Azure SDK result."""
+
+    features: list[str | DocumentAnalysisFeature] | None = (
+        [DocumentAnalysisFeature.KEY_VALUE_PAIRS] if include_key_value_pairs else None
+    )
+
+    try:
+        poller = get_document_intelligence_client().begin_analyze_document(
+            model_id=model_id,
+            body=build_analyze_request(document_url_or_base64),
+            features=features,
+        )
+        return poller.result()
+    except HttpResponseError as exc:
+        raise ContentUnderstandingOperationError(
+            f"Document analysis failed for model '{model_id}': {exc.message}"
+        ) from exc
+
+
+def to_tables(result: AnalyzeResult) -> list[Table]:
+    """Convert SDK table objects into MCP-friendly models."""
+
+    tables: list[Table] = []
+    for table in result.tables or []:
+        cells = [
+            TableCell(
+                row_index=cell.row_index,
+                column_index=cell.column_index,
+                content=cell.content,
+                kind=cell.kind,
+                page_number=cell.bounding_regions[0].page_number if cell.bounding_regions else None,
+            )
+            for cell in table.cells
+        ]
+        tables.append(Table(row_count=table.row_count, column_count=table.column_count, cells=cells))
+    return tables
+
+
+def to_key_value_pairs(result: AnalyzeResult) -> list[KVPair]:
+    """Convert SDK key-value pairs into MCP-friendly models."""
+
+    pairs: list[KVPair] = []
+    for pair in result.key_value_pairs or []:
+        key_content = pair.key.content if pair.key else ""
+        value_content = pair.value.content if pair.value else None
+        pairs.append(KVPair(key=key_content, value=value_content, confidence=pair.confidence))
+    return pairs
+
+
+def document_field_value(field: DocumentField) -> Any:
+    """Return the best available scalar or composite value for an invoice field."""
+
+    for attribute_name in (
+        "value_string",
+        "value_currency",
+        "value_number",
+        "value_date",
+        "value_integer",
+        "value_phone_number",
+        "value_country_region",
+        "value_selection_mark",
+    ):
+        value = getattr(field, attribute_name, None)
+        if value is not None:
+            if hasattr(value, "amount"):
+                return value.amount
+            if hasattr(value, "currency_code"):
+                return value.currency_code
+            return value
+
+    if field.value_object:
+        return {key: document_field_value(nested_field) for key, nested_field in field.value_object.items()}
+    if field.value_array:
+        return [document_field_value(nested_field) for nested_field in field.value_array]
+    return field.content
+
+
+def extract_invoice_result(result: AnalyzeResult) -> InvoiceResult:
+    """Build a normalized invoice payload from the raw SDK result."""
+
+    document = result.documents[0] if result.documents else None
+    fields: dict[str, DocumentField] = (document.fields or {}) if document else {}
+
+    normalized_fields = [
+        InvoiceField(
+            name=name,
+            value=document_field_value(field),
+            content=field.content,
+            confidence=field.confidence,
+        )
+        for name, field in fields.items()
+    ]
+
+    line_items_field = fields.get("Items")
+    line_items = []
+    if line_items_field and line_items_field.value_array:
+        for item in line_items_field.value_array:
+            if item.value_object:
+                line_items.append({key: document_field_value(value) for key, value in item.value_object.items()})
+
+    total_field = fields.get("InvoiceTotal")
+    vendor_name_field = fields.get("VendorName")
+    customer_name_field = fields.get("CustomerName")
+    invoice_id_field = fields.get("InvoiceId")
+    invoice_date_field = fields.get("InvoiceDate")
+    due_date_field = fields.get("DueDate")
+
+    total_amount = None
+    currency = None
+    if total_field and total_field.value_currency:
+        total_amount = total_field.value_currency.amount
+        currency = total_field.value_currency.currency_code
+
+    invoice_date = str(invoice_date_field.value_date) if invoice_date_field and invoice_date_field.value_date else None
+    due_date = str(due_date_field.value_date) if due_date_field and due_date_field.value_date else None
+
+    return InvoiceResult(
+        vendor_name=vendor_name_field.content if vendor_name_field else None,
+        customer_name=customer_name_field.content if customer_name_field else None,
+        invoice_id=invoice_id_field.content if invoice_id_field else None,
+        invoice_date=invoice_date,
+        due_date=due_date,
+        total_amount=total_amount,
+        currency=currency,
+        fields=normalized_fields,
+        line_items=line_items,
+    )
+
+
+@mcp.tool()
+def analyze_document(document_url_or_base64: str, model_id: str = "prebuilt-layout") -> dict[str, Any]:
+    """Analyze a document with Azure AI Document Intelligence."""
+
+    result = run_analysis(document_url_or_base64, model_id)
+    normalized = MCPAnalysisResult(
+        model_id=model_id,
+        content=result.content,
+        page_count=len(result.pages or []),
+        tables=to_tables(result),
+        key_value_pairs=to_key_value_pairs(result),
+    )
+    return normalized.model_dump()
+
+
+@mcp.tool()
+def analyze_invoice(document_url_or_base64: str) -> dict[str, Any]:
+    """Analyze an invoice document and return normalized invoice fields."""
+
+    result = run_analysis(document_url_or_base64, "prebuilt-invoice")
+    return extract_invoice_result(result).model_dump()
+
+
+@mcp.tool()
+def extract_tables(document_url_or_base64: str) -> list[dict[str, Any]]:
+    """Extract tables from a document using the prebuilt layout model."""
+
+    result = run_analysis(document_url_or_base64, "prebuilt-layout", include_key_value_pairs=False)
+    return [table.model_dump() for table in to_tables(result)]
+
+
+@mcp.tool()
+def extract_key_value_pairs(document_url_or_base64: str) -> list[dict[str, Any]]:
+    """Extract key-value pairs from a document."""
+
+    result = run_analysis(document_url_or_base64, "prebuilt-document")
+    return [pair.model_dump() for pair in to_key_value_pairs(result)]
+
+
+def main() -> None:
+    """Run the Document Intelligence MCP server."""
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp/cosmos_mcp/README.md
+++ b/src/mcp/cosmos_mcp/README.md
@@ -1,0 +1,20 @@
+# Cosmos DB MCP Server
+
+FastMCP server for Cosmos DB read/write operations using Azure Managed Identity.
+
+## Configuration
+
+- `COSMOS_ENDPOINT`: Cosmos DB account endpoint.
+
+## Tools
+
+- `read_document(database, container, document_id, partition_key)`
+- `query_documents(database, container, query, parameters)`
+- `upsert_document(database, container, document)`
+- `delete_document(database, container, document_id, partition_key)`
+
+## Run locally
+
+```bash
+python -m src.mcp.cosmos_mcp.server
+```

--- a/src/mcp/cosmos_mcp/__init__.py
+++ b/src/mcp/cosmos_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Cosmos DB MCP server package."""

--- a/src/mcp/cosmos_mcp/models.py
+++ b/src/mcp/cosmos_mcp/models.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CosmosQueryParameter(BaseModel):
+    """A parameter passed to a parameterized Cosmos DB query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Cosmos SQL parameter name, including the @ prefix.")
+    value: Any = Field(description="JSON-serializable parameter value.")

--- a/src/mcp/cosmos_mcp/server.py
+++ b/src/mcp/cosmos_mcp/server.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from azure.cosmos import ContainerProxy, CosmosClient, DatabaseProxy, exceptions
+from mcp.server.fastmcp import FastMCP
+
+from src.mcp.common import MCPServerError, MCPValidationError, get_default_credential, require_env
+from src.mcp.cosmos_mcp.models import CosmosQueryParameter
+
+mcp = FastMCP("verdecora-cosmos-mcp", json_response=True)
+
+
+class CosmosMCPError(MCPServerError):
+    """Base error for Cosmos MCP operations."""
+
+
+class CosmosOperationError(CosmosMCPError):
+    """Raised when a Cosmos DB operation fails."""
+
+
+@lru_cache(maxsize=1)
+def get_cosmos_client() -> CosmosClient:
+    """Create a cached Cosmos DB client authenticated with managed identity."""
+
+    return CosmosClient(url=require_env("COSMOS_ENDPOINT"), credential=get_default_credential())
+
+
+def get_database_client(database: str) -> DatabaseProxy:
+    """Return a Cosmos database client for the provided database name."""
+
+    if not database.strip():
+        raise MCPValidationError("database must not be empty")
+    return get_cosmos_client().get_database_client(database)
+
+
+def get_container_client(database: str, container: str) -> ContainerProxy:
+    """Return a Cosmos container client for the provided database and container names."""
+
+    if not container.strip():
+        raise MCPValidationError("container must not be empty")
+    return get_database_client(database).get_container_client(container)
+
+
+@mcp.tool()
+def read_document(database: str, container: str, document_id: str, partition_key: str) -> dict[str, Any]:
+    """Read a single document from Cosmos DB."""
+
+    if not document_id.strip():
+        raise MCPValidationError("document_id must not be empty")
+    if not partition_key.strip():
+        raise MCPValidationError("partition_key must not be empty")
+
+    try:
+        document = get_container_client(database, container).read_item(item=document_id, partition_key=partition_key)
+    except exceptions.CosmosResourceNotFoundError as exc:
+        raise CosmosOperationError(f"Document '{document_id}' was not found in '{database}/{container}'.") from exc
+    except exceptions.CosmosHttpResponseError as exc:
+        raise CosmosOperationError(f"Failed to read document '{document_id}': {exc.message}") from exc
+
+    return dict(document)
+
+
+@mcp.tool()
+def query_documents(
+    database: str,
+    container: str,
+    query: str,
+    parameters: list[CosmosQueryParameter] | None = None,
+) -> list[dict[str, Any]]:
+    """Execute a Cosmos DB SQL query and return the matching documents."""
+
+    if not query.strip():
+        raise MCPValidationError("query must not be empty")
+
+    cosmos_parameters = [parameter.model_dump() for parameter in parameters or []]
+
+    try:
+        items = get_container_client(database, container).query_items(
+            query=query,
+            parameters=cosmos_parameters,
+            enable_cross_partition_query=True,
+        )
+    except exceptions.CosmosHttpResponseError as exc:
+        raise CosmosOperationError(f"Failed to execute query against '{database}/{container}': {exc.message}") from exc
+
+    return [dict(item) for item in items]
+
+
+@mcp.tool()
+def upsert_document(database: str, container: str, document: dict[str, Any]) -> dict[str, Any]:
+    """Create or update a document in Cosmos DB."""
+
+    document_id = str(document.get("id", "")).strip()
+    if not document_id:
+        raise MCPValidationError("document must include a non-empty 'id' field")
+
+    try:
+        response = get_container_client(database, container).upsert_item(body=document)
+    except exceptions.CosmosHttpResponseError as exc:
+        raise CosmosOperationError(f"Failed to upsert document '{document_id}': {exc.message}") from exc
+
+    return dict(response)
+
+
+@mcp.tool()
+def delete_document(database: str, container: str, document_id: str, partition_key: str) -> bool:
+    """Delete a single document from Cosmos DB."""
+
+    if not document_id.strip():
+        raise MCPValidationError("document_id must not be empty")
+    if not partition_key.strip():
+        raise MCPValidationError("partition_key must not be empty")
+
+    try:
+        get_container_client(database, container).delete_item(item=document_id, partition_key=partition_key)
+    except exceptions.CosmosResourceNotFoundError:
+        return False
+    except exceptions.CosmosHttpResponseError as exc:
+        raise CosmosOperationError(f"Failed to delete document '{document_id}': {exc.message}") from exc
+
+    return True
+
+
+def main() -> None:
+    """Run the Cosmos MCP server."""
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp/feature_flags_mcp/README.md
+++ b/src/mcp/feature_flags_mcp/README.md
@@ -1,0 +1,29 @@
+# Feature Flags MCP Server
+
+FastMCP server for Cosmos-backed feature flags and per-supplier configuration using Azure Managed Identity.
+
+## Configuration
+
+- `COSMOS_ENDPOINT`: Cosmos DB account endpoint.
+
+## Data model
+
+- Database: `verdecora-config`
+- Container: `feature-flags`
+- Flag documents use `document_type = 'feature-flag'`
+- Supplier config documents use `document_type = 'supplier-config'`
+
+## Tools
+
+- `get_flag(flag_name, context=None)`
+- `set_flag(flag_name, value, description=None)`
+- `list_flags(prefix=None)`
+- `get_supplier_config(supplier_id)`
+
+The server keeps a small in-memory cache with a 60 second TTL for reads.
+
+## Run locally
+
+```bash
+python -m src.mcp.feature_flags_mcp.server
+```

--- a/src/mcp/feature_flags_mcp/__init__.py
+++ b/src/mcp/feature_flags_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Feature flags MCP server package."""

--- a/src/mcp/feature_flags_mcp/models.py
+++ b/src/mcp/feature_flags_mcp/models.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FlagOverride(BaseModel):
+    """A contextual override for a feature flag."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    match: dict[str, Any] = Field(default_factory=dict)
+    value: Any = None
+
+
+class FlagValue(BaseModel):
+    """A feature flag value stored in Cosmos DB."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    flag_name: str
+    value: Any = None
+    description: str | None = None
+    version: int = 1
+    overrides: list[FlagOverride] = Field(default_factory=list)
+    updated_at: str | None = None
+
+
+class SupplierConfig(BaseModel):
+    """Per-supplier triage or behavior overrides."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    supplier_id: str
+    configuration: dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+    updated_at: str | None = None

--- a/src/mcp/feature_flags_mcp/server.py
+++ b/src/mcp/feature_flags_mcp/server.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from functools import lru_cache
+from time import monotonic
+from typing import Any
+
+from azure.cosmos import ContainerProxy, CosmosClient, exceptions
+from mcp.server.fastmcp import FastMCP
+
+from src.mcp.common import MCPServerError, MCPValidationError, get_default_credential, require_env
+from src.mcp.feature_flags_mcp.models import FlagOverride, FlagValue, SupplierConfig
+
+mcp = FastMCP("verdecora-feature-flags-mcp", json_response=True)
+
+CONFIG_DATABASE = "verdecora-config"
+FLAGS_CONTAINER = "feature-flags"
+FLAG_DOCUMENT_TYPE = "feature-flag"
+SUPPLIER_CONFIG_DOCUMENT_TYPE = "supplier-config"
+CACHE_TTL_SECONDS = 60.0
+
+_cache: dict[str, tuple[float, FlagValue | SupplierConfig]] = {}
+
+
+class FeatureFlagsMCPError(MCPServerError):
+    """Base error for feature flag operations."""
+
+
+class FeatureFlagNotFoundError(FeatureFlagsMCPError):
+    """Raised when a requested feature flag or supplier config does not exist."""
+
+
+class FeatureFlagsOperationError(FeatureFlagsMCPError):
+    """Raised when Cosmos-backed feature flag operations fail."""
+
+
+@lru_cache(maxsize=1)
+def get_cosmos_client() -> CosmosClient:
+    """Create a cached Cosmos DB client authenticated with managed identity."""
+
+    return CosmosClient(url=require_env("COSMOS_ENDPOINT"), credential=get_default_credential())
+
+
+def get_flags_container() -> ContainerProxy:
+    """Return the shared Cosmos container used for feature flags and supplier configs."""
+
+    database = get_cosmos_client().get_database_client(CONFIG_DATABASE)
+    return database.get_container_client(FLAGS_CONTAINER)
+
+
+def cache_key(prefix: str, identifier: str) -> str:
+    """Build an in-memory cache key."""
+
+    return f"{prefix}:{identifier}"
+
+
+def read_cached(key: str) -> FlagValue | SupplierConfig | None:
+    """Read a value from the in-memory cache when it is still fresh."""
+
+    cached_entry = _cache.get(key)
+    if not cached_entry:
+        return None
+
+    expires_at, value = cached_entry
+    if monotonic() >= expires_at:
+        _cache.pop(key, None)
+        return None
+    return value
+
+
+def write_cached(key: str, value: FlagValue | SupplierConfig) -> None:
+    """Store a value in the in-memory cache."""
+
+    _cache[key] = (monotonic() + CACHE_TTL_SECONDS, value)
+
+
+def invalidate_flag_cache(flag_name: str) -> None:
+    """Remove cached flag values that match the provided flag name."""
+
+    _cache.pop(cache_key(FLAG_DOCUMENT_TYPE, flag_name), None)
+
+
+def document_matches_context(override: FlagOverride, context: dict[str, Any]) -> bool:
+    """Return whether a contextual override applies to the provided request context."""
+
+    return all(context.get(key) == value for key, value in override.match.items())
+
+
+def query_single_document(query: str, parameters: list[dict[str, Any]]) -> dict[str, Any]:
+    """Execute a query and return the first matching document."""
+
+    try:
+        items = list(
+            get_flags_container().query_items(
+                query=query,
+                parameters=parameters,
+                enable_cross_partition_query=True,
+            )
+        )
+    except exceptions.CosmosHttpResponseError as exc:
+        raise FeatureFlagsOperationError(f"Feature flag query failed: {exc.message}") from exc
+
+    if not items:
+        raise FeatureFlagNotFoundError("No matching document found.")
+    return dict(items[0])
+
+
+def to_flag_value(document: dict[str, Any]) -> FlagValue:
+    """Convert a stored feature flag document into a typed model."""
+
+    return FlagValue(
+        flag_name=str(document.get("flag_name", document.get("id", ""))),
+        value=document.get("value"),
+        description=document.get("description"),
+        version=int(document.get("version", 1)),
+        overrides=[FlagOverride.model_validate(override) for override in document.get("overrides", [])],
+        updated_at=document.get("updated_at"),
+    )
+
+
+def to_supplier_config(document: dict[str, Any]) -> SupplierConfig:
+    """Convert a stored supplier config document into a typed model."""
+
+    return SupplierConfig(
+        supplier_id=str(document.get("supplier_id", document.get("id", ""))),
+        configuration=document.get("configuration", {}),
+        description=document.get("description"),
+        updated_at=document.get("updated_at"),
+    )
+
+
+@mcp.tool()
+def get_flag(flag_name: str, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return a feature flag, applying the first matching override for the provided context."""
+
+    normalized_flag_name = flag_name.strip()
+    if not normalized_flag_name:
+        raise MCPValidationError("flag_name must not be empty")
+
+    cached = read_cached(cache_key(FLAG_DOCUMENT_TYPE, normalized_flag_name))
+    flag = cached if isinstance(cached, FlagValue) else None
+    if flag is None:
+        document = query_single_document(
+            "SELECT TOP 1 * FROM c WHERE c.document_type = @document_type AND c.flag_name = @flag_name",
+            [
+                {"name": "@document_type", "value": FLAG_DOCUMENT_TYPE},
+                {"name": "@flag_name", "value": normalized_flag_name},
+            ],
+        )
+        flag = to_flag_value(document)
+        write_cached(cache_key(FLAG_DOCUMENT_TYPE, normalized_flag_name), flag)
+
+    effective_value = flag.value
+    if context:
+        for override in flag.overrides:
+            if document_matches_context(override, context):
+                effective_value = override.value
+                break
+
+    return flag.model_copy(update={"value": effective_value}).model_dump()
+
+
+@mcp.tool()
+def set_flag(flag_name: str, value: Any, description: str | None = None) -> dict[str, Any]:
+    """Create or update a feature flag document."""
+
+    normalized_flag_name = flag_name.strip()
+    if not normalized_flag_name:
+        raise MCPValidationError("flag_name must not be empty")
+
+    timestamp = datetime.now(tz=UTC).isoformat()
+    current_version = 0
+    try:
+        current_flag = get_flag(normalized_flag_name)
+        current_version = int(current_flag.get("version", 0))
+    except FeatureFlagNotFoundError:
+        current_version = 0
+
+    document = {
+        "id": normalized_flag_name,
+        "flag_name": normalized_flag_name,
+        "document_type": FLAG_DOCUMENT_TYPE,
+        "value": value,
+        "description": description,
+        "version": current_version + 1,
+        "updated_at": timestamp,
+        "overrides": [],
+    }
+
+    try:
+        response = get_flags_container().upsert_item(body=document)
+    except exceptions.CosmosHttpResponseError as exc:
+        raise FeatureFlagsOperationError(f"Failed to set flag '{normalized_flag_name}': {exc.message}") from exc
+
+    invalidate_flag_cache(normalized_flag_name)
+    return to_flag_value(dict(response)).model_dump()
+
+
+@mcp.tool()
+def list_flags(prefix: str | None = None) -> list[dict[str, Any]]:
+    """List feature flags, optionally constrained to a name prefix."""
+
+    query = "SELECT * FROM c WHERE c.document_type = @document_type"
+    parameters: list[dict[str, Any]] = [{"name": "@document_type", "value": FLAG_DOCUMENT_TYPE}]
+    if prefix:
+        query += " AND STARTSWITH(c.flag_name, @prefix)"
+        parameters.append({"name": "@prefix", "value": prefix})
+    query += " ORDER BY c.flag_name"
+
+    try:
+        items = list(
+            get_flags_container().query_items(
+                query=query,
+                parameters=parameters,
+                enable_cross_partition_query=True,
+            )
+        )
+    except exceptions.CosmosHttpResponseError as exc:
+        raise FeatureFlagsOperationError(f"Failed to list flags: {exc.message}") from exc
+
+    return [to_flag_value(dict(item)).model_dump() for item in items]
+
+
+@mcp.tool()
+def get_supplier_config(supplier_id: str) -> dict[str, Any]:
+    """Return the supplier-specific configuration document."""
+
+    normalized_supplier_id = supplier_id.strip()
+    if not normalized_supplier_id:
+        raise MCPValidationError("supplier_id must not be empty")
+
+    cached = read_cached(cache_key(SUPPLIER_CONFIG_DOCUMENT_TYPE, normalized_supplier_id))
+    supplier_config = cached if isinstance(cached, SupplierConfig) else None
+    if supplier_config is None:
+        document = query_single_document(
+            "SELECT TOP 1 * FROM c WHERE c.document_type = @document_type AND c.supplier_id = @supplier_id",
+            [
+                {"name": "@document_type", "value": SUPPLIER_CONFIG_DOCUMENT_TYPE},
+                {"name": "@supplier_id", "value": normalized_supplier_id},
+            ],
+        )
+        supplier_config = to_supplier_config(document)
+        write_cached(cache_key(SUPPLIER_CONFIG_DOCUMENT_TYPE, normalized_supplier_id), supplier_config)
+
+    return supplier_config.model_dump()
+
+
+def main() -> None:
+    """Run the feature flags MCP server."""
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/poc/acs_email_poc/escalation_template.py
+++ b/src/poc/acs_email_poc/escalation_template.py
@@ -4,7 +4,6 @@ from html import escape
 
 from .email_templates import HitlEmailContext, build_action_url
 
-
 ESCALATION_NOTICE = (
     "This escalation is intended for the responsible approver and their backup contact. "
     "If no action is recorded, operations should intervene."

--- a/src/poc/bc_mcp_poc/test_bc_read.py
+++ b/src/poc/bc_mcp_poc/test_bc_read.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from entity_schemas import ACTION_SCHEMAS, SEARCH_RESULTS, VALIDATED_READS, summarize_action
 
-
 READ_SEQUENCE: list[tuple[str, str]] = [
     ("List purchase orders", "purchase_orders_top5"),
     ("Read purchase order 106030", "purchase_order_106030"),

--- a/src/poc/maf_poc/orchestrator.py
+++ b/src/poc/maf_poc/orchestrator.py
@@ -8,20 +8,17 @@ Demonstrates two orchestration patterns from agent_framework:
 Also sets up OpenTelemetry with console exporter for local testing.
 """
 
-import asyncio
 
+from agent_framework.orchestrations import HandoffBuilder, SequentialBuilder
 from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
     ConsoleSpanExporter,
 )
-from opentelemetry.sdk.resources import Resource
 
-from agent_framework.orchestrations import SequentialBuilder, HandoffBuilder
-
-from .stub_agents import create_extractor, create_validator, create_inventory
-
+from .stub_agents import create_extractor, create_inventory, create_validator
 
 # ---------------------------------------------------------------------------
 # Telemetry setup (console exporter for local dev)

--- a/src/poc/maf_poc/run_poc.py
+++ b/src/poc/maf_poc/run_poc.py
@@ -22,10 +22,8 @@ import argparse
 import asyncio
 import json
 import os
-import sys
 
 from .orchestrator import run_full_poc
-
 
 # ---------------------------------------------------------------------------
 # Chat client factory
@@ -79,7 +77,7 @@ class _MockChatClient:
 
 async def _dry_run_poc(albaran_input: str) -> dict:
     """Simulate the full PoC without an LLM by invoking tools directly."""
-    from .stub_agents import extract_document, validate_against_po, post_inventory_receipt
+    from .stub_agents import extract_document, post_inventory_receipt, validate_against_po
 
     print("\n" + "=" * 60)
     print("DRY-RUN MODE — Calling tools directly (no LLM)")

--- a/src/poc/maf_poc/stub_agents.py
+++ b/src/poc/maf_poc/stub_agents.py
@@ -15,7 +15,6 @@ from typing import Annotated
 
 from agent_framework import Agent, tool
 
-
 # ---------------------------------------------------------------------------
 # Mock tools (replace with MCPStreamableHTTPTool in production)
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_security.py
+++ b/tests/unit/config/test_security.py
@@ -19,28 +19,40 @@ class ManagedIdentityCredentialTests(unittest.TestCase):
     def test_uses_explicit_client_id_when_provided(self) -> None:
         captured_kwargs = {}
 
-        class FakeManagedIdentityCredential:
+        class FakeDefaultAzureCredential:
             def __init__(self, **kwargs):
                 captured_kwargs.update(kwargs)
 
-        with patch.object(security, '_load_symbol', return_value=FakeManagedIdentityCredential):
-            credential = security.get_managed_identity_credential(client_id='mi-client-id')
+        with patch.object(security, "_load_symbol", return_value=FakeDefaultAzureCredential):
+            credential = security.get_managed_identity_credential(client_id="mi-client-id")
 
-        self.assertIsInstance(credential, FakeManagedIdentityCredential)
-        self.assertEqual(captured_kwargs, {'client_id': 'mi-client-id'})
+        self.assertIsInstance(credential, FakeDefaultAzureCredential)
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "exclude_interactive_browser_credential": True,
+                "managed_identity_client_id": "mi-client-id",
+            },
+        )
 
     def test_falls_back_to_environment_client_id(self) -> None:
         captured_kwargs = {}
 
-        class FakeManagedIdentityCredential:
+        class FakeDefaultAzureCredential:
             def __init__(self, **kwargs):
                 captured_kwargs.update(kwargs)
 
-        with patch.dict(os.environ, {'AZURE_CLIENT_ID': 'env-client-id'}, clear=False):
-            with patch.object(security, '_load_symbol', return_value=FakeManagedIdentityCredential):
+        with patch.dict(os.environ, {"AZURE_CLIENT_ID": "env-client-id"}, clear=False):
+            with patch.object(security, "_load_symbol", return_value=FakeDefaultAzureCredential):
                 security.get_managed_identity_credential()
 
-        self.assertEqual(captured_kwargs, {'client_id': 'env-client-id'})
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "exclude_interactive_browser_credential": True,
+                "managed_identity_client_id": "env-client-id",
+            },
+        )
 
 
 class SecurityClientFactoryTests(unittest.TestCase):
@@ -53,19 +65,21 @@ class SecurityClientFactoryTests(unittest.TestCase):
                 self.credential = credential
 
             def get_secret(self, name, version=None):
-                return SimpleNamespace(value=f'{name}:{version or "latest"}:{self.vault_url}:{self.credential is credential}')
+                return SimpleNamespace(
+                    value=f"{name}:{version or 'latest'}:{self.vault_url}:{self.credential is credential}"
+                )
 
-        with patch.object(security, '_load_symbol', return_value=FakeSecretClient):
+        with patch.object(security, "_load_symbol", return_value=FakeSecretClient):
             secret_value = security.get_keyvault_secret(
-                'bc-oauth-client-secret',
-                vault_url='https://kv-verdecoratest.vault.azure.net/',
+                "bc-oauth-client-secret",
+                vault_url="https://kv-verdecoratest.vault.azure.net/",
                 credential=credential,
-                version='v1',
+                version="v1",
             )
 
         self.assertEqual(
             secret_value,
-            'bc-oauth-client-secret:v1:https://kv-verdecoratest.vault.azure.net/:True',
+            "bc-oauth-client-secret:v1:https://kv-verdecoratest.vault.azure.net/:True",
         )
 
     def test_get_cosmos_client_uses_managed_identity_credential(self) -> None:
@@ -74,18 +88,18 @@ class SecurityClientFactoryTests(unittest.TestCase):
 
         class FakeCosmosClient:
             def __init__(self, *, url, credential):
-                created_clients.append({'url': url, 'credential': credential})
+                created_clients.append({"url": url, "credential": credential})
 
-        with patch.object(security, '_load_symbol', return_value=FakeCosmosClient):
-            with patch.object(security, 'get_managed_identity_credential', return_value=fake_credential):
-                security.get_cosmos_client(endpoint='https://cosmos-verdecoratest.documents.azure.com:443/')
+        with patch.object(security, "_load_symbol", return_value=FakeCosmosClient):
+            with patch.object(security, "get_managed_identity_credential", return_value=fake_credential):
+                security.get_cosmos_client(endpoint="https://cosmos-verdecoratest.documents.azure.com:443/")
 
         self.assertEqual(
             created_clients,
             [
                 {
-                    'url': 'https://cosmos-verdecoratest.documents.azure.com:443/',
-                    'credential': fake_credential,
+                    "url": "https://cosmos-verdecoratest.documents.azure.com:443/",
+                    "credential": fake_credential,
                 }
             ],
         )
@@ -98,21 +112,21 @@ class SecurityClientFactoryTests(unittest.TestCase):
             def __init__(self, *, fully_qualified_namespace, credential):
                 created_clients.append(
                     {
-                        'fully_qualified_namespace': fully_qualified_namespace,
-                        'credential': credential,
+                        "fully_qualified_namespace": fully_qualified_namespace,
+                        "credential": credential,
                     }
                 )
 
-        with patch.object(security, '_load_symbol', return_value=FakeServiceBusClient):
-            with patch.object(security, 'get_managed_identity_credential', return_value=fake_credential):
-                security.get_servicebus_client(fully_qualified_namespace='sb-verdecoratest.servicebus.windows.net')
+        with patch.object(security, "_load_symbol", return_value=FakeServiceBusClient):
+            with patch.object(security, "get_managed_identity_credential", return_value=fake_credential):
+                security.get_servicebus_client(fully_qualified_namespace="sb-verdecoratest.servicebus.windows.net")
 
         self.assertEqual(
             created_clients,
             [
                 {
-                    'fully_qualified_namespace': 'sb-verdecoratest.servicebus.windows.net',
-                    'credential': fake_credential,
+                    "fully_qualified_namespace": "sb-verdecoratest.servicebus.windows.net",
+                    "credential": fake_credential,
                 }
             ],
         )
@@ -123,5 +137,5 @@ class SecurityClientFactoryTests(unittest.TestCase):
                 security.get_servicebus_client()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/mcp/test_content_understanding_mcp.py
+++ b/tests/unit/mcp/test_content_understanding_mcp.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from src.mcp.common import MCPValidationError
+from src.mcp.content_understanding_mcp.server import build_analyze_request
+
+
+def test_build_analyze_request_accepts_https_url() -> None:
+    request = build_analyze_request("https://example.com/document.pdf")
+
+    assert request.url_source == "https://example.com/document.pdf"
+    assert request.bytes_source is None
+
+
+def test_build_analyze_request_accepts_base64_payload() -> None:
+    payload = base64.b64encode(b"hello world").decode("utf-8")
+
+    request = build_analyze_request(payload)
+
+    assert request.url_source is None
+    assert request.bytes_source == b"hello world"
+
+
+def test_build_analyze_request_rejects_invalid_input() -> None:
+    with pytest.raises(MCPValidationError):
+        build_analyze_request("not-a-url-or-base64")

--- a/tests/unit/mcp/test_cosmos_mcp.py
+++ b/tests/unit/mcp/test_cosmos_mcp.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+from src.mcp.common import MCPValidationError
+from src.mcp.cosmos_mcp.server import upsert_document
+
+
+def test_upsert_document_requires_id() -> None:
+    with pytest.raises(MCPValidationError):
+        upsert_document("db", "container", {"pk": "abc"})

--- a/tests/unit/mcp/test_feature_flags_mcp.py
+++ b/tests/unit/mcp/test_feature_flags_mcp.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from src.mcp.feature_flags_mcp.models import FlagOverride
+from src.mcp.feature_flags_mcp.server import document_matches_context, to_flag_value
+
+
+def test_document_matches_context_returns_true_for_matching_override() -> None:
+    override = FlagOverride(match={"supplier_id": "SUP-1", "store_id": "MAD-01"}, value=True)
+
+    assert document_matches_context(override, {"supplier_id": "SUP-1", "store_id": "MAD-01"}) is True
+
+
+def test_document_matches_context_returns_false_for_non_matching_override() -> None:
+    override = FlagOverride(match={"supplier_id": "SUP-1"}, value=True)
+
+    assert document_matches_context(override, {"supplier_id": "SUP-2"}) is False
+
+
+def test_to_flag_value_builds_typed_model() -> None:
+    flag = to_flag_value(
+        {
+            "id": "triage.enabled",
+            "flag_name": "triage.enabled",
+            "value": True,
+            "version": 3,
+            "description": "Enable the triage agent",
+            "overrides": [{"match": {"supplier_id": "SUP-1"}, "value": False}],
+            "updated_at": "2026-05-04T12:00:00Z",
+        }
+    )
+
+    assert flag.flag_name == "triage.enabled"
+    assert flag.value is True
+    assert flag.version == 3
+    assert flag.overrides[0].match == {"supplier_id": "SUP-1"}

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,31 +1,141 @@
-from __future__ import annotations
-
+import os
 import sys
+import unittest
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from src.config import security
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.config import security  # noqa: E402
 
 
-def test_get_managed_identity_credential_uses_default_azure_credential(
-    monkeypatch,
-) -> None:
-    expected_credential = object()
-    calls: list[dict[str, bool]] = []
+class ManagedIdentityCredentialTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        security.get_managed_identity_credential.cache_clear()
 
-    def fake_default_azure_credential(**kwargs: bool) -> object:
-        calls.append(kwargs)
-        return expected_credential
+    def test_uses_explicit_client_id_when_provided(self) -> None:
+        captured_kwargs = {}
 
-    monkeypatch.setitem(
-        sys.modules,
-        "azure.identity",
-        SimpleNamespace(DefaultAzureCredential=fake_default_azure_credential),
-    )
-    security.get_managed_identity_credential.cache_clear()
+        class FakeDefaultAzureCredential:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
 
-    credential = security.get_managed_identity_credential()
+        with patch.object(security, "_load_symbol", return_value=FakeDefaultAzureCredential):
+            credential = security.get_managed_identity_credential(client_id="mi-client-id")
 
-    assert credential is expected_credential
-    assert calls == [{"exclude_interactive_browser_credential": True}]
+        self.assertIsInstance(credential, FakeDefaultAzureCredential)
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "exclude_interactive_browser_credential": True,
+                "managed_identity_client_id": "mi-client-id",
+            },
+        )
 
-    security.get_managed_identity_credential.cache_clear()
+    def test_falls_back_to_environment_client_id(self) -> None:
+        captured_kwargs = {}
+
+        class FakeDefaultAzureCredential:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        with patch.dict(os.environ, {"AZURE_CLIENT_ID": "env-client-id"}, clear=False):
+            with patch.object(security, "_load_symbol", return_value=FakeDefaultAzureCredential):
+                security.get_managed_identity_credential()
+
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "exclude_interactive_browser_credential": True,
+                "managed_identity_client_id": "env-client-id",
+            },
+        )
+
+
+class SecurityClientFactoryTests(unittest.TestCase):
+    def test_get_keyvault_secret_reads_secret_value(self) -> None:
+        credential = object()
+
+        class FakeSecretClient:
+            def __init__(self, *, vault_url, credential):
+                self.vault_url = vault_url
+                self.credential = credential
+
+            def get_secret(self, name, version=None):
+                return SimpleNamespace(
+                    value=f"{name}:{version or 'latest'}:{self.vault_url}:{self.credential is credential}"
+                )
+
+        with patch.object(security, "_load_symbol", return_value=FakeSecretClient):
+            secret_value = security.get_keyvault_secret(
+                "bc-oauth-client-secret",
+                vault_url="https://kv-verdecoratest.vault.azure.net/",
+                credential=credential,
+                version="v1",
+            )
+
+        self.assertEqual(
+            secret_value,
+            "bc-oauth-client-secret:v1:https://kv-verdecoratest.vault.azure.net/:True",
+        )
+
+    def test_get_cosmos_client_uses_managed_identity_credential(self) -> None:
+        created_clients = []
+        fake_credential = object()
+
+        class FakeCosmosClient:
+            def __init__(self, *, url, credential):
+                created_clients.append({"url": url, "credential": credential})
+
+        with patch.object(security, "_load_symbol", return_value=FakeCosmosClient):
+            with patch.object(security, "get_managed_identity_credential", return_value=fake_credential):
+                security.get_cosmos_client(endpoint="https://cosmos-verdecoratest.documents.azure.com:443/")
+
+        self.assertEqual(
+            created_clients,
+            [
+                {
+                    "url": "https://cosmos-verdecoratest.documents.azure.com:443/",
+                    "credential": fake_credential,
+                }
+            ],
+        )
+
+    def test_get_servicebus_client_uses_managed_identity_credential(self) -> None:
+        created_clients = []
+        fake_credential = object()
+
+        class FakeServiceBusClient:
+            def __init__(self, *, fully_qualified_namespace, credential):
+                created_clients.append(
+                    {
+                        "fully_qualified_namespace": fully_qualified_namespace,
+                        "credential": credential,
+                    }
+                )
+
+        with patch.object(security, "_load_symbol", return_value=FakeServiceBusClient):
+            with patch.object(security, "get_managed_identity_credential", return_value=fake_credential):
+                security.get_servicebus_client(fully_qualified_namespace="sb-verdecoratest.servicebus.windows.net")
+
+        self.assertEqual(
+            created_clients,
+            [
+                {
+                    "fully_qualified_namespace": "sb-verdecoratest.servicebus.windows.net",
+                    "credential": fake_credential,
+                }
+            ],
+        )
+
+    def test_missing_environment_variable_raises_runtime_error(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                security.get_servicebus_client()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Azure OpenAI and Document Intelligence Bicep modules and wire outputs into the subscription entrypoint
- grant ACA identity access to Azure OpenAI and Document Intelligence, and resolve existing infra/security merge conflicts blocking validation
- add Cosmos, Document Intelligence, and feature-flags FastMCP servers with managed identity auth, docs, and unit tests

## Validation
- python -m ruff check src tests
- python -m mypy src\mcp src\config\security.py
- python -m pytest tests\unit -v --cov=src --cov-report=term
- python -c "import importlib; modules=['src.mcp.cosmos_mcp.server','src.mcp.content_understanding_mcp.server','src.mcp.feature_flags_mcp.server']; [importlib.import_module(name) for name in modules]; print('mcp-imports-ok')"
- bicep CLI unavailable locally, so Bicep compile could not be run here