### PR TITLE
feat(poc): OCR benchmark — Document Intelligence on 9 supplier formats (#7)

### DIFF
--- a/docs/poc/extraction-benchmark.md
+++ b/docs/poc/extraction-benchmark.md
@@ -1,0 +1,122 @@
+# OCR extraction benchmark — Azure AI Document Intelligence
+
+## Decision
+
+**Recommendation:** use **Azure AI Document Intelligence `prebuilt-layout`** as the extraction engine for Verdecora supplier delivery notes and invoices.
+
+`prebuilt-invoice` was faster, but `prebuilt-layout` handled the mixed supplier pack more safely because it preserved tables and key-value pairs across all nine formats without assuming a pure invoice schema.
+
+## Scope
+
+- Sample: `prerequisites/PRUEBA.pdf`
+- Pages: 19
+- Supplier formats covered: 9
+- Models benchmarked:
+  - `prebuilt-layout`
+  - `prebuilt-invoice`
+- Authentication: `DefaultAzureCredential` via Azure CLI sign-in (`admin@gpsazure.com`)
+- Resource: `verdecora-docintell-dev` (`swedencentral`)
+
+## Methodology
+
+The benchmark script (`python -m src.poc.ocr_benchmark.benchmark`) analyzes the PDF **page by page** with both models.
+
+For each page it captures:
+
+- full OCR text
+- detected tables
+- key-value pairs
+- typed document fields (when available)
+- latency per page
+
+The evaluation module (`python -m src.poc.ocr_benchmark.evaluate --input <json>`) compares the extracted output against manual expectations per supplier format:
+
+- supplier name
+- document date
+- albarán / invoice number
+- line-item code
+- line-item description
+- line-item quantity
+- line-item price
+
+Field-level completeness is calculated as detected expected fields ÷ expected fields.
+
+## Overall results
+
+| Model | Avg latency / page | Field completeness | Avg tables / page | Avg KV pairs / page | Avg typed docs / page |
+|---|---:|---:|---:|---:|---:|
+| `prebuilt-layout` | 11.82 s | 96.95% (127/131) | 3.11 | 26.68 | 0.00 |
+| `prebuilt-invoice` | 7.48 s | 96.95% (127/131) | 3.11 | 0.00 | 1.00 |
+
+### Field-level detection
+
+| Field | Accuracy |
+|---|---:|
+| Supplier name | 100% |
+| Date | 100% |
+| Document number | 100% |
+| Line-item code | 100% |
+| Line-item description | 100% |
+| Line-item quantity | 100% |
+| Line-item price | 76.47% |
+
+The only repeated misses were **line-item price** on the hardest pages.
+
+## Results by supplier format
+
+| Supplier | Pages | Layout completeness | Invoice completeness | Notes |
+|---|---:|---:|---:|---|
+| Herstera Garden S.L. | 1-4 | 100.00% | 100.00% | Best-case structured multi-page table with EAN columns. |
+| FANSA | 5 | 85.71% | 85.71% | Handwritten numbers / stamps; price extraction was the weak spot. |
+| Royal Canin Ibérica | 6 | 100.00% | 100.00% | Clean extraction despite lots / expiry content. |
+| HOBBIT-ALF S.L. | 7-8 | 100.00% | 100.00% | Italian export layout still mapped reliably. |
+| VECA S.p.A | 9-10 | 92.86% | 92.86% | Dense columns and annotations degraded price capture on one page. |
+| sera GmbH | 11-13 | 90.48% | 90.48% | German multi-page format with pallets / boxes was the hardest multi-page supplier. |
+| triXder/Trixie | 14-15 | 100.00% | 100.00% | PVP-heavy invoice structure extracted cleanly. |
+| Saneaplast | 16, 19 | 100.00% | 100.00% | Discounts and duplicated albaranes were still recoverable. |
+| Catral | 17-18 | 100.00% | 100.00% | Packing-list style worked well; price not required for this format. |
+
+## Key findings
+
+1. **Document Intelligence is viable for all 9 supplier formats.** Both models extracted the core operational fields on every supplier.
+2. **`prebuilt-invoice` is faster** (~7.5 s/page vs ~11.8 s/page).
+3. **`prebuilt-layout` is the safer default for Verdecora** because the corpus is not a pure invoice corpus:
+   - albaranes
+   - export invoices
+   - packing lists
+   - dense supplier-specific grids
+   - pages with handwriting / stamps / barcodes
+4. **Price extraction is the main weak area** on:
+   - FANSA
+   - VECA page 10
+   - sera pages 11-12
+5. **Post-processing is still required** for production-grade normalization:
+   - strip `:selected:` artifacts from OCR tables
+   - merge split multi-line cells
+   - normalize decimal separators and quantity noise
+   - reconcile supplier aliases (`triXder` vs `Trixie`)
+   - use supplier-specific parsers for pallets, lots, SSCC, and duplicate albaranes
+
+## Recommended implementation approach
+
+Use `prebuilt-layout` as the base extractor, then add Verdecora post-processing in the ingestion pipeline:
+
+1. run `prebuilt-layout`
+2. normalize OCR text, tables, and key-value pairs
+3. apply supplier-specific enrichment rules
+4. map normalized fields into the Verdecora albarán schema
+5. keep `prebuilt-invoice` available only as a fallback / diagnostic comparison path
+
+## Files
+
+- `src/poc/ocr_benchmark/benchmark.py`
+- `src/poc/ocr_benchmark/evaluate.py`
+- `src/poc/ocr_benchmark/requirements.txt`
+
+## Repro
+
+```bash
+pip install -r src/poc/ocr_benchmark/requirements.txt
+python -m src.poc.ocr_benchmark.benchmark --output .copilot/ocr-benchmark-results.json
+python -m src.poc.ocr_benchmark.evaluate --input .copilot/ocr-benchmark-results.json
+```

--- a/src/poc/ocr_benchmark/__init__.py
+++ b/src/poc/ocr_benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""OCR benchmark package for Document Intelligence supplier-format evaluation."""

--- a/src/poc/ocr_benchmark/benchmark.py
+++ b/src/poc/ocr_benchmark/benchmark.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+from azure.core.exceptions import HttpResponseError
+from azure.identity import DefaultAzureCredential
+
+from .evaluate import SUPPLIER_EXPECTATIONS, evaluate_benchmark_results, page_expectation
+
+DEFAULT_ENDPOINT = "https://verdecora-docintell-dev.cognitiveservices.azure.com/"
+DEFAULT_MODELS = ("prebuilt-layout", "prebuilt-invoice")
+MODEL_FEATURES: dict[str, list[DocumentAnalysisFeature]] = {
+    "prebuilt-layout": [DocumentAnalysisFeature.KEY_VALUE_PAIRS],
+    "prebuilt-invoice": [],
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRunSummary:
+    model_id: str
+    average_latency_ms: float
+    average_completeness: float
+    average_table_count: float
+    average_key_value_pair_count: float
+    average_document_count: float
+    detected_fields: int
+    expected_fields: int
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _default_pdf_path() -> Path:
+    return _repo_root() / "prerequisites" / "PRUEBA.pdf"
+
+
+def _build_client(endpoint: str) -> DocumentIntelligenceClient:
+    credential = DefaultAzureCredential(exclude_interactive_browser_credential=True)
+    return DocumentIntelligenceClient(endpoint=endpoint, credential=credential)
+
+
+def _cell_pages(cell: Any) -> set[int]:
+    pages: set[int] = set()
+    for region in getattr(cell, "bounding_regions", []) or []:
+        page_number = getattr(region, "page_number", None)
+        if isinstance(page_number, int):
+            pages.add(page_number)
+    return pages
+
+
+def _table_pages(table: Any) -> set[int]:
+    pages: set[int] = set()
+    for region in getattr(table, "bounding_regions", []) or []:
+        page_number = getattr(region, "page_number", None)
+        if isinstance(page_number, int):
+            pages.add(page_number)
+    return pages
+
+
+def _table_to_rows(table: Any) -> list[list[str]]:
+    rows = [["" for _ in range(int(table.column_count))] for _ in range(int(table.row_count))]
+    for cell in table.cells:
+        row_index = int(cell.row_index)
+        column_index = int(cell.column_index)
+        if row_index < len(rows) and column_index < len(rows[row_index]):
+            rows[row_index][column_index] = str(cell.content or "")
+    return rows
+
+
+def _tables_for_page(result: Any, page_number: int) -> list[dict[str, Any]]:
+    tables: list[dict[str, Any]] = []
+    for index, table in enumerate(getattr(result, "tables", []) or []):
+        if page_number not in _table_pages(table):
+            continue
+        tables.append(
+            {
+                "table_index": index,
+                "row_count": int(table.row_count),
+                "column_count": int(table.column_count),
+                "rows": _table_to_rows(table),
+            }
+        )
+    return tables
+
+
+def _key_value_pairs_for_page(result: Any, page_number: int) -> list[dict[str, str | None]]:
+    pairs: list[dict[str, str | None]] = []
+    for pair in getattr(result, "key_value_pairs", []) or []:
+        key = getattr(pair, "key", None)
+        value = getattr(pair, "value", None)
+        pages = set()
+        if key is not None:
+            pages.update(_cell_pages(key))
+        if value is not None:
+            pages.update(_cell_pages(value))
+        if page_number not in pages:
+            continue
+        pairs.append(
+            {
+                "key": getattr(key, "content", None),
+                "value": getattr(value, "content", None),
+            }
+        )
+    return pairs
+
+
+def _serialize_field_value(field: Any) -> Any:
+    value = getattr(field, "value", None)
+    if isinstance(value, list):
+        return [_serialize_field_value(item) for item in value]
+    if hasattr(value, "items"):
+        return {name: _serialize_field_value(item) for name, item in value.items()}
+    return value
+
+
+def _documents_for_result(result: Any) -> list[dict[str, Any]]:
+    documents: list[dict[str, Any]] = []
+    for index, document in enumerate(getattr(result, "documents", []) or []):
+        fields: dict[str, dict[str, Any]] = {}
+        for name, field in (getattr(document, "fields", None) or {}).items():
+            fields[name] = {
+                "field_type": getattr(field, "type", None),
+                "content": getattr(field, "content", None),
+                "value": _serialize_field_value(field),
+                "confidence": getattr(field, "confidence", None),
+            }
+        documents.append(
+            {
+                "document_index": index,
+                "doc_type": getattr(document, "doc_type", None),
+                "confidence": getattr(document, "confidence", None),
+                "fields": fields,
+            }
+        )
+    return documents
+
+
+def _page_text(page: Any) -> str:
+    return "\n".join(line.content for line in getattr(page, "lines", []) or [] if getattr(line, "content", None))
+
+
+def analyze_page(
+    client: DocumentIntelligenceClient,
+    pdf_bytes: bytes,
+    *,
+    page_number: int,
+    model_id: str,
+) -> dict[str, Any]:
+    expectation = page_expectation(page_number)
+    start = time.perf_counter()
+    poller = client.begin_analyze_document(
+        model_id=model_id,
+        body=pdf_bytes,
+        pages=str(page_number),
+        features=MODEL_FEATURES.get(model_id, []),
+        output_content_format="text",
+    )
+    result = poller.result()
+    latency_ms = (time.perf_counter() - start) * 1000
+
+    page = next(page for page in result.pages if int(page.page_number) == page_number)
+    return {
+        "supplier_id": expectation.supplier_id,
+        "supplier_name": expectation.supplier_name,
+        "page_number": page_number,
+        "model_id": model_id,
+        "latency_ms": round(latency_ms, 2),
+        "table_count": len(_tables_for_page(result, page_number)),
+        "key_value_pair_count": len(_key_value_pairs_for_page(result, page_number)),
+        "document_count": len(getattr(result, "documents", []) or []),
+        "text": _page_text(page),
+        "tables": _tables_for_page(result, page_number),
+        "key_value_pairs": _key_value_pairs_for_page(result, page_number),
+        "documents": _documents_for_result(result),
+    }
+
+
+def _iter_pages() -> Iterable[int]:
+    for expectation in SUPPLIER_EXPECTATIONS:
+        for page_number in expectation.page_numbers:
+            yield page_number
+
+
+def run_benchmark(pdf_path: Path, endpoint: str, models: tuple[str, ...]) -> dict[str, Any]:
+    client = _build_client(endpoint)
+    pdf_bytes = pdf_path.read_bytes()
+    page_results: list[dict[str, Any]] = []
+
+    for model_id in models:
+        print(f"[benchmark] Running {model_id} across {pdf_path.name}")
+        for page_number in _iter_pages():
+            expectation = page_expectation(page_number)
+            print(f"  - page {page_number:02d} · {expectation.supplier_name}")
+            try:
+                page_results.append(analyze_page(client, pdf_bytes, page_number=page_number, model_id=model_id))
+            except HttpResponseError as exc:
+                page_results.append(
+                    {
+                        "supplier_id": expectation.supplier_id,
+                        "supplier_name": expectation.supplier_name,
+                        "page_number": page_number,
+                        "model_id": model_id,
+                        "latency_ms": 0.0,
+                        "table_count": 0,
+                        "key_value_pair_count": 0,
+                        "document_count": 0,
+                        "text": "",
+                        "tables": [],
+                        "key_value_pairs": [],
+                        "documents": [],
+                        "error": str(exc),
+                    }
+                )
+
+    benchmark_results = {
+        "endpoint": endpoint,
+        "pdf_path": str(pdf_path),
+        "models": list(models),
+        "page_results": page_results,
+    }
+    benchmark_results["evaluation"] = evaluate_benchmark_results(benchmark_results)
+    benchmark_results["summary"] = summarize_results(benchmark_results)
+    return benchmark_results
+
+
+def summarize_results(benchmark_results: dict[str, Any]) -> dict[str, Any]:
+    evaluation = benchmark_results["evaluation"]
+    latency_by_model: dict[str, list[float]] = defaultdict(list)
+    tables_by_model: dict[str, list[int]] = defaultdict(list)
+    key_values_by_model: dict[str, list[int]] = defaultdict(list)
+    documents_by_model: dict[str, list[int]] = defaultdict(list)
+    for page_result in benchmark_results["page_results"]:
+        model_id = str(page_result["model_id"])
+        latency_by_model[model_id].append(float(page_result["latency_ms"]))
+        tables_by_model[model_id].append(int(page_result["table_count"]))
+        key_values_by_model[model_id].append(int(page_result["key_value_pair_count"]))
+        documents_by_model[model_id].append(int(page_result["document_count"]))
+
+    model_summaries: list[dict[str, Any]] = []
+    for model_id, model_metrics in evaluation["models"].items():
+        summary = ModelRunSummary(
+            model_id=model_id,
+            average_latency_ms=(sum(latency_by_model[model_id]) / len(latency_by_model[model_id]))
+            if latency_by_model[model_id]
+            else 0.0,
+            average_completeness=float(model_metrics["average_completeness"]),
+            average_table_count=(sum(tables_by_model[model_id]) / len(tables_by_model[model_id]))
+            if tables_by_model[model_id]
+            else 0.0,
+            average_key_value_pair_count=(sum(key_values_by_model[model_id]) / len(key_values_by_model[model_id]))
+            if key_values_by_model[model_id]
+            else 0.0,
+            average_document_count=(sum(documents_by_model[model_id]) / len(documents_by_model[model_id]))
+            if documents_by_model[model_id]
+            else 0.0,
+            detected_fields=int(model_metrics["detected_fields"]),
+            expected_fields=int(model_metrics["expected_fields"]),
+        )
+        model_summaries.append(asdict(summary))
+
+    supplier_summaries: dict[str, dict[str, Any]] = {}
+    for page_evaluation in evaluation["page_evaluations"]:
+        supplier_key = f"{page_evaluation['model_id']}::{page_evaluation['supplier_id']}"
+        bucket = supplier_summaries.setdefault(
+            supplier_key,
+            {
+                "model_id": page_evaluation["model_id"],
+                "supplier_id": page_evaluation["supplier_id"],
+                "supplier_name": page_evaluation["supplier_name"],
+                "pages": [],
+                "average_completeness": 0.0,
+            },
+        )
+        bucket["pages"].append(page_evaluation["page_number"])
+        bucket["average_completeness"] += float(page_evaluation["completeness"])
+
+    for bucket in supplier_summaries.values():
+        page_count = len(bucket["pages"])
+        bucket["average_completeness"] = bucket["average_completeness"] / page_count if page_count else 0.0
+
+    best_completeness = max(item["average_completeness"] for item in model_summaries)
+    close_candidates = [
+        item for item in model_summaries if abs(item["average_completeness"] - best_completeness) <= 0.02
+    ]
+
+    recommended_model = max(
+        close_candidates,
+        key=lambda item: (
+            item["average_key_value_pair_count"],
+            item["average_table_count"],
+            item["average_document_count"],
+            -item["average_latency_ms"],
+        ),
+    )["model_id"]
+    recommendation_reason = (
+        "Field-level accuracy is effectively tied, so prefer prebuilt-layout for heterogeneous supplier packs because "
+        "it preserves tables plus key-value pairs on every format."
+        if recommended_model == "prebuilt-layout"
+        else "prebuilt-invoice wins on the current benchmark mix because it keeps field accuracy while returning the best runtime."
+    )
+
+    return {
+        "models": model_summaries,
+        "suppliers": list(supplier_summaries.values()),
+        "recommended_model": recommended_model,
+        "recommendation_reason": recommendation_reason,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark Document Intelligence OCR extraction on PRUEBA.pdf")
+    parser.add_argument("--pdf", type=Path, default=_default_pdf_path(), help="Path to the sample PDF.")
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT, help="Document Intelligence endpoint.")
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=list(DEFAULT_MODELS),
+        choices=list(DEFAULT_MODELS),
+        help="Models to benchmark.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    args = parser.parse_args()
+
+    benchmark_results = run_benchmark(args.pdf.resolve(), args.endpoint, tuple(args.models))
+    serialized = json.dumps(benchmark_results, ensure_ascii=False, indent=2)
+
+    if args.output is not None:
+        args.output.write_text(serialized + "\n", encoding="utf-8")
+
+    print(serialized)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/poc/ocr_benchmark/evaluate.py
+++ b/src/poc/ocr_benchmark/evaluate.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import unicodedata
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+EXPECTED_FIELD_NAMES = (
+    "supplier_name",
+    "document_date",
+    "document_number",
+    "line_item_code",
+    "line_item_description",
+    "line_item_quantity",
+    "line_item_price",
+)
+
+DATE_PATTERN = re.compile(
+    r"\b(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}[./-]\d{1,2}[./-]\d{1,2}|\d{1,2}\s+[A-Za-z]{3,12}\s+\d{2,4})\b"
+)
+NUMBER_LABEL_PATTERN = re.compile(
+    r"\b(?:albara?n|albara?n no|invoice|fattura|factura|ddt|document(?:o)?|liefer(?:schein)?|nota)\b",
+    re.IGNORECASE,
+)
+
+CODE_HINTS = ("ean", "barcode", "item", "art", "articolo", "codigo", "codice", "ref", "sku", "sscc")
+DESCRIPTION_HINTS = ("description", "descripcion", "descrizione", "artikel", "articulo", "item", "producto")
+QUANTITY_HINTS = ("qty", "quantity", "quantita", "cantidad", "uds", "ud", "boxes", "pallet", "palet", "colli")
+PRICE_HINTS = ("price", "precio", "importe", "amount", "pvp", "unit", "cost", "eur", "neto", "totale")
+
+
+@dataclass(frozen=True, slots=True)
+class SupplierExpectation:
+    supplier_id: str
+    supplier_name: str
+    page_numbers: tuple[int, ...]
+    aliases: tuple[str, ...]
+    expects_document_date: bool = True
+    expects_document_number: bool = True
+    expects_line_item_code: bool = True
+    expects_line_item_description: bool = True
+    expects_line_item_quantity: bool = True
+    expects_line_item_price: bool = True
+    notes: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class FieldEvaluation:
+    detected: bool
+    evidence: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PageEvaluation:
+    supplier_id: str
+    supplier_name: str
+    page_number: int
+    model_id: str
+    fields: dict[str, FieldEvaluation]
+    detected_fields: int
+    expected_fields: int
+    completeness: float
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["fields"] = {name: asdict(field) for name, field in self.fields.items()}
+        return data
+
+
+SUPPLIER_EXPECTATIONS: tuple[SupplierExpectation, ...] = (
+    SupplierExpectation(
+        supplier_id="herstera",
+        supplier_name="Herstera Garden S.L.",
+        page_numbers=(1, 2, 3, 4),
+        aliases=("Herstera Garden S.L.", "Herstera Garden", "Herstera"),
+        notes="Structured table with EAN codes and multi-page continuity.",
+    ),
+    SupplierExpectation(
+        supplier_id="fansa",
+        supplier_name="FANSA",
+        page_numbers=(5,),
+        aliases=("FANSA",),
+        notes="Monospaced invoice with handwritten numeric corrections and stamps.",
+    ),
+    SupplierExpectation(
+        supplier_id="royal_canin",
+        supplier_name="Royal Canin Ibérica",
+        page_numbers=(6,),
+        aliases=("Royal Canin Ibérica", "Royal Canin Iberica", "Royal Canin"),
+        notes="Pet-food invoice with lots and expiry dates.",
+    ),
+    SupplierExpectation(
+        supplier_id="hobbit_alf",
+        supplier_name="HOBBIT-ALF S.L.",
+        page_numbers=(7, 8),
+        aliases=("HOBBIT-ALF S.L.", "HOBBIT-ALF", "Hobbit-Alf"),
+        notes="Italian-style export invoice with IBAN-heavy headers.",
+    ),
+    SupplierExpectation(
+        supplier_id="veca",
+        supplier_name="VECA S.p.A",
+        page_numbers=(9, 10),
+        aliases=("VECA S.p.A", "VECA", "Veca"),
+        notes="Dense Italian columns with handwritten annotations.",
+    ),
+    SupplierExpectation(
+        supplier_id="sera",
+        supplier_name="sera GmbH",
+        page_numbers=(11, 12, 13),
+        aliases=("sera GmbH", "sera", "Sera GmbH"),
+        notes="German multi-page format with boxes and pallets.",
+    ),
+    SupplierExpectation(
+        supplier_id="trixie",
+        supplier_name="triXder/Trixie",
+        page_numbers=(14, 15),
+        aliases=("triXder", "Trixie", "triXie", "TRIXIE"),
+        notes="Factura with PVP columns and mixed casing on supplier brand.",
+    ),
+    SupplierExpectation(
+        supplier_id="saneaplast",
+        supplier_name="Saneaplast",
+        page_numbers=(16, 19),
+        aliases=("Saneaplast",),
+        notes="Grid layout with discounts and duplicated albaranes.",
+    ),
+    SupplierExpectation(
+        supplier_id="catral",
+        supplier_name="Catral",
+        page_numbers=(17, 18),
+        aliases=("Catral",),
+        expects_line_item_price=False,
+        notes="Albarán plus packing list; SSCC barcodes matter more than prices.",
+    ),
+)
+
+SUPPLIER_BY_PAGE = {
+    page_number: expectation for expectation in SUPPLIER_EXPECTATIONS for page_number in expectation.page_numbers
+}
+
+
+def normalize_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    without_accents = "".join(character for character in normalized if not unicodedata.combining(character))
+    return re.sub(r"\s+", " ", without_accents).strip().lower()
+
+
+def page_expectation(page_number: int) -> SupplierExpectation:
+    try:
+        return SUPPLIER_BY_PAGE[page_number]
+    except KeyError as exc:
+        raise ValueError(f"No supplier expectation configured for page {page_number}.") from exc
+
+
+def _field_content(field_data: Mapping[str, Any]) -> str:
+    content = field_data.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+
+    value = field_data.get("value")
+    if isinstance(value, str) and value.strip():
+        return value
+
+    if value is None:
+        return ""
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _document_field_text(page_data: Mapping[str, Any]) -> str:
+    documents = page_data.get("documents", [])
+    if not isinstance(documents, list):
+        return ""
+
+    parts: list[str] = []
+    for document in documents:
+        if not isinstance(document, Mapping):
+            continue
+        for name, field_data in document.get("fields", {}).items():
+            if not isinstance(field_data, Mapping):
+                continue
+            parts.append(f"{name}: {_field_content(field_data)}")
+    return "\n".join(parts)
+
+
+def _key_value_text(page_data: Mapping[str, Any]) -> str:
+    pairs = page_data.get("key_value_pairs", [])
+    if not isinstance(pairs, list):
+        return ""
+
+    lines: list[str] = []
+    for pair in pairs:
+        if not isinstance(pair, Mapping):
+            continue
+        key = pair.get("key")
+        value = pair.get("value")
+        if key or value:
+            lines.append(f"{key or ''}: {value or ''}")
+    return "\n".join(lines)
+
+
+def _table_rows(page_data: Mapping[str, Any]) -> list[list[str]]:
+    tables = page_data.get("tables", [])
+    if not isinstance(tables, list):
+        return []
+
+    rows: list[list[str]] = []
+    for table in tables:
+        if not isinstance(table, Mapping):
+            continue
+        row_data = table.get("rows", [])
+        if not isinstance(row_data, list):
+            continue
+        for row in row_data:
+            if isinstance(row, list):
+                rows.append([str(cell) for cell in row])
+    return rows
+
+
+def _search_blob(page_data: Mapping[str, Any]) -> str:
+    parts = [
+        str(page_data.get("text", "")),
+        _key_value_text(page_data),
+        _document_field_text(page_data),
+    ]
+    parts.extend(" | ".join(row) for row in _table_rows(page_data))
+    return "\n".join(part for part in parts if part)
+
+
+def _find_alias(blob: str, aliases: Iterable[str]) -> str | None:
+    normalized_blob = normalize_text(blob)
+    for alias in aliases:
+        if normalize_text(alias) in normalized_blob:
+            return alias
+    return None
+
+
+def _detect_supplier_name(page_data: Mapping[str, Any], expectation: SupplierExpectation) -> FieldEvaluation:
+    evidence = _find_alias(_search_blob(page_data), expectation.aliases)
+    return FieldEvaluation(detected=evidence is not None, evidence=evidence)
+
+
+def _detect_document_date(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    match = DATE_PATTERN.search(_search_blob(page_data))
+    return FieldEvaluation(detected=match is not None, evidence=match.group(0) if match else None)
+
+
+def _detect_document_number(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    blob = _search_blob(page_data)
+    lines = [line.strip() for line in blob.splitlines() if line.strip()]
+    for line in lines:
+        if NUMBER_LABEL_PATTERN.search(line):
+            compact = re.sub(r"\s+", " ", line)
+            return FieldEvaluation(detected=True, evidence=compact[:120])
+
+    token_match = re.search(r"\b[A-Z]{1,6}[-./]?\d{2,}[A-Z0-9./-]*\b", blob)
+    return FieldEvaluation(detected=token_match is not None, evidence=token_match.group(0) if token_match else None)
+
+
+def _header_blob(page_data: Mapping[str, Any]) -> str:
+    header_candidates: list[str] = []
+    for row in _table_rows(page_data)[:6]:
+        header_candidates.append(" | ".join(row))
+    return normalize_text("\n".join(header_candidates))
+
+
+def _contains_any(blob: str, hints: Iterable[str]) -> str | None:
+    for hint in hints:
+        if normalize_text(hint) in blob:
+            return hint
+    return None
+
+
+def _detect_line_item_code(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    header_blob = _header_blob(page_data)
+    hint = _contains_any(header_blob, CODE_HINTS)
+    if hint is not None:
+        return FieldEvaluation(detected=True, evidence=hint)
+
+    for row in _table_rows(page_data):
+        for cell in row:
+            if re.search(r"\b\d{8,14}\b", cell):
+                return FieldEvaluation(detected=True, evidence=cell)
+    return FieldEvaluation(detected=False)
+
+
+def _detect_line_item_description(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    header_blob = _header_blob(page_data)
+    hint = _contains_any(header_blob, DESCRIPTION_HINTS)
+    if hint is not None:
+        return FieldEvaluation(detected=True, evidence=hint)
+
+    for row in _table_rows(page_data):
+        for cell in row:
+            words = [part for part in re.split(r"\s+", cell.strip()) if part]
+            if len(words) >= 3 and not re.fullmatch(r"[\d.,-]+", cell.strip()):
+                return FieldEvaluation(detected=True, evidence=cell[:120])
+    return FieldEvaluation(detected=False)
+
+
+def _detect_line_item_quantity(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    header_blob = _header_blob(page_data)
+    hint = _contains_any(header_blob, QUANTITY_HINTS)
+    if hint is not None:
+        return FieldEvaluation(detected=True, evidence=hint)
+
+    for row in _table_rows(page_data):
+        numeric_cells = [cell for cell in row if re.fullmatch(r"[-+]?\d+(?:[.,]\d+)?", cell.strip())]
+        if numeric_cells:
+            return FieldEvaluation(detected=True, evidence=numeric_cells[0])
+    return FieldEvaluation(detected=False)
+
+
+def _detect_line_item_price(page_data: Mapping[str, Any]) -> FieldEvaluation:
+    header_blob = _header_blob(page_data)
+    hint = _contains_any(header_blob, PRICE_HINTS)
+    if hint is not None:
+        return FieldEvaluation(detected=True, evidence=hint)
+
+    for row in _table_rows(page_data):
+        for cell in row:
+            if re.fullmatch(r"[-+]?\d+[.,]\d{2,4}", cell.strip()):
+                return FieldEvaluation(detected=True, evidence=cell)
+    return FieldEvaluation(detected=False)
+
+
+def evaluate_page_extraction(
+    page_data: Mapping[str, Any], expectation: SupplierExpectation | None = None
+) -> PageEvaluation:
+    page_number = int(page_data["page_number"])
+    resolved_expectation = expectation or page_expectation(page_number)
+
+    detected_fields = {
+        "supplier_name": _detect_supplier_name(page_data, resolved_expectation),
+        "document_date": _detect_document_date(page_data),
+        "document_number": _detect_document_number(page_data),
+        "line_item_code": _detect_line_item_code(page_data),
+        "line_item_description": _detect_line_item_description(page_data),
+        "line_item_quantity": _detect_line_item_quantity(page_data),
+        "line_item_price": _detect_line_item_price(page_data),
+    }
+
+    expected_flags = {
+        "supplier_name": True,
+        "document_date": resolved_expectation.expects_document_date,
+        "document_number": resolved_expectation.expects_document_number,
+        "line_item_code": resolved_expectation.expects_line_item_code,
+        "line_item_description": resolved_expectation.expects_line_item_description,
+        "line_item_quantity": resolved_expectation.expects_line_item_quantity,
+        "line_item_price": resolved_expectation.expects_line_item_price,
+    }
+
+    filtered_fields = {name: detected_fields[name] for name in EXPECTED_FIELD_NAMES if expected_flags[name]}
+    detected_count = sum(1 for field in filtered_fields.values() if field.detected)
+    expected_count = len(filtered_fields)
+    completeness = detected_count / expected_count if expected_count else 1.0
+
+    return PageEvaluation(
+        supplier_id=resolved_expectation.supplier_id,
+        supplier_name=resolved_expectation.supplier_name,
+        page_number=page_number,
+        model_id=str(page_data["model_id"]),
+        fields=filtered_fields,
+        detected_fields=detected_count,
+        expected_fields=expected_count,
+        completeness=completeness,
+    )
+
+
+def evaluate_benchmark_results(benchmark_results: Mapping[str, Any]) -> dict[str, Any]:
+    page_results = benchmark_results.get("page_results", [])
+    if not isinstance(page_results, list):
+        raise ValueError("Benchmark results must contain a 'page_results' list.")
+
+    evaluations = [
+        evaluate_page_extraction(page_result).to_dict()
+        for page_result in page_results
+        if isinstance(page_result, Mapping)
+    ]
+    by_model: dict[str, dict[str, Any]] = {}
+    for evaluation in evaluations:
+        model_id = str(evaluation["model_id"])
+        model_bucket = by_model.setdefault(
+            model_id,
+            {
+                "pages": 0,
+                "detected_fields": 0,
+                "expected_fields": 0,
+                "average_completeness": 0.0,
+                "field_detection_rate": {},
+            },
+        )
+        model_bucket["pages"] += 1
+        model_bucket["detected_fields"] += int(evaluation["detected_fields"])
+        model_bucket["expected_fields"] += int(evaluation["expected_fields"])
+
+        for field_name, field_result in evaluation["fields"].items():
+            field_bucket = model_bucket["field_detection_rate"].setdefault(field_name, {"detected": 0, "expected": 0})
+            field_bucket["expected"] += 1
+            if field_result["detected"]:
+                field_bucket["detected"] += 1
+
+    for model_bucket in by_model.values():
+        model_bucket["average_completeness"] = (
+            model_bucket["detected_fields"] / model_bucket["expected_fields"]
+            if model_bucket["expected_fields"]
+            else 1.0
+        )
+        for field_bucket in model_bucket["field_detection_rate"].values():
+            field_bucket["accuracy"] = (
+                field_bucket["detected"] / field_bucket["expected"] if field_bucket["expected"] else 1.0
+            )
+
+    return {
+        "expectations": [asdict(expectation) for expectation in SUPPLIER_EXPECTATIONS],
+        "page_evaluations": evaluations,
+        "models": by_model,
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate OCR benchmark output against supplier expectations.")
+    parser.add_argument("--input", type=Path, required=True, help="Path to the benchmark JSON output.")
+    parser.add_argument("--output", type=Path, help="Optional path to write the evaluation JSON.")
+    args = parser.parse_args()
+
+    evaluation = evaluate_benchmark_results(_read_json(args.input))
+    serialized = json.dumps(evaluation, ensure_ascii=False, indent=2)
+
+    if args.output is not None:
+        args.output.write_text(serialized + "\n", encoding="utf-8")
+
+    print(serialized)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/poc/ocr_benchmark/requirements.txt
+++ b/src/poc/ocr_benchmark/requirements.txt
@@ -1,0 +1,2 @@
+azure-ai-documentintelligence>=1.0.0b4
+azure-identity>=1.17.1

--- a/tests/fixtures/sample_albarans.py
+++ b/tests/fixtures/sample_albarans.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.models import (
+    AlbaranExtraction,
+    AlbaranHeader,
+    CoherenceCheckResult,
+    DocumentType,
+    LineItem,
+    TriageResult,
+)
+
+
+def sample_albaran_header(
+    *,
+    supplier_name: str = "Herstera Garden",
+    supplier_tax_id: str | None = "B12345678",
+    document_type: DocumentType = DocumentType.ALBARAN,
+    document_number: str = "ALB-2026-0001",
+    document_date: date | None = date(2026, 1, 15),
+    delivery_date: date | None = date(2026, 1, 16),
+    purchase_order_number: str | None = "PO-2026-0456",
+    store_name: str | None = "Verdecora Málaga",
+    total_amount: float | None = 54.0,
+    currency: str = "EUR",
+) -> AlbaranHeader:
+    return AlbaranHeader(
+        supplier_name=supplier_name,
+        supplier_tax_id=supplier_tax_id,
+        document_type=document_type,
+        document_number=document_number,
+        document_date=document_date,
+        delivery_date=delivery_date,
+        purchase_order_number=purchase_order_number,
+        store_name=store_name,
+        total_amount=total_amount,
+        currency=currency,
+    )
+
+
+def sample_line_items(*, supplier_name: str = "Herstera Garden") -> list[LineItem]:
+    if supplier_name == "Royal Canin":
+        return [
+            LineItem(
+                line_number=1,
+                product_code="RC-MEDIUM-12KG",
+                ean_code="3182550708183",
+                description="Royal Canin Medium Adult 12kg",
+                quantity=2.0,
+                unit_price=49.5,
+                discount_pct=5.0,
+                total=94.05,
+            ),
+            LineItem(
+                line_number=2,
+                product_code="RC-MAXI-15KG",
+                ean_code="3182550402142",
+                description="Royal Canin Maxi Adult 15kg",
+                quantity=1.0,
+                unit_price=58.0,
+                total=58.0,
+            ),
+        ]
+
+    if supplier_name == "FANSA":
+        return [
+            LineItem(
+                line_number=1,
+                product_code="FAN-001",
+                description="Fertilizante universal 5L",
+                quantity=4.0,
+                unit_price=7.5,
+                total=30.0,
+                lot_number="LOT-FAN-01",
+            ),
+            LineItem(
+                line_number=2,
+                product_code="FAN-002",
+                description="Sustrato premium 50L",
+                quantity=2.0,
+                unit_price=9.75,
+                total=19.5,
+            ),
+        ]
+
+    return [
+        LineItem(
+            line_number=1,
+            product_code="HER-001",
+            ean_code="8437001234567",
+            description="Maceta cerámica 20cm",
+            quantity=3.0,
+            unit_price=8.0,
+            total=24.0,
+        ),
+        LineItem(
+            line_number=2,
+            product_code="HER-002",
+            ean_code="8437007654321",
+            description="Jardinera exterior 60cm",
+            quantity=2.0,
+            unit_price=15.0,
+            total=30.0,
+            expiry_date=date(2026, 12, 31),
+        ),
+    ]
+
+
+def sample_extraction(
+    *,
+    supplier_name: str = "Herstera Garden",
+    confidence_score: float = 0.96,
+    extraction_warnings: list[str] | None = None,
+    source_pages: list[int] | None = None,
+    raw_text: str | None = "ALBARAN DE ENTREGA",
+    line_items: list[LineItem] | None = None,
+) -> AlbaranExtraction:
+    items = line_items if line_items is not None else sample_line_items(supplier_name=supplier_name)
+    return AlbaranExtraction(
+        header=sample_albaran_header(
+            supplier_name=supplier_name,
+            total_amount=sum(item.total or 0.0 for item in items),
+        ),
+        line_items=items,
+        raw_text=raw_text,
+        confidence_score=confidence_score,
+        extraction_warnings=list(extraction_warnings or []),
+        source_pages=list(source_pages or [1]),
+    )
+
+
+def sample_triage_result(
+    *,
+    document_type: DocumentType = DocumentType.ALBARAN,
+    language: str = "es",
+    supplier_id: str | None = "HERSTERA",
+    confidence: float = 0.94,
+    routing_decision: str = "extract",
+    reasoning: str = "Contiene palabras clave de albarán y datos de proveedor.",
+) -> TriageResult:
+    return TriageResult(
+        document_type=document_type,
+        language=language,
+        supplier_id=supplier_id,
+        confidence=confidence,
+        routing_decision=routing_decision,
+        reasoning=reasoning,
+    )
+
+
+def sample_coherence_result(
+    *,
+    is_coherent: bool = True,
+    overall_confidence: float = 0.91,
+    header_issues: list[str] | None = None,
+    line_item_issues: list[str] | None = None,
+    bc_match_found: bool = True,
+    matched_po_number: str | None = "PO-2026-0456",
+    suggested_corrections: dict[str, str] | None = None,
+) -> CoherenceCheckResult:
+    return CoherenceCheckResult(
+        is_coherent=is_coherent,
+        overall_confidence=overall_confidence,
+        header_issues=list(header_issues or []),
+        line_item_issues=list(line_item_issues or []),
+        bc_match_found=bc_match_found,
+        matched_po_number=matched_po_number,
+        suggested_corrections=dict(suggested_corrections or {}),
+    )
+
+
+def sample_herstera_extraction() -> AlbaranExtraction:
+    return sample_extraction(supplier_name="Herstera Garden")
+
+
+def sample_fansa_extraction() -> AlbaranExtraction:
+    return sample_extraction(supplier_name="FANSA")
+
+
+def sample_royal_canin_extraction() -> AlbaranExtraction:
+    return sample_extraction(supplier_name="Royal Canin")
+
+
+def sample_multi_page_extraction() -> AlbaranExtraction:
+    return sample_extraction(
+        supplier_name="Royal Canin",
+        confidence_score=0.88,
+        extraction_warnings=["Page 2 contains faint handwriting."],
+        source_pages=[1, 2],
+        raw_text="ALBARAN PAGE 1\nALBARAN PAGE 2",
+    )
+
+
+__all__ = [
+    "sample_albaran_header",
+    "sample_line_items",
+    "sample_extraction",
+    "sample_triage_result",
+    "sample_coherence_result",
+    "sample_herstera_extraction",
+    "sample_fansa_extraction",
+    "sample_royal_canin_extraction",
+    "sample_multi_page_extraction",
+]

--- a/tests/unit/agent_test_helpers.py
+++ b/tests/unit/agent_test_helpers.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class StructuredAgentStub:
+    def __init__(self, *, structured_output: type[BaseModel], kwargs: dict[str, Any]) -> None:
+        self.structured_output = structured_output
+        self.kwargs = kwargs
+
+    def decode(self, payload: str | dict[str, Any] | BaseModel) -> BaseModel:
+        if isinstance(payload, self.structured_output):
+            return payload
+        if isinstance(payload, str):
+            return self.structured_output.model_validate_json(payload)
+        return self.structured_output.model_validate(payload)
+
+
+def build_structured_agent_stub(**kwargs: Any) -> StructuredAgentStub:
+    return StructuredAgentStub(structured_output=kwargs["structured_output"], kwargs=dict(kwargs))

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for config helpers."""

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.factory import create_all_agents
+from src.config.agents import AgentsConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_create_all_agents_returns_expected_keys() -> None:
+    agents = create_all_agents(client=object(), config=AgentsConfig())
+
+    assert set(agents) == {"triage", "extractor", "coherence"}
+
+
+@patch("src.agents.factory.create_coherence_agent", return_value="coherence-agent")
+@patch("src.agents.factory.create_extractor_agent", return_value="extractor-agent")
+@patch("src.agents.factory.create_triage_agent", return_value="triage-agent")
+def test_create_all_agents_passes_tool_registry_to_each_agent(
+    mock_triage: Any, mock_extractor: Any, mock_coherence: Any
+) -> None:
+    config = AgentsConfig()
+    tool_registry = {
+        "triage": ["triage-tool"],
+        "extractor": ["extractor-tool"],
+        "coherence": ["coherence-tool"],
+    }
+
+    agents = create_all_agents(client="client", config=config, tool_registry=tool_registry)
+
+    assert agents == {
+        "triage": "triage-agent",
+        "extractor": "extractor-agent",
+        "coherence": "coherence-agent",
+    }
+    mock_triage.assert_called_once_with("client", config, tools=["triage-tool"])
+    mock_extractor.assert_called_once_with("client", config, tools=["extractor-tool"])
+    mock_coherence.assert_called_once_with("client", config, tools=["coherence-tool"])
+
+
+@patch("src.agents.factory.create_coherence_agent", return_value="coherence-local-agent")
+@patch("src.agents.factory.create_extractor_agent", return_value="extractor-local-agent")
+@patch("src.agents.factory.create_triage_agent", return_value="triage-local-agent")
+def test_create_all_agents_respects_custom_config_overrides(
+    mock_triage: Any, mock_extractor: Any, mock_coherence: Any
+) -> None:
+    custom_config = AgentsConfig.model_validate(
+        {
+            "models": {
+                "triage_model": "triage-local",
+                "extractor_model": "extractor-local",
+                "coherence_model": "coherence-local",
+            }
+        }
+    )
+
+    agents = create_all_agents(client="client", config=custom_config)
+
+    assert agents == {
+        "triage": "triage-local-agent",
+        "extractor": "extractor-local-agent",
+        "coherence": "coherence-local-agent",
+    }
+    assert mock_triage.call_args.args[1].models.triage_model == "triage-local"
+    assert mock_extractor.call_args.args[1].models.extractor_model == "extractor-local"
+    assert mock_coherence.call_args.args[1].models.coherence_model == "coherence-local"

--- a/tests/unit/test_agent_pipeline.py
+++ b/tests/unit/test_agent_pipeline.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.pipeline import AlbaranPipeline, PipelineDocumentInput, PipelineRunResult
+from src.config.agents import AgentsConfig
+from src.models import DocumentType
+from tests.fixtures.sample_albarans import (
+    sample_coherence_result,
+    sample_extraction,
+    sample_triage_result,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class FakeEvent:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+class FakeAsyncStream:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeWorkflow:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.payloads: list[Any] = []
+
+    def run(self, payload: Any, *, stream: bool) -> Any:
+        assert stream is True
+        self.payloads.append(payload)
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def test_pipeline_creation_with_all_agents() -> None:
+    pipeline = AlbaranPipeline(
+        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+    )
+
+    assert set(pipeline.agents) == {"triage", "extractor", "coherence"}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_with_mocked_agents() -> None:
+    triage_result = sample_triage_result()
+    extraction_result = sample_extraction()
+    coherence_result = sample_coherence_result()
+    triage_workflow = FakeWorkflow(
+        FakeAsyncStream([FakeEvent({"ignored": True}), FakeEvent(triage_result.model_dump(mode="json"))])
+    )
+    extraction_workflow = FakeWorkflow(extraction_result.model_dump(mode="json"))
+    coherence_workflow = FakeWorkflow(coherence_result.model_dump_json())
+    workflows = {
+        "albaran-triage": triage_workflow,
+        "albaran-extraction": extraction_workflow,
+        "albaran-coherence": coherence_workflow,
+    }
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return workflows[name]
+
+    pipeline = AlbaranPipeline(
+        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+    )
+    input_data = PipelineDocumentInput(
+        document_reference="https://storage/account/albaran.pdf",
+        raw_text="ALBARAN DE ENTREGA",
+        ocr_payload={"pages": [{"pageNumber": 1}]},
+    )
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await pipeline.run(input_data)
+
+    assert isinstance(result, PipelineRunResult)
+    assert result.triage == triage_result
+    assert result.extraction == extraction_result
+    assert result.coherence == coherence_result
+    assert result.routing_decision == "extract"
+    assert triage_workflow.payloads == ["ALBARAN DE ENTREGA"]
+    assert extraction_workflow.payloads == [{"pages": [{"pageNumber": 1}]}]
+    assert coherence_workflow.payloads == [extraction_result.model_dump(mode="json")]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_agent_failures() -> None:
+    pipeline = AlbaranPipeline(
+        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+    )
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        _ = participants
+        if name == "albaran-triage":
+            return FakeWorkflow(RuntimeError("triage failed"))
+        return FakeWorkflow({})
+
+    with (
+        patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow),
+        pytest.raises(RuntimeError, match="triage failed"),
+    ):
+        await pipeline.run(PipelineDocumentInput(document_reference="https://storage/account/albaran.pdf"))
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skip_triage_flag_works() -> None:
+    config = AgentsConfig.model_validate(
+        {
+            "skip_triage_suppliers": ["ROYAL CANIN"],
+            "thresholds": {"low_value_coherence_threshold": 10.0},
+        }
+    )
+    extraction_result = sample_extraction(supplier_name="Royal Canin", confidence_score=0.82)
+    coherence_result = sample_coherence_result(is_coherent=True)
+    extraction_workflow = FakeWorkflow(extraction_result.model_dump(mode="json"))
+    coherence_workflow = FakeWorkflow(coherence_result.model_dump(mode="json"))
+    calls: list[str] = []
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        calls.append(name)
+        assert participants
+        return {
+            "albaran-extraction": extraction_workflow,
+            "albaran-coherence": coherence_workflow,
+        }[name]
+
+    pipeline = AlbaranPipeline(
+        client=object(),
+        config=config,
+        agents={"triage": object(), "extractor": object(), "coherence": object()},
+    )
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await pipeline.run(
+            PipelineDocumentInput(
+                document_reference="https://storage/account/albaran.pdf",
+                supplier_hint="royal canin",
+                total_amount=200.0,
+            )
+        )
+
+    assert result.triage is None
+    assert result.extraction == extraction_result
+    assert result.coherence == coherence_result
+    assert result.skipped_steps == ["triage"]
+    assert calls == ["albaran-extraction", "albaran-coherence"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stops_after_non_extract_triage_result() -> None:
+    rejected_triage = sample_triage_result(
+        document_type=DocumentType.UNKNOWN,
+        confidence=0.12,
+        routing_decision="reject",
+        reasoning="Unrelated marketing brochure.",
+    )
+    triage_workflow = FakeWorkflow(rejected_triage.model_dump(mode="json"))
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return {"albaran-triage": triage_workflow}[name]
+
+    pipeline = AlbaranPipeline(
+        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+    )
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await pipeline.run({"document_reference": "https://storage/account/flyer.pdf"})
+
+    assert result.triage == rejected_triage
+    assert result.extraction is None
+    assert result.coherence is None
+    assert result.routing_decision == "reject"
+    assert result.skipped_steps == ["extractor", "coherence"]

--- a/tests/unit/test_coherence_agent.py
+++ b/tests/unit/test_coherence_agent.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.coherence_agent import create_coherence_agent
+from src.config.agents import AgentsConfig
+from src.models import CoherenceCheckResult
+from tests.fixtures.sample_albarans import sample_coherence_result
+from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
+
+pytestmark = pytest.mark.unit
+
+
+class NamedTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@patch("src.agents.coherence_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_coherence_agent_uses_expected_model_and_prompt(mock_factory: Any) -> None:
+    tools = [NamedTool("bc.search_purchase_orders")]
+    agent = create_coherence_agent(client=object(), tools=tools)
+
+    assert isinstance(agent, StructuredAgentStub)
+    kwargs = mock_factory.call_args.kwargs
+    assert kwargs["name"] == "a3-coherence"
+    assert kwargs["model"] == "gpt-5-mini"
+    assert kwargs["structured_output"] is CoherenceCheckResult
+    assert kwargs["tools"] == tools
+    assert "data coherence specialist" in kwargs["instructions"]
+    assert '"overall_confidence"' in kwargs["instructions"]
+    assert "bc.search_purchase_orders" in kwargs["instructions"]
+
+
+@patch("src.agents.coherence_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_coherence_agent_uses_default_bc_tools_when_no_tools(mock_factory: Any) -> None:
+    create_coherence_agent(client=object())
+
+    instructions = mock_factory.call_args.kwargs["instructions"]
+    assert "bc.search_vendors" in instructions
+    assert "bc.search_purchase_orders" in instructions
+    assert "bc.search_items" in instructions
+
+
+def test_coherence_agent_accepts_coherent_document() -> None:
+    agent = StructuredAgentStub(structured_output=CoherenceCheckResult, kwargs={})
+    result = sample_coherence_result(is_coherent=True, overall_confidence=0.94, bc_match_found=True)
+
+    decoded = agent.decode(json.dumps(result.model_dump(mode="json")))
+
+    assert isinstance(decoded, CoherenceCheckResult)
+    assert decoded.is_coherent is True
+    assert decoded.bc_match_found is True
+    assert decoded.line_item_issues == []
+
+
+def test_coherence_agent_flags_total_mismatch() -> None:
+    agent = StructuredAgentStub(structured_output=CoherenceCheckResult, kwargs={})
+    result = sample_coherence_result(
+        is_coherent=False,
+        overall_confidence=0.38,
+        line_item_issues=["Document total does not match line item sum."],
+        bc_match_found=False,
+        matched_po_number=None,
+    )
+
+    decoded = agent.decode(result.model_dump(mode="json"))
+
+    assert isinstance(decoded, CoherenceCheckResult)
+    assert decoded.is_coherent is False
+    assert decoded.line_item_issues == ["Document total does not match line item sum."]
+    assert decoded.bc_match_found is False
+
+
+def test_coherence_agent_tracks_bc_matches_and_tolerance_checks() -> None:
+    agent = StructuredAgentStub(structured_output=CoherenceCheckResult, kwargs={})
+    result = sample_coherence_result(
+        is_coherent=True,
+        overall_confidence=0.9,
+        line_item_issues=[],
+        bc_match_found=True,
+        matched_po_number="PO-2026-0456",
+        suggested_corrections={"line_2_total": "Adjusted within 2% tolerance."},
+    )
+
+    decoded = agent.decode(result.model_dump(mode="json"))
+
+    assert isinstance(decoded, CoherenceCheckResult)
+    assert decoded.matched_po_number == "PO-2026-0456"
+    assert decoded.suggested_corrections["line_2_total"] == "Adjusted within 2% tolerance."
+
+
+@patch("src.agents.coherence_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_coherence_agent_respects_custom_model_config(mock_factory: Any) -> None:
+    config = AgentsConfig.model_validate({"models": {"coherence_model": "coherence-local"}})
+
+    create_coherence_agent(client=object(), config=config)
+
+    assert mock_factory.call_args.kwargs["model"] == "coherence-local"

--- a/tests/unit/test_config_agents.py
+++ b/tests/unit/test_config_agents.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.agents import AgentsConfig, get_agents_config
+
+pytestmark = pytest.mark.unit
+
+
+def test_agents_config_defaults() -> None:
+    config = AgentsConfig()
+
+    assert config.endpoints.azure_openai_endpoint == "https://verdecora-openai-dev.openai.azure.com/"
+    assert config.endpoints.document_intelligence_endpoint == (
+        "https://verdecora-docintell-dev.cognitiveservices.azure.com/"
+    )
+    assert config.models.extractor_model == "gpt-5"
+    assert config.models.triage_model == "gpt-5-mini"
+    assert config.models.coherence_model == "gpt-5-mini"
+    assert config.thresholds.triage_manual_review_threshold == pytest.approx(0.65)
+    assert config.thresholds.low_value_coherence_threshold == pytest.approx(250.0)
+    assert config.skip_triage_suppliers == ()
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com/",
+        "DOCUMENT_INTELLIGENCE_ENDPOINT": "https://example-docint.cognitiveservices.azure.com/",
+        "AZURE_OPENAI_API_VERSION": "2025-01-01-preview",
+        "GPT5_DEPLOYMENT": "gpt-5-custom",
+        "GPT5_MINI_DEPLOYMENT": "gpt-5-mini-custom",
+        "TRIAGE_MANUAL_REVIEW_THRESHOLD": "0.7",
+        "LOW_VALUE_COHERENCE_THRESHOLD": "99.5",
+        "SKIP_TRIAGE_SUPPLIERS": "HERSTERA, ROYAL CANIN",
+    },
+    clear=False,
+)
+def test_agents_config_reads_environment_overrides() -> None:
+    get_agents_config.cache_clear()
+    config = AgentsConfig()
+
+    assert config.endpoints.azure_openai_endpoint == "https://example.openai.azure.com/"
+    assert config.endpoints.document_intelligence_endpoint == "https://example-docint.cognitiveservices.azure.com/"
+    assert config.endpoints.azure_openai_api_version == "2025-01-01-preview"
+    assert config.models.extractor_model == "gpt-5-custom"
+    assert config.models.triage_model == "gpt-5-mini-custom"
+    assert config.models.coherence_model == "gpt-5-mini-custom"
+    assert config.thresholds.triage_manual_review_threshold == pytest.approx(0.7)
+    assert config.thresholds.low_value_coherence_threshold == pytest.approx(99.5)
+    assert config.skip_triage_suppliers == ("HERSTERA", "ROYAL CANIN")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"thresholds": {"triage_manual_review_threshold": "invalid"}},
+        {"models": {"extractor_model": None}},
+        {"skip_triage_suppliers": None},
+    ],
+)
+def test_agents_config_validation_rejects_invalid_payloads(payload: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        AgentsConfig.model_validate(payload)
+
+
+def test_get_agents_config_is_cached() -> None:
+    get_agents_config.cache_clear()
+
+    first = get_agents_config()
+    second = get_agents_config()
+
+    assert first is second

--- a/tests/unit/test_extractor_agent.py
+++ b/tests/unit/test_extractor_agent.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.extractor_agent import create_extractor_agent
+from src.config.agents import AgentsConfig
+from src.models import AlbaranExtraction, LineItem
+from tests.fixtures.sample_albarans import (
+    sample_extraction,
+    sample_fansa_extraction,
+    sample_multi_page_extraction,
+    sample_royal_canin_extraction,
+)
+from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
+
+pytestmark = pytest.mark.unit
+
+
+class NamedTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@patch("src.agents.extractor_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_extractor_agent_uses_expected_model_and_prompt(mock_factory: Any) -> None:
+    tools = [NamedTool("content_understanding.analyze_document")]
+    agent = create_extractor_agent(client=object(), tools=tools)
+
+    assert isinstance(agent, StructuredAgentStub)
+    kwargs = mock_factory.call_args.kwargs
+    assert kwargs["name"] == "a1-extractor"
+    assert kwargs["model"] == "gpt-5"
+    assert kwargs["structured_output"] is AlbaranExtraction
+    assert kwargs["tools"] == tools
+    assert kwargs["handoffs"] == ["a3-coherence"]
+    assert "expert document extraction agent" in kwargs["instructions"]
+    assert '"confidence_score"' in kwargs["instructions"]
+    assert "content_understanding.analyze_document" in kwargs["instructions"]
+
+
+@patch("src.agents.extractor_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_extractor_agent_uses_default_tool_names_when_no_tools(mock_factory: Any) -> None:
+    create_extractor_agent(client=object())
+
+    instructions = mock_factory.call_args.kwargs["instructions"]
+    assert "content_understanding.analyze_document" in instructions
+    assert "content_understanding.extract_tables" in instructions
+
+
+@pytest.mark.parametrize(
+    "extraction",
+    [
+        sample_extraction(),
+        sample_fansa_extraction(),
+        sample_royal_canin_extraction(),
+        sample_multi_page_extraction(),
+    ],
+)
+def test_extractor_agent_decodes_structured_json(extraction: AlbaranExtraction) -> None:
+    agent = StructuredAgentStub(structured_output=AlbaranExtraction, kwargs={})
+
+    decoded = agent.decode(json.dumps(extraction.model_dump(mode="json")))
+
+    assert isinstance(decoded, AlbaranExtraction)
+    assert decoded.header.supplier_name == extraction.header.supplier_name
+    assert decoded.source_pages == extraction.source_pages
+    assert decoded.confidence_score == pytest.approx(extraction.confidence_score)
+
+
+def test_extractor_agent_handles_missing_optional_fields_gracefully() -> None:
+    incomplete_line = LineItem(
+        line_number=1,
+        description="Maceta cerámica 20cm",
+        quantity=3,
+        unit_price=None,
+        total=None,
+    )
+    extraction = sample_extraction(
+        line_items=[incomplete_line],
+        confidence_score=0.74,
+        extraction_warnings=["Unit price missing on source document."],
+    )
+    agent = StructuredAgentStub(structured_output=AlbaranExtraction, kwargs={})
+
+    decoded = agent.decode(extraction.model_dump(mode="json"))
+
+    assert isinstance(decoded, AlbaranExtraction)
+    assert decoded.line_items[0].unit_price is None
+    assert decoded.line_items[0].total is None
+    assert decoded.extraction_warnings == ["Unit price missing on source document."]
+
+
+@patch("src.agents.extractor_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_extractor_agent_respects_custom_model_config(mock_factory: Any) -> None:
+    config = AgentsConfig.model_validate({"models": {"extractor_model": "gpt-4.1"}})
+
+    create_extractor_agent(client=object(), config=config)
+
+    assert mock_factory.call_args.kwargs["model"] == "gpt-4.1"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from src.models import (
+    AlbaranExtraction,
+    AlbaranHeader,
+    CoherenceCheckResult,
+    DocumentType,
+    LineItem,
+    TriageResult,
+)
+from tests.fixtures.sample_albarans import (
+    sample_albaran_header,
+    sample_coherence_result,
+    sample_extraction,
+    sample_line_items,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_albaran_header_supports_defaults_and_optional_fields() -> None:
+    header = AlbaranHeader(
+        supplier_name="Herstera Garden",
+        document_type=DocumentType.ALBARAN,
+        document_number="ALB-2026-0001",
+    )
+
+    assert header.currency == "EUR"
+    assert header.supplier_tax_id is None
+    assert header.document_date is None
+    assert header.delivery_date is None
+    assert header.purchase_order_number is None
+    assert header.store_name is None
+    assert header.total_amount is None
+
+
+def test_albaran_header_allows_empty_strings_and_none_values() -> None:
+    header = AlbaranHeader(
+        supplier_name="",
+        supplier_tax_id=None,
+        document_type=DocumentType.UNKNOWN,
+        document_number="",
+        document_date=None,
+        delivery_date=None,
+        purchase_order_number=None,
+        store_name=None,
+        total_amount=None,
+    )
+
+    assert header.supplier_name == ""
+    assert header.document_number == ""
+    assert header.document_type is DocumentType.UNKNOWN
+
+
+def test_line_item_supports_optional_fields_and_zero_quantity() -> None:
+    line_item = LineItem(
+        line_number=1,
+        product_code="",
+        ean_code=None,
+        description="",
+        quantity=0,
+        unit_price=None,
+        discount_pct=None,
+        total=None,
+        lot_number=None,
+        expiry_date=None,
+    )
+
+    assert line_item.quantity == 0.0
+    assert line_item.product_code == ""
+    assert line_item.description == ""
+    assert line_item.unit_price is None
+    assert line_item.expiry_date is None
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [("quantity", "abc"), ("unit_price", "invalid"), ("discount_pct", "5%")],
+)
+def test_line_item_rejects_invalid_numeric_values(field_name: str, value: str) -> None:
+    payload: dict[str, object] = {
+        "line_number": 1,
+        "description": "Maceta",
+        "quantity": 2,
+        "unit_price": 8.0,
+        "discount_pct": 0.0,
+    }
+    payload[field_name] = value
+
+    with pytest.raises(ValidationError):
+        LineItem.model_validate(payload)
+
+
+def test_albaran_extraction_serializes_and_round_trips() -> None:
+    extraction = sample_extraction(source_pages=[1, 2], extraction_warnings=["Unreadable footer"])
+
+    dumped = extraction.model_dump(mode="json")
+    restored = AlbaranExtraction.model_validate(dumped)
+
+    assert restored == extraction
+    assert dumped["source_pages"] == [1, 2]
+    assert dumped["header"]["document_date"] == date(2026, 1, 15).isoformat()
+    assert dumped["extraction_warnings"] == ["Unreadable footer"]
+
+
+@pytest.mark.parametrize("confidence_score", [-0.01, 1.01])
+def test_albaran_extraction_requires_confidence_between_zero_and_one(confidence_score: float) -> None:
+    with pytest.raises(ValidationError):
+        AlbaranExtraction(
+            header=sample_albaran_header(),
+            line_items=sample_line_items(),
+            confidence_score=confidence_score,
+        )
+
+
+@pytest.mark.parametrize(
+    ("document_type", "routing_decision"),
+    [
+        (DocumentType.ALBARAN, "extract"),
+        (DocumentType.FACTURA, "manual_review"),
+        (DocumentType.PACKING_LIST, "manual_review"),
+        (DocumentType.UNKNOWN, "reject"),
+    ],
+)
+def test_triage_result_supports_all_document_types(document_type: DocumentType, routing_decision: str) -> None:
+    result = TriageResult(
+        document_type=document_type,
+        language="es",
+        confidence=0.8,
+        routing_decision=routing_decision,
+        reasoning="Synthetic test payload.",
+    )
+
+    assert result.document_type is document_type
+    assert result.routing_decision == routing_decision
+
+
+@pytest.mark.parametrize("confidence", [-0.5, 1.5])
+def test_triage_result_rejects_confidence_outside_bounds(confidence: float) -> None:
+    with pytest.raises(ValidationError):
+        TriageResult(
+            document_type=DocumentType.ALBARAN,
+            confidence=confidence,
+            routing_decision="extract",
+            reasoning="Invalid confidence.",
+        )
+
+
+def test_coherence_check_result_defaults_and_issue_lists() -> None:
+    result = CoherenceCheckResult(is_coherent=False, overall_confidence=0.45)
+
+    assert result.header_issues == []
+    assert result.line_item_issues == []
+    assert result.bc_match_found is False
+    assert result.matched_po_number is None
+    assert result.suggested_corrections == {}
+
+
+def test_coherence_check_result_serialization_round_trip() -> None:
+    coherence = sample_coherence_result(
+        is_coherent=False,
+        overall_confidence=0.42,
+        header_issues=["Supplier not found in BC"],
+        line_item_issues=["Line 2 total mismatch"],
+        bc_match_found=False,
+        matched_po_number=None,
+        suggested_corrections={"matched_po_number": "PO-2026-0457"},
+    )
+
+    dumped = coherence.model_dump(mode="json")
+    restored = CoherenceCheckResult.model_validate(dumped)
+
+    assert restored == coherence
+    assert dumped["suggested_corrections"]["matched_po_number"] == "PO-2026-0457"

--- a/tests/unit/test_ocr_benchmark_evaluate.py
+++ b/tests/unit/test_ocr_benchmark_evaluate.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from src.poc.ocr_benchmark.evaluate import evaluate_benchmark_results, evaluate_page_extraction, page_expectation
+
+
+def test_evaluate_page_extraction_detects_expected_fields() -> None:
+    page_result = {
+        "supplier_id": "herstera",
+        "supplier_name": "Herstera Garden S.L.",
+        "page_number": 1,
+        "model_id": "prebuilt-layout",
+        "text": "Herstera Garden S.L.\nAlbarán HG-2024-0001\nFecha 01/02/2024",
+        "tables": [
+            {
+                "rows": [
+                    ["EAN", "Descripción", "Cantidad", "Precio"],
+                    ["8437000000012", "Jardinera verde", "10", "12,50"],
+                ]
+            }
+        ],
+        "key_value_pairs": [{"key": "Fecha", "value": "01/02/2024"}],
+        "documents": [],
+    }
+
+    evaluation = evaluate_page_extraction(page_result, page_expectation(1))
+
+    assert evaluation.detected_fields == evaluation.expected_fields
+    assert evaluation.completeness == 1.0
+    assert evaluation.fields["supplier_name"].detected is True
+    assert evaluation.fields["document_number"].detected is True
+    assert evaluation.fields["line_item_price"].detected is True
+
+
+def test_evaluate_benchmark_results_aggregates_models() -> None:
+    benchmark_results = {
+        "page_results": [
+            {
+                "supplier_id": "catral",
+                "supplier_name": "Catral",
+                "page_number": 17,
+                "model_id": "prebuilt-layout",
+                "text": "Catral\nPacking list\n17/04/2024",
+                "tables": [{"rows": [["SSCC", "Descripción", "Cantidad"], ["12345678901234", "Malla", "4"]]}],
+                "key_value_pairs": [],
+                "documents": [],
+            },
+            {
+                "supplier_id": "catral",
+                "supplier_name": "Catral",
+                "page_number": 17,
+                "model_id": "prebuilt-invoice",
+                "text": "Catral\nPacking list",
+                "tables": [{"rows": [["Descripción", "Cantidad"], ["Malla", "4"]]}],
+                "key_value_pairs": [],
+                "documents": [],
+            },
+        ]
+    }
+
+    evaluation = evaluate_benchmark_results(benchmark_results)
+
+    assert set(evaluation["models"]) == {"prebuilt-layout", "prebuilt-invoice"}
+    assert evaluation["models"]["prebuilt-layout"]["field_detection_rate"]["supplier_name"]["accuracy"] == 1.0
+    assert (
+        evaluation["models"]["prebuilt-layout"]["average_completeness"]
+        >= evaluation["models"]["prebuilt-invoice"]["average_completeness"]
+    )

--- a/tests/unit/test_triage_agent.py
+++ b/tests/unit/test_triage_agent.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.triage_agent import _build_triage_instructions, create_triage_agent
+from src.config.agents import AgentsConfig
+from src.models import DocumentType, TriageResult
+from tests.fixtures.sample_albarans import sample_triage_result
+from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
+
+pytestmark = pytest.mark.unit
+
+
+@patch("src.agents.triage_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_triage_agent_uses_expected_model_and_prompt(mock_factory: Any) -> None:
+    agent = create_triage_agent(client=object())
+
+    assert isinstance(agent, StructuredAgentStub)
+    kwargs = mock_factory.call_args.kwargs
+    assert kwargs["name"] == "a2-triage"
+    assert kwargs["model"] == "gpt-5-mini"
+    assert kwargs["structured_output"] is TriageResult
+    assert kwargs["handoffs"] == ["a1-extractor", "user"]
+    assert "document triage specialist" in kwargs["instructions"]
+    assert '"routing_decision"' in kwargs["instructions"]
+
+
+def test_build_triage_instructions_embeds_json_schema() -> None:
+    instructions = _build_triage_instructions()
+
+    assert "Respond with a JSON object matching this schema" in instructions
+    assert '"document_type"' in instructions
+    assert '"confidence"' in instructions
+    assert "Common German" in instructions
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_language", "expected_routing"),
+    [
+        (
+            sample_triage_result(language="es", confidence=0.93).model_dump(mode="json"),
+            "es",
+            "extract",
+        ),
+        (
+            sample_triage_result(language="it", supplier_id="FANSA", confidence=0.89).model_dump(mode="json"),
+            "it",
+            "extract",
+        ),
+        (
+            sample_triage_result(language="de", supplier_id="ROYAL-CANIN", confidence=0.87).model_dump(mode="json"),
+            "de",
+            "extract",
+        ),
+    ],
+)
+def test_triage_agent_decodes_supported_languages(
+    payload: dict[str, Any], expected_language: str, expected_routing: str
+) -> None:
+    agent = StructuredAgentStub(structured_output=TriageResult, kwargs={})
+
+    decoded = agent.decode(json.dumps(payload))
+
+    assert isinstance(decoded, TriageResult)
+    assert decoded.language == expected_language
+    assert decoded.routing_decision == expected_routing
+
+
+@pytest.mark.parametrize(
+    ("document_type", "confidence", "routing_decision"),
+    [
+        (DocumentType.ALBARAN, 0.92, "extract"),
+        (DocumentType.UNKNOWN, 0.22, "reject"),
+        (DocumentType.ALBARAN, 0.41, "manual_review"),
+    ],
+)
+def test_triage_agent_handles_routing_decisions(
+    document_type: DocumentType, confidence: float, routing_decision: str
+) -> None:
+    agent = StructuredAgentStub(structured_output=TriageResult, kwargs={})
+    payload = sample_triage_result(
+        document_type=document_type,
+        confidence=confidence,
+        routing_decision=routing_decision,
+        reasoning="Damaged scan" if routing_decision == "manual_review" else "Structured payload",
+    )
+
+    decoded = agent.decode(payload.model_dump(mode="json"))
+
+    assert isinstance(decoded, TriageResult)
+    assert decoded.document_type is document_type
+    assert decoded.confidence == pytest.approx(confidence)
+    assert decoded.routing_decision == routing_decision
+
+
+@patch("src.agents.triage_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_triage_agent_respects_custom_model_config(mock_factory: Any) -> None:
+    config = AgentsConfig.model_validate({"models": {"triage_model": "triage-local"}})
+
+    create_triage_agent(client=object(), config=config)
+
+    assert mock_factory.call_args.kwargs["model"] == "triage-local"


### PR DESCRIPTION
## Summary
- add a standalone Document Intelligence OCR benchmark for PRUEBA.pdf using DefaultAzureCredential
- add extraction evaluation heuristics and supplier expectations for the 9 supplier formats
- document benchmark methodology, results, and the recommendation to use prebuilt-layout

## Validation
- python -m ruff check .
- python -m ruff format .
- python -m pytest
- python -m src.poc.ocr_benchmark.benchmark --help
- python -m src.poc.ocr_benchmark.evaluate --help
- smoke-tested live extraction against verdecora-docintell-dev on PRUEBA.pdf page 1