### PR TITLE
docs(agents): A1-A3 technical specification + prompt docs (#20)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,9 @@
 Complete documentation for the project:
 
 - **architecture/** - Architecture decisions and system design
+  - [Architecture decision record](architecture/architecture-decision-record.md)
+  - [Core agents technical specification](architecture/agents-technical-spec.md)
+  - [Prompt engineering for core agents](architecture/prompt-engineering.md)
+  - [Core agent data models](architecture/data-models.md)
 - **operations/** - Runbooks and operational procedures
 - **user/** - User manuals and guides

--- a/docs/architecture/agents-technical-spec.md
+++ b/docs/architecture/agents-technical-spec.md
@@ -1,0 +1,413 @@
+# Core agents technical specification
+
+## Scope
+
+This document describes the **implemented** core agents in `src/agents/`:
+
+- **A1 Extractor**
+- **A2 Triage**
+- **A3 Coherence**
+
+> The broader ADR describes a six-agent target architecture. The current codebase implements the first three agents only, using the Microsoft Agent Framework (MAF) **in-process** pattern inside one Python application.
+
+## Architecture overview
+
+### Runtime pattern
+
+The code uses a small compatibility layer in `src/agents/_maf_compat.py` to build agents and workflows without hard-coupling the rest of the code to one MAF constructor shape.
+
+```python
+return create_structured_agent(
+    client=client,
+    name="a1-extractor",
+    model=resolved_config.models.extractor_model,
+    instructions=_build_extractor_instructions(tool_names),
+    structured_output=AlbaranExtraction,
+    tools=resolved_tools,
+    handoffs=["a3-coherence"],
+)
+```
+
+At runtime:
+
+1. `factory.py` creates the three agents.
+2. `pipeline.py` decides which stages to run.
+3. Each stage is executed as a **single-step `SequentialBuilder` workflow**.
+4. Outputs are validated back into Pydantic models.
+
+### Important implementation note
+
+`AlbaranPipeline.build_workflow()` can assemble a combined sequential workflow for inspection/testing, but `AlbaranPipeline.run()` currently executes **three separate single-step workflows** (`triage`, `extractor`, `coherence`) with explicit Python control flow between them.
+
+## End-to-end data flow
+
+```mermaid
+flowchart TD
+    A[PipelineDocumentInput] --> B{Skip triage?}
+    B -- yes --> E[Extractor]
+    B -- no --> C[Triage]
+    C --> D{routing_decision == "extract"?}
+    D -- no --> Z[Return early\ntriage only]
+    D -- yes --> E[Extractor]
+    E --> F{Skip coherence?}
+    F -- yes --> Y[Return extraction result]
+    F -- no --> G[Coherence]
+    G --> H[PipelineRunResult]
+```
+
+### Stage inputs used by `pipeline.py`
+
+| Stage | Payload sent to workflow |
+|---|---|
+| Triage | `raw_text` if present, otherwise `document_reference` |
+| Extractor | `ocr_payload` if present, otherwise `raw_text`, otherwise `document_reference` |
+| Coherence | `extraction_result.model_dump(mode="json")` if extraction succeeded, otherwise the extractor payload fallback |
+
+## Agent factory and orchestration modules
+
+| Module | Responsibility |
+|---|---|
+| `src/agents/triage_agent.py` | Builds A2 with `TriageResult` structured output |
+| `src/agents/extractor_agent.py` | Builds A1 with `AlbaranExtraction` structured output |
+| `src/agents/coherence_agent.py` | Builds A3 with `CoherenceCheckResult` structured output |
+| `src/agents/factory.py` | Resolves config and tool registry, returns all three agents |
+| `src/agents/pipeline.py` | Applies skip logic and runs the stage sequence |
+| `src/agents/_maf_compat.py` | MAF compatibility wrapper + graceful fallback when `agent-framework` is missing |
+
+## Agent specifications
+
+## A2 Triage agent
+
+### Purpose
+
+Classify raw OCR text and decide whether the document should continue through the extraction pipeline.
+
+### Primary responsibility
+
+- Identify document type: `albaran`, `factura`, `packing_list`, or `unknown`
+- Detect language
+- Capture supplier hint if possible
+- Produce a routing decision
+
+### Model selection
+
+- **Configured model:** `config.models.triage_model`
+- **Default deployment:** `gpt-5-mini`
+
+Why this model split exists in code:
+
+- Triage works on **text classification and routing**, not heavy field extraction.
+- `AgentModelSettings` intentionally assigns the cheaper/faster mini deployment to triage.
+
+### Input/output contract
+
+**Input:** free-form string payload from OCR text (`raw_text`) or a fallback document reference.
+
+**Structured output:** `src.models.albaran.TriageResult`
+
+```python
+class TriageResult(BaseModel):
+    document_type: DocumentType
+    language: str = "es"
+    supplier_id: str | None = None
+    confidence: float = Field(ge=0.0, le=1.0)
+    routing_decision: str
+    reasoning: str
+```
+
+### Prompt strategy
+
+- Prompt lives in `prompts/triage_prompt.py`
+- Runtime injects `TriageResult.model_json_schema()` into the system prompt
+- Prompt is intentionally conservative: if unsure, prefer `manual_review`
+- Prompt includes multilingual keyword hints for Spanish, Italian, and German delivery documents
+
+### MCP tools
+
+- `create_triage_agent()` accepts optional tools
+- No default MCP tool names are appended to the prompt
+- In the current codebase, triage is tool-ready but not tool-opinionated
+
+### Handoffs
+
+Declared handoffs: `a1-extractor`, `user`
+
+These handoff names are embedded in the agent definition, but the current `run()` implementation does **not** use `HandoffBuilder`; routing is enforced in Python by checking `routing_decision`.
+
+### Error handling behavior
+
+- If the workflow backend is unavailable, `run()` raises a `RuntimeError` via `ensure_workflow_available()`
+- If streamed or returned output cannot be validated into `TriageResult`, the stage returns `None`
+- Any `routing_decision` other than `"extract"` stops the pipeline early
+
+## A1 Extractor agent
+
+### Purpose
+
+Convert OCR-derived content for an albarán/factura into the project’s canonical extraction model.
+
+### Primary responsibility
+
+- Populate `AlbaranHeader`
+- Extract all `LineItem` rows
+- Estimate extraction confidence
+- Produce extraction warnings and source page references
+
+### Model selection
+
+- **Configured model:** `config.models.extractor_model`
+- **Default deployment:** `gpt-5`
+
+Why this model split exists in code:
+
+- Extraction is the most schema-heavy stage and must recover structured data from messy OCR/table content.
+- `AgentModelSettings` assigns the full `gpt-5` deployment to extraction by default.
+
+### Input/output contract
+
+**Input:** `ocr_payload`, or fallback `raw_text`, or fallback `document_reference`.
+
+**Structured output:** `src.models.albaran.AlbaranExtraction`
+
+```python
+class AlbaranExtraction(BaseModel):
+    header: AlbaranHeader
+    line_items: list[LineItem]
+    raw_text: str | None = None
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    extraction_warnings: list[str] = Field(default_factory=list)
+    source_pages: list[int] = Field(default_factory=list)
+```
+
+### Prompt strategy
+
+- Prompt lives in `prompts/extractor_prompt.py`
+- Runtime injects `AlbaranExtraction.model_json_schema()`
+- Prompt explicitly asks for:
+  - complete header extraction
+  - complete line-item extraction
+  - confidence scoring
+  - warning generation
+  - multi-page aggregation
+  - barcode/EAN preservation
+
+The builder also appends a tool hint:
+
+```python
+tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names)
+```
+
+### MCP tools
+
+Default tool names documented in code:
+
+- `content_understanding.analyze_document`
+- `content_understanding.extract_tables`
+
+Actual tool objects come from `tool_registry["extractor"]`.
+
+### Handoffs
+
+Declared handoff: `a3-coherence`
+
+As with triage, this is future-friendly metadata in the current implementation; stage progression is handled directly in Python.
+
+### Error handling behavior
+
+- Invalid structured output is coerced to `None`
+- Pipeline still proceeds to coherence with a fallback payload if extraction returns `None`
+- No extractor-specific retry policy is implemented in this module
+
+## A3 Coherence agent
+
+### Purpose
+
+Validate the extraction result against business rules and, when tools are available, Business Central lookup results.
+
+### Primary responsibility
+
+- Check header plausibility
+- Check line-item quantities/prices/totals
+- Indicate whether a BC match was found
+- Propose corrections when issues are detected
+
+### Model selection
+
+- **Configured model:** `config.models.coherence_model`
+- **Default deployment:** `gpt-5-mini`
+
+Why this model split exists in code:
+
+- Coherence is primarily a text-and-logic validation stage over already structured JSON.
+- The config mirrors triage by using the lighter model by default.
+
+### Input/output contract
+
+**Input:** serialized `AlbaranExtraction` JSON when extraction succeeds; otherwise the extractor fallback payload.
+
+**Structured output:** `src.models.albaran.CoherenceCheckResult`
+
+```python
+class CoherenceCheckResult(BaseModel):
+    is_coherent: bool
+    overall_confidence: float = Field(ge=0.0, le=1.0)
+    header_issues: list[str] = Field(default_factory=list)
+    line_item_issues: list[str] = Field(default_factory=list)
+    bc_match_found: bool = False
+    matched_po_number: str | None = None
+    suggested_corrections: dict[str, str] = Field(default_factory=dict)
+```
+
+### Prompt strategy
+
+- Prompt lives in `prompts/coherence_prompt.py`
+- Runtime injects `CoherenceCheckResult.model_json_schema()`
+- Prompt asks the model to apply:
+  - header checks
+  - line-item math/coherence checks
+  - BC cross-reference checks when available
+  - 2% total-tolerance validation
+
+### MCP tools
+
+Default tool names documented in code:
+
+- `bc.search_vendors`
+- `bc.search_purchase_orders`
+- `bc.search_items`
+
+Actual tool objects come from `tool_registry["coherence"]`.
+
+### Error handling behavior
+
+- Invalid structured output becomes `None`
+- If `PipelineDocumentInput.total_amount` is below the configured threshold, the entire coherence stage is skipped
+- The stage does not throw on validation issues; it returns a `CoherenceCheckResult` describing them
+
+## Configuration
+
+## `AgentsConfig`
+
+`src/config/agents.py` groups agent settings into endpoints, model names, thresholds, and triage-skip suppliers.
+
+| Environment variable | Default | Used by |
+|---|---|---|
+| `AZURE_OPENAI_ENDPOINT` | `https://verdecora-openai-dev.openai.azure.com/` | Client construction outside agent factories |
+| `DOCUMENT_INTELLIGENCE_ENDPOINT` | `https://verdecora-docintell-dev.cognitiveservices.azure.com/` | OCR / document client construction outside agent factories |
+| `AZURE_OPENAI_API_VERSION` | `2024-10-21` | Client construction outside agent factories |
+| `GPT5_DEPLOYMENT` | `gpt-5` | Extractor model selection |
+| `GPT5_MINI_DEPLOYMENT` | `gpt-5-mini` | Triage + coherence model selection |
+| `TRIAGE_MANUAL_REVIEW_THRESHOLD` | `0.65` | Present in config, **not currently consumed** by pipeline/agent code |
+| `LOW_VALUE_COHERENCE_THRESHOLD` | `250.0` | Skip coherence when `total_amount` is below this value |
+| `SKIP_TRIAGE_SUPPLIERS` | empty | Skip triage when `supplier_id` or `supplier_hint` matches one of these tokens |
+
+### Credential creation
+
+`AgentsConfig.create_credential()` returns:
+
+```python
+DefaultAzureCredential(exclude_interactive_browser_credential=True)
+```
+
+This keeps the agent runtime aligned with managed identity / workload identity patterns.
+
+## Pipeline control logic
+
+### Triage skip
+
+Triage is skipped when either `supplier_id` or `supplier_hint` matches `skip_triage_suppliers` case-insensitively.
+
+### Coherence skip
+
+Coherence is skipped when `total_amount < low_value_coherence_threshold`.
+
+### Result shape
+
+The pipeline returns a `PipelineRunResult`:
+
+```python
+class PipelineRunResult(BaseModel):
+    triage: TriageResult | None = None
+    extraction: AlbaranExtraction | None = None
+    coherence: CoherenceCheckResult | None = None
+    routing_decision: str
+    skipped_steps: list[str] = Field(default_factory=list)
+```
+
+## MAF compatibility and failure modes
+
+`src/agents/_maf_compat.py` supports three operating modes:
+
+1. **Preferred:** `AgentBuilder` / `SequentialBuilder` available
+2. **Fallback:** `Agent` available but builder APIs differ
+3. **Unavailable:** return `UnavailableAgentSpec` / `UnavailableWorkflowSpec`
+
+This allows imports and unit tests to work even when `agent-framework` is not installed locally.
+
+### Practical implications
+
+- Agent creation can succeed in "spec only" mode
+- Pipeline execution cannot run in that mode
+- `coerce_model()` intentionally suppresses `ValidationError`, `TypeError`, and `ValueError`, returning `None` instead of crashing the run
+
+## Deployment notes (ACA + Managed Identity)
+
+## What the code assumes
+
+The core agent code assumes:
+
+- agents run **in-process** inside one Python service
+- the caller injects a ready-made MAF chat client
+- Azure authentication uses `DefaultAzureCredential` / managed identity
+- MCP tools are injected from outside via a registry
+
+## What the repo infrastructure already provisions
+
+The current infrastructure modules provision the Azure dependencies needed by the future ACA-hosted orchestrator:
+
+- **Azure OpenAI** account with `disableLocalAuth: true`
+- **Document Intelligence** account with `disableLocalAuth: true`
+- **user-assigned managed identity** `agentic-orchestrator`
+- RBAC for that identity on:
+  - Azure OpenAI (`Cognitive Services OpenAI User`)
+  - Document Intelligence (`Cognitive Services User`)
+  - Cosmos DB
+  - Service Bus
+  - Blob Storage
+  - Key Vault
+
+## Current gap to be aware of
+
+The repository contains the identity/RBAC foundation and the architectural ADR for ACA deployment, but **this branch does not yet define the actual `agentic-orchestrator` Azure Container App resource**. In other words:
+
+- **deployment target:** ACA
+- **identity model:** managed identity
+- **implemented infra here:** supporting resources and RBAC
+- **not yet present here:** the concrete container app manifest for the three-agent runtime
+
+## Minimal code wiring example
+
+```python
+from src.agents import build_pipeline
+from src.config import get_agents_config
+
+config = get_agents_config()
+pipeline = build_pipeline(
+    client=my_maf_client,
+    config=config,
+    tool_registry={
+        "extractor": [content_understanding_mcp],
+        "coherence": [bc_mcp],
+    },
+)
+```
+
+## Summary
+
+The implemented A1-A3 design is a pragmatic in-process MAF pipeline:
+
+- **A2 Triage** decides whether to continue
+- **A1 Extractor** produces the canonical albarán JSON
+- **A3 Coherence** validates the result
+
+The design is already structured for ACA + managed identity deployment, while keeping local development safe through `_maf_compat.py` and Pydantic-based structured outputs.

--- a/docs/architecture/data-models.md
+++ b/docs/architecture/data-models.md
@@ -1,0 +1,370 @@
+# Core agent data models
+
+## Scope
+
+This document describes the Pydantic models in `src/models/albaran.py` used by the implemented A1-A3 agents.
+
+## Model relationships
+
+```mermaid
+classDiagram
+    class DocumentType {
+      albaran
+      factura
+      packing_list
+      unknown
+    }
+
+    class LineItem {
+      int line_number
+      str? product_code
+      str? ean_code
+      str description
+      float quantity
+      float? unit_price
+      float? discount_pct
+      float? total
+      str? lot_number
+      date? expiry_date
+    }
+
+    class AlbaranHeader {
+      str supplier_name
+      str? supplier_tax_id
+      DocumentType document_type
+      str document_number
+      date? document_date
+      date? delivery_date
+      str? purchase_order_number
+      str? store_name
+      float? total_amount
+      str currency
+    }
+
+    class AlbaranExtraction {
+      AlbaranHeader header
+      LineItem[] line_items
+      str? raw_text
+      float confidence_score
+      str[] extraction_warnings
+      int[] source_pages
+    }
+
+    class TriageResult {
+      DocumentType document_type
+      str language
+      str? supplier_id
+      float confidence
+      str routing_decision
+      str reasoning
+    }
+
+    class CoherenceCheckResult {
+      bool is_coherent
+      float overall_confidence
+      str[] header_issues
+      str[] line_item_issues
+      bool bc_match_found
+      str? matched_po_number
+      map suggested_corrections
+    }
+
+    AlbaranExtraction --> AlbaranHeader
+    AlbaranExtraction --> LineItem
+    TriageResult --> DocumentType
+    AlbaranHeader --> DocumentType
+```
+
+## `DocumentType`
+
+Enum values:
+
+- `albaran`
+- `factura`
+- `packing_list`
+- `unknown`
+
+This enum is reused by both triage and extraction.
+
+## `AlbaranHeader`
+
+Represents the business-level header of the document.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `supplier_name` | `str` | Supplier / proveedor name shown on the document |
+| `supplier_tax_id` | `str | None` | Tax identifier (NIF/CIF/VAT) when present |
+| `document_type` | `DocumentType` | Business document type classified for the extraction |
+| `document_number` | `str` | Supplier document number / número de albarán |
+| `document_date` | `date | None` | Document issue date |
+| `delivery_date` | `date | None` | Delivery date if separate from issue date |
+| `purchase_order_number` | `str | None` | Purchase order / pedido number used for downstream BC validation |
+| `store_name` | `str | None` | Store / tienda receiving the delivery |
+| `total_amount` | `float | None` | Document grand total when present |
+| `currency` | `str` | Currency code, default `EUR` |
+
+### Example JSON
+
+```json
+{
+  "supplier_name": "Viveros Costa Verde S.L.",
+  "supplier_tax_id": "B12345678",
+  "document_type": "albaran",
+  "document_number": "ALB-2026-00421",
+  "document_date": "2026-05-03",
+  "delivery_date": "2026-05-04",
+  "purchase_order_number": "PO-45001234",
+  "store_name": "Verdecora Málaga",
+  "total_amount": 1845.70,
+  "currency": "EUR"
+}
+```
+
+## `LineItem`
+
+Represents one extracted line from the albarán body.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `line_number` | `int` | Sequential line identifier inside the extracted result |
+| `product_code` | `str | None` | Supplier or internal product code |
+| `ean_code` | `str | None` | Barcode / EAN code |
+| `description` | `str` | Human-readable item description |
+| `quantity` | `float` | Delivered quantity |
+| `unit_price` | `float | None` | Unit price when visible |
+| `discount_pct` | `float | None` | Discount percentage applied to the line |
+| `total` | `float | None` | Final line total |
+| `lot_number` | `str | None` | Lot / lote number |
+| `expiry_date` | `date | None` | Caducidad / expiry date |
+
+### Example JSON
+
+```json
+{
+  "line_number": 1,
+  "product_code": "PLT-ROS-5L",
+  "ean_code": "8437001234567",
+  "description": "Rosal rojo maceta 5L",
+  "quantity": 24.0,
+  "unit_price": 6.95,
+  "discount_pct": 10.0,
+  "total": 150.12,
+  "lot_number": "L240503A",
+  "expiry_date": null
+}
+```
+
+## `AlbaranExtraction`
+
+Top-level structured output from A1 Extractor.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `header` | `AlbaranHeader` | Document header |
+| `line_items` | `list[LineItem]` | Extracted delivery lines |
+| `raw_text` | `str | None` | Optional OCR/plain-text trace |
+| `confidence_score` | `float` | Normalized extraction confidence from `0.0` to `1.0` |
+| `extraction_warnings` | `list[str]` | Human-readable warnings about OCR ambiguity or missing fields |
+| `source_pages` | `list[int]` | Source pages used in the extraction |
+
+### Example JSON
+
+```json
+{
+  "header": {
+    "supplier_name": "Viveros Costa Verde S.L.",
+    "supplier_tax_id": "B12345678",
+    "document_type": "albaran",
+    "document_number": "ALB-2026-00421",
+    "document_date": "2026-05-03",
+    "delivery_date": "2026-05-04",
+    "purchase_order_number": "PO-45001234",
+    "store_name": "Verdecora Málaga",
+    "total_amount": 1845.70,
+    "currency": "EUR"
+  },
+  "line_items": [
+    {
+      "line_number": 1,
+      "product_code": "PLT-ROS-5L",
+      "ean_code": "8437001234567",
+      "description": "Rosal rojo maceta 5L",
+      "quantity": 24.0,
+      "unit_price": 6.95,
+      "discount_pct": 10.0,
+      "total": 150.12,
+      "lot_number": "L240503A",
+      "expiry_date": null
+    },
+    {
+      "line_number": 2,
+      "product_code": "SUB-TUR-2L",
+      "ean_code": null,
+      "description": "Sustrato universal 2L",
+      "quantity": 80.0,
+      "unit_price": 1.80,
+      "discount_pct": 0.0,
+      "total": 144.0,
+      "lot_number": null,
+      "expiry_date": null
+    }
+  ],
+  "raw_text": "ALBARÁN ALB-2026-00421 ...",
+  "confidence_score": 0.93,
+  "extraction_warnings": [
+    "Handwritten note near line 2 ignored.",
+    "Supplier VAT read with high confidence."
+  ],
+  "source_pages": [1, 2]
+}
+```
+
+## `TriageResult`
+
+Structured output from A2 Triage.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `document_type` | `DocumentType` | Document classification |
+| `language` | `str` | Detected language; defaults to `es` |
+| `supplier_id` | `str | None` | Supplier identifier or hint if recognized |
+| `confidence` | `float` | Routing confidence from `0.0` to `1.0` |
+| `routing_decision` | `str` | Routing decision string |
+| `reasoning` | `str` | Short explanation of the decision |
+
+### Routing decision values in practice
+
+The model does not enforce an enum for `routing_decision`, but the current prompt and pipeline assume these values:
+
+- `extract`
+- `reject`
+- `manual_review`
+
+### Example JSON
+
+```json
+{
+  "document_type": "albaran",
+  "language": "es",
+  "supplier_id": "VIVEROS_COSTA_VERDE",
+  "confidence": 0.91,
+  "routing_decision": "extract",
+  "reasoning": "Contains delivery-note keywords, supplier header, quantities and PO reference."
+}
+```
+
+## `CoherenceCheckResult`
+
+Structured output from A3 Coherence.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `is_coherent` | `bool` | Final pass/fail result for the coherence stage |
+| `overall_confidence` | `float` | Validation confidence from `0.0` to `1.0` |
+| `header_issues` | `list[str]` | Header-level problems |
+| `line_item_issues` | `list[str]` | Line-level or arithmetic problems |
+| `bc_match_found` | `bool` | Whether BC lookup found a match |
+| `matched_po_number` | `str | None` | Purchase order matched in BC |
+| `suggested_corrections` | `dict[str, str]` | Proposed corrections keyed by field or business concept |
+
+### Example JSON
+
+```json
+{
+  "is_coherent": false,
+  "overall_confidence": 0.82,
+  "header_issues": [
+    "Document date is later than delivery date.",
+    "Supplier tax ID is missing."
+  ],
+  "line_item_issues": [
+    "Line 2 total does not match quantity * unit price.",
+    "Line 4 quantity must be greater than zero."
+  ],
+  "bc_match_found": true,
+  "matched_po_number": "PO-45001234",
+  "suggested_corrections": {
+    "header.delivery_date": "Use 2026-05-04 instead of 2026-05-02.",
+    "line_items[1].total": "Recalculate to 144.00 EUR."
+  }
+}
+```
+
+## Serialization notes
+
+- `date` fields serialize as ISO-8601 strings (`YYYY-MM-DD`)
+- confidence fields are bounded to `0.0..1.0`
+- list and dict fields use safe defaults via `default_factory`
+- coherence and triage can be absent from `PipelineRunResult` when a stage is skipped or cannot be coerced from workflow output
+
+## Pipeline boundary models
+
+Two additional models matter at runtime even though they are not agent outputs.
+
+### `PipelineDocumentInput`
+
+This is the entry payload for `AlbaranPipeline.run()`:
+
+```json
+{
+  "document_reference": "https://storage/verdecora/albaranes/alb-00421.pdf",
+  "raw_text": "ALBARÁN ALB-2026-00421 ...",
+  "ocr_payload": {
+    "tables": [],
+    "key_values": {}
+  },
+  "supplier_id": null,
+  "supplier_hint": "Viveros Costa Verde",
+  "total_amount": 1845.70,
+  "metadata": {
+    "blob_etag": "0x8DEADBEEF"
+  }
+}
+```
+
+### `PipelineRunResult`
+
+Runtime result returned by the orchestrator:
+
+```json
+{
+  "triage": {
+    "document_type": "albaran",
+    "language": "es",
+    "supplier_id": "VIVEROS_COSTA_VERDE",
+    "confidence": 0.91,
+    "routing_decision": "extract",
+    "reasoning": "Contains delivery-note keywords, supplier header, quantities and PO reference."
+  },
+  "extraction": {
+    "header": {
+      "supplier_name": "Viveros Costa Verde S.L.",
+      "supplier_tax_id": "B12345678",
+      "document_type": "albaran",
+      "document_number": "ALB-2026-00421",
+      "document_date": "2026-05-03",
+      "delivery_date": "2026-05-04",
+      "purchase_order_number": "PO-45001234",
+      "store_name": "Verdecora Málaga",
+      "total_amount": 1845.70,
+      "currency": "EUR"
+    },
+    "line_items": [],
+    "raw_text": null,
+    "confidence_score": 0.93,
+    "extraction_warnings": [],
+    "source_pages": [1]
+  },
+  "coherence": {
+    "is_coherent": true,
+    "overall_confidence": 0.88,
+    "header_issues": [],
+    "line_item_issues": [],
+    "bc_match_found": true,
+    "matched_po_number": "PO-45001234",
+    "suggested_corrections": {}
+  },
+  "routing_decision": "extract",
+  "skipped_steps": []
+}
+```

--- a/docs/architecture/prompt-engineering.md
+++ b/docs/architecture/prompt-engineering.md
@@ -1,0 +1,300 @@
+# Prompt engineering for core agents
+
+## Scope
+
+This document explains how the three implemented prompts work in `src/agents/prompts/` and how they are consumed by the agent builders.
+
+## Shared prompt pattern
+
+All three agents use the same pattern:
+
+1. Store the base prompt as a module-level string constant.
+2. Generate a live JSON schema from the corresponding Pydantic model.
+3. Inject that schema into the system prompt with `.format(schema=schema)`.
+4. Optionally append a human-readable MCP tool hint.
+
+```python
+schema = json.dumps(AlbaranExtraction.model_json_schema(), ensure_ascii=False, indent=2)
+return EXTRACTOR_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+```
+
+### Why this matters
+
+- The prompt stays aligned with the real output model.
+- Schema drift is easier to notice during code review.
+- The LLM is told exactly what JSON shape to emit.
+
+## A2 triage prompt
+
+## Source
+
+- `src/agents/prompts/triage_prompt.py`
+- Builder: `src/agents/triage_agent.py`
+
+## Classification strategy
+
+The triage prompt tells the model to inspect **raw OCR text** and answer five questions implicitly:
+
+1. Is this an `albaran`, `factura`, `packing_list`, or `unknown` document?
+2. Which language is it written in?
+3. Can the supplier be identified?
+4. Should the document be extracted?
+5. Why was that routing decision made?
+
+### Keyword support baked into the prompt
+
+The prompt contains concrete keyword cues:
+
+- **Spanish:** `albarán`, `entrega`, `pedido`, `proveedor`, `cantidad`
+- **Italian:** `bolla di consegna`, `fattura`, `quantità`
+- **German:** `Lieferschein`, `Rechnung`, `Menge`
+
+These are not exhaustive dictionaries; they are anchor terms to help the model classify common supplier formats.
+
+## Language detection
+
+The prompt explicitly asks for language detection across:
+
+- Spanish
+- Italian
+- German
+- English
+
+Important nuance: the output model uses `language: str`, so the restriction is **prompt-level**, not enum-enforced.
+
+## Routing logic
+
+Prompt-level routes are:
+
+- `extract`
+- `reject`
+- `manual_review`
+
+The prompt also instructs the model to be conservative:
+
+> if unsure, route to `manual_review` rather than `extract`
+
+### Runtime consequence in `pipeline.py`
+
+The Python pipeline only continues when:
+
+```python
+triage_result.routing_decision == "extract"
+```
+
+So, in practice:
+
+- `extract` -> continue to A1 extractor
+- any other value -> return early with triage only
+
+```mermaid
+flowchart TD
+    A[OCR text] --> B{Document looks like delivery doc?}
+    B -- no --> R[reject]
+    B -- unclear --> M[manual_review]
+    B -- yes --> C{Enough confidence?}
+    C -- no --> M
+    C -- yes --> E[extract]
+```
+
+## Tool usage
+
+Triage accepts optional tools, but unlike extractor/coherence it does **not** append a default tool list into the prompt text. In the current implementation, the prompt is primarily classification-first.
+
+## A1 extractor prompt
+
+## Source
+
+- `src/agents/prompts/extractor_prompt.py`
+- Builder: `src/agents/extractor_agent.py`
+
+## Extraction strategy
+
+The extractor prompt frames the agent as a structured-data specialist over OCR output. It asks for:
+
+- header extraction
+- line-item extraction
+- confidence scoring
+- warning generation
+
+### Field extraction rules encoded in the prompt
+
+| Prompt rule | Intended result in model |
+|---|---|
+| "Header: supplier name, tax ID, document number, date, PO number, store, total" | `AlbaranHeader` |
+| "Line items: product code, EAN, description, quantity, unit price, discount, total, lot, expiry" | `LineItem[]` |
+| "Quantities must be numeric" | numeric `quantity` |
+| "Prices should include currency (default EUR)" | `currency` defaults to `EUR` in header |
+| "If a field is partially readable, extract what you can and lower confidence" | lower `confidence_score` + possible warnings |
+| "Multi-page documents: combine data from all pages" | single `AlbaranExtraction` with `source_pages` |
+| "Barcodes/EAN codes are valuable — always extract them" | populate `ean_code` whenever possible |
+
+## Confidence scoring
+
+The prompt asks for a confidence score between `0.0` and `1.0`. The output model enforces this with `Field(ge=0.0, le=1.0)`.
+
+Practical interpretation:
+
+- **High confidence**: clean OCR, clear totals, line items complete
+- **Medium confidence**: partial ambiguity but usable structure
+- **Low confidence**: illegible values, handwritten notes, missing tables
+
+## Warning generation
+
+Warnings are free-form strings in `extraction_warnings`.
+
+Typical warning themes encouraged by the prompt:
+
+- illegible quantities
+- handwritten annotations
+- missing supplier/date/PO fields
+- partial totals
+
+## Tool hinting
+
+Extractor is the only stage that documents OCR-oriented MCP tools directly in the prompt builder.
+
+Default names appended when no explicit tool objects are passed:
+
+- `content_understanding.analyze_document`
+- `content_understanding.extract_tables`
+
+This gives the model extra runtime context without changing the base prompt file.
+
+## A3 coherence prompt
+
+## Source
+
+- `src/agents/prompts/coherence_prompt.py`
+- Builder: `src/agents/coherence_agent.py`
+
+## Validation strategy
+
+The coherence prompt treats the extractor output as already-structured business data and asks the model to validate it on four axes:
+
+1. **Header coherence**
+2. **Line-item coherence**
+3. **Business Central cross-reference**
+4. **Mathematical validation**
+
+### Validation rules called out explicitly
+
+| Rule family | Prompt guidance |
+|---|---|
+| Header coherence | dates make sense, supplier exists, PO format is valid |
+| Line-item coherence | quantities > 0, prices reasonable, totals match line math |
+| BC cross-reference | supplier exists, PO exists, items match |
+| Mathematical validation | line totals should sum to document total within **2% tolerance** |
+
+Important nuance: the 2% tolerance is currently a **prompt instruction**, not a hard-coded Python validator in `pipeline.py`.
+
+## BC cross-reference behavior
+
+The prompt says "if available", which matches the code design:
+
+- coherence accepts optional tools
+- the builder appends default Business Central search tool names
+- the output model exposes `bc_match_found` and `matched_po_number`
+
+Default tool names appended by the builder:
+
+- `bc.search_vendors`
+- `bc.search_purchase_orders`
+- `bc.search_items`
+
+## Suggested corrections
+
+The prompt asks the model to "Suggest corrections where possible". This maps directly to:
+
+```python
+suggested_corrections: dict[str, str] = Field(default_factory=dict)
+```
+
+Typical entries could describe corrected PO numbers, supplier names, or total fields.
+
+## Prompt versioning strategy
+
+## Current strategy in this repo
+
+Prompt versioning is currently **source-controlled, file-based versioning**:
+
+- one prompt constant per file
+- no runtime prompt registry
+- no explicit `version` field inside prompt outputs
+- changes tracked through Git history / PRs
+
+That means the effective prompt version is the combination of:
+
+1. prompt file content
+2. Pydantic schema at that commit
+3. builder logic that appends tool hints
+
+## Practical guidance for future prompt edits
+
+When changing a prompt, review all three layers together:
+
+- prompt text
+- output model
+- builder logic
+
+For example, adding a new field to `AlbaranExtraction` without updating examples/tests will silently change the injected schema.
+
+## Testing prompts approach
+
+## What is implemented today
+
+Current automated coverage is indirect:
+
+- `tests/unit/test_agents_pipeline.py` verifies config defaults and model round-tripping
+- builder functions inject live schemas from the Pydantic models
+- `_maf_compat.py` allows unit tests to run even if MAF is not installed
+
+There is **no dedicated prompt-evaluation harness** in this branch.
+
+## Practical testing approach for this codebase
+
+### 1. Builder-level tests
+
+Validate that the generated instructions contain:
+
+- the expected schema name/fields
+- the expected MCP tool hint text
+- important route/validation keywords
+
+### 2. Structured-output integration tests
+
+Run the agents against representative OCR fixtures and assert that responses validate into:
+
+- `TriageResult`
+- `AlbaranExtraction`
+- `CoherenceCheckResult`
+
+### 3. Golden examples for supplier formats
+
+Maintain sample albaranes for:
+
+- Spanish suppliers
+- Italian suppliers
+- German suppliers
+- low-quality scans
+- multi-page deliveries
+
+### 4. Regression review on prompt edits
+
+For every prompt change, compare:
+
+- routing changes (`extract` vs `manual_review`)
+- confidence-score shifts
+- new or missing warnings
+- changes to `bc_match_found` / correction suggestions
+
+## Example: schema-aware builder pattern
+
+```python
+def _build_coherence_instructions(tool_names: tuple[str, ...]) -> str:
+    schema = json.dumps(CoherenceCheckResult.model_json_schema(), ensure_ascii=False, indent=2)
+    tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names) if tool_names else ""
+    return COHERENCE_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+```
+
+This pattern is the key prompt-engineering decision in the current implementation: prompts are not static prose, they are **schema-bound system instructions**.


### PR DESCRIPTION
## Summary
- add a technical specification for the implemented A1-A3 MAF agents
- document prompt engineering details for triage, extractor, and coherence
- document the Pydantic data models with JSON examples
- link the new architecture docs from docs/README.md`n
## Validation
- python -m pytest tests/unit/test_agents_pipeline.py ✅
- python -m pytest ⚠️ fails in baseline due existing 	ests/unit/test_security.py import mismatch
- python -m ruff check . ✅