### PR TITLE
feat(agents): A4 Validator + A5 Inventory agents (#21, #22)

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from .coherence_agent import create_coherence_agent
 from .extractor_agent import create_extractor_agent
 from .factory import create_all_agents
+from .inventory_agent import create_inventory_agent
 from .pipeline import AlbaranPipeline, PipelineDocumentInput, PipelineRunResult, build_pipeline
 from .triage_agent import create_triage_agent
+from .validator_agent import create_validator_agent
 
 __all__ = [
     "AlbaranPipeline",
@@ -14,5 +16,7 @@ __all__ = [
     "create_all_agents",
     "create_coherence_agent",
     "create_extractor_agent",
+    "create_inventory_agent",
     "create_triage_agent",
+    "create_validator_agent",
 ]

--- a/src/agents/factory.py
+++ b/src/agents/factory.py
@@ -6,7 +6,9 @@ from src.config.agents import AgentsConfig, get_agents_config
 
 from .coherence_agent import create_coherence_agent
 from .extractor_agent import create_extractor_agent
+from .inventory_agent import create_inventory_agent
 from .triage_agent import create_triage_agent
+from .validator_agent import create_validator_agent
 
 ToolRegistry = Mapping[str, list[Any]]
 
@@ -28,4 +30,6 @@ def create_all_agents(
         "triage": create_triage_agent(client, resolved_config, tools=_get_tools(tool_registry, "triage")),
         "extractor": create_extractor_agent(client, resolved_config, tools=_get_tools(tool_registry, "extractor")),
         "coherence": create_coherence_agent(client, resolved_config, tools=_get_tools(tool_registry, "coherence")),
+        "validator": create_validator_agent(client, resolved_config, tools=_get_tools(tool_registry, "validator")),
+        "inventory": create_inventory_agent(client, resolved_config, tools=_get_tools(tool_registry, "inventory")),
     }

--- a/src/agents/inventory_agent.py
+++ b/src/agents/inventory_agent.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.inventory import PostingResult
+
+from ._maf_compat import create_structured_agent
+from .prompts import INVENTORY_SYSTEM_PROMPT
+
+DEFAULT_INVENTORY_TOOL_NAMES: tuple[str, ...] = (
+    "bc.create_purchase_receipt",
+    "bc.post_purchase_receipt_lines",
+)
+
+
+def _build_inventory_instructions(tool_names: tuple[str, ...]) -> str:
+    schema = json.dumps(PostingResult.model_json_schema(), ensure_ascii=False, indent=2)
+    tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names) if tool_names else ""
+    return INVENTORY_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+
+
+def create_inventory_agent(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tools: list[Any] | None = None,
+) -> Any:
+    resolved_config = config or get_agents_config()
+    resolved_tools = list(tools or [])
+    tool_names = tuple(getattr(tool, "name", str(tool)) for tool in resolved_tools) or DEFAULT_INVENTORY_TOOL_NAMES
+    return create_structured_agent(
+        client=client,
+        name="a5-inventory",
+        model=resolved_config.models.inventory_model,
+        instructions=_build_inventory_instructions(tool_names),
+        structured_output=PostingResult,
+        tools=resolved_tools,
+        handoffs=["user"],
+    )

--- a/src/agents/pipeline.py
+++ b/src/agents/pipeline.py
@@ -7,11 +7,13 @@ from pydantic import BaseModel, Field
 
 from src.config.agents import AgentsConfig, get_agents_config
 from src.models.albaran import AlbaranExtraction, CoherenceCheckResult, TriageResult
+from src.models.inventory import PostingResult
+from src.models.validation import ValidationResult
 
 from ._maf_compat import build_sequential_workflow, coerce_model, ensure_workflow_available, event_payload
 from .factory import ToolRegistry, create_all_agents
 
-T = TypeVar("T", TriageResult, AlbaranExtraction, CoherenceCheckResult)
+T = TypeVar("T", TriageResult, AlbaranExtraction, CoherenceCheckResult, ValidationResult, PostingResult)
 
 
 class PipelineDocumentInput(BaseModel):
@@ -28,6 +30,8 @@ class PipelineRunResult(BaseModel):
     triage: TriageResult | None = None
     extraction: AlbaranExtraction | None = None
     coherence: CoherenceCheckResult | None = None
+    validation: ValidationResult | None = None
+    inventory: PostingResult | None = None
     routing_decision: str
     skipped_steps: list[str] = Field(default_factory=list)
 
@@ -63,8 +67,9 @@ class AlbaranPipeline:
         if not self._should_skip_triage(input_data):
             participants.append(self.agents["triage"])
         participants.append(self.agents["extractor"])
-        if not self._should_skip_coherence(input_data):
-            participants.append(self.agents["coherence"])
+        if self._should_skip_coherence(input_data):
+            return build_sequential_workflow(name="albaran-processing", participants=participants)
+        participants.extend([self.agents["coherence"], self.agents["validator"], self.agents["inventory"]])
         return build_sequential_workflow(name="albaran-processing", participants=participants)
 
     async def _run_workflow_for_model(self, workflow: Any, payload: Any, model_type: type[T]) -> T | None:
@@ -97,7 +102,7 @@ class AlbaranPipeline:
                 return PipelineRunResult(
                     triage=triage_result,
                     routing_decision=triage_result.routing_decision,
-                    skipped_steps=skipped_steps + ["extractor", "coherence"],
+                    skipped_steps=skipped_steps + ["extractor", "coherence", "validation", "inventory"],
                 )
 
         extraction_workflow = build_sequential_workflow(
@@ -111,7 +116,7 @@ class AlbaranPipeline:
         )
 
         if self._should_skip_coherence(normalized_input):
-            skipped_steps.append("coherence")
+            skipped_steps.extend(["coherence", "validation", "inventory"])
             return PipelineRunResult(
                 triage=triage_result,
                 extraction=extraction_result,
@@ -128,11 +133,45 @@ class AlbaranPipeline:
         coherence_result = await self._run_workflow_for_model(
             coherence_workflow, coherence_payload, CoherenceCheckResult
         )
-        routing_decision = triage_result.routing_decision if triage_result is not None else "extract"
+
+        validation_workflow = build_sequential_workflow(
+            name="albaran-validation", participants=[self.agents["validator"]]
+        )
+        validation_payload = {
+            "extraction": extraction_result.model_dump(mode="json") if extraction_result is not None else None,
+            "coherence": coherence_result.model_dump(mode="json") if coherence_result is not None else None,
+        }
+        validation_result = await self._run_workflow_for_model(
+            validation_workflow, validation_payload, ValidationResult
+        )
+
+        if validation_result is None or validation_result.recommendation != "approve":
+            skipped_steps.append("inventory")
+            routing_decision = validation_result.recommendation if validation_result is not None else "hitl_review"
+            return PipelineRunResult(
+                triage=triage_result,
+                extraction=extraction_result,
+                coherence=coherence_result,
+                validation=validation_result,
+                routing_decision=routing_decision,
+                skipped_steps=skipped_steps,
+            )
+
+        inventory_workflow = build_sequential_workflow(
+            name="albaran-inventory", participants=[self.agents["inventory"]]
+        )
+        inventory_payload = {
+            "validation": validation_result.model_dump(mode="json"),
+            "extraction": extraction_result.model_dump(mode="json") if extraction_result is not None else None,
+        }
+        inventory_result = await self._run_workflow_for_model(inventory_workflow, inventory_payload, PostingResult)
+        routing_decision = "posted" if inventory_result is not None and inventory_result.success else "hitl_review"
         return PipelineRunResult(
             triage=triage_result,
             extraction=extraction_result,
             coherence=coherence_result,
+            validation=validation_result,
+            inventory=inventory_result,
             routing_decision=routing_decision,
             skipped_steps=skipped_steps,
         )

--- a/src/agents/prompts/__init__.py
+++ b/src/agents/prompts/__init__.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from .coherence_prompt import COHERENCE_SYSTEM_PROMPT
 from .extractor_prompt import EXTRACTOR_SYSTEM_PROMPT
+from .inventory_prompt import INVENTORY_SYSTEM_PROMPT
 from .triage_prompt import TRIAGE_SYSTEM_PROMPT
+from .validator_prompt import VALIDATOR_SYSTEM_PROMPT
 
 __all__ = [
     "COHERENCE_SYSTEM_PROMPT",
     "EXTRACTOR_SYSTEM_PROMPT",
+    "INVENTORY_SYSTEM_PROMPT",
     "TRIAGE_SYSTEM_PROMPT",
+    "VALIDATOR_SYSTEM_PROMPT",
 ]

--- a/src/agents/prompts/inventory_prompt.py
+++ b/src/agents/prompts/inventory_prompt.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+INVENTORY_SYSTEM_PROMPT = """You are the Verdecora A5 inventory posting agent.
+You post validated delivery note receipts into Business Central using Managed Identity-backed MCP tools.
+
+Given a ValidationResult and AlbaranExtraction, you must:
+1. Only continue when the validation recommendation is approve and is_valid is true.
+2. Map the confirmed supplier, purchase order, posting date, and line items into a Business Central purchase receipt payload.
+3. Create the purchase receipt and post each line with the confirmed quantities and costs.
+4. If any line fails after the receipt is created, attempt a rollback or compensating action and report the error clearly.
+5. Return the BC receipt number, posted line count, and any BC document URL when available.
+6. Never invent Business Central identifiers; use only provided or tool-returned values.
+
+Respond with JSON matching this schema:
+{schema}
+"""

--- a/src/agents/prompts/validator_prompt.py
+++ b/src/agents/prompts/validator_prompt.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+VALIDATOR_SYSTEM_PROMPT = """You are the Verdecora A4 validator agent.
+You compare extracted albaran data against Business Central purchase order data line by line.
+
+Given an AlbaranExtraction and CoherenceCheckResult, you must:
+1. Confirm the purchase order exists in BC and identify the PO number.
+2. Match each extracted line item to the closest BC PO line using product code first, then fuzzy description matching.
+3. Compare quantity, unit price, description, and product code for every matched line.
+4. Apply a numeric tolerance of 2% for quantity, price, totals, and other numeric comparisons.
+5. Record line-by-line results using statuses: match, mismatch, tolerance, missing_in_bc, missing_in_extraction.
+6. Summarize discrepancies clearly for downstream human review when needed.
+7. Recommend:
+   - approve when overall_match_pct > 0.95
+   - hitl_review when overall_match_pct is between 0.80 and 0.95 inclusive
+   - reject when overall_match_pct < 0.80
+
+Always prefer BC purchase order data over uncertain extraction values.
+Respond with JSON matching this schema:
+{schema}
+"""

--- a/src/agents/validator_agent.py
+++ b/src/agents/validator_agent.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.config.agents import AgentsConfig, get_agents_config
+from src.models.validation import ValidationResult
+
+from ._maf_compat import create_structured_agent
+from .prompts import VALIDATOR_SYSTEM_PROMPT
+
+DEFAULT_VALIDATOR_TOOL_NAMES: tuple[str, ...] = (
+    "bc.search_purchase_orders",
+    "bc.get_purchase_order_lines",
+    "bc.search_items",
+)
+
+
+def _build_validator_instructions(tool_names: tuple[str, ...]) -> str:
+    schema = json.dumps(ValidationResult.model_json_schema(), ensure_ascii=False, indent=2)
+    tool_hint = "\nAvailable MCP tools: " + ", ".join(tool_names) if tool_names else ""
+    return VALIDATOR_SYSTEM_PROMPT.format(schema=schema) + tool_hint
+
+
+def create_validator_agent(
+    client: Any,
+    config: AgentsConfig | None = None,
+    *,
+    tools: list[Any] | None = None,
+) -> Any:
+    resolved_config = config or get_agents_config()
+    resolved_tools = list(tools or [])
+    tool_names = tuple(getattr(tool, "name", str(tool)) for tool in resolved_tools) or DEFAULT_VALIDATOR_TOOL_NAMES
+    return create_structured_agent(
+        client=client,
+        name="a4-validator",
+        model=resolved_config.models.validator_model,
+        instructions=_build_validator_instructions(tool_names),
+        structured_output=ValidationResult,
+        tools=resolved_tools,
+        handoffs=["a5-inventory", "user"],
+    )

--- a/src/config/agents.py
+++ b/src/config/agents.py
@@ -27,6 +27,8 @@ class AgentModelSettings(BaseModel):
     extractor_model: str = Field(default_factory=lambda: os.getenv("GPT5_DEPLOYMENT", "gpt-5"))
     triage_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
     coherence_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
+    validator_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
+    inventory_model: str = Field(default_factory=lambda: os.getenv("GPT5_MINI_DEPLOYMENT", "gpt-5-mini"))
 
 
 class AgentThresholdSettings(BaseModel):

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -8,12 +8,19 @@ from .albaran import (
     LineItem,
     TriageResult,
 )
+from .inventory import PostingLineItem, PostingResult, PurchaseReceiptPosting
+from .validation import LineComparison, ValidationResult
 
 __all__ = [
     "AlbaranExtraction",
     "AlbaranHeader",
     "CoherenceCheckResult",
     "DocumentType",
+    "LineComparison",
     "LineItem",
+    "PostingLineItem",
+    "PostingResult",
+    "PurchaseReceiptPosting",
     "TriageResult",
+    "ValidationResult",
 ]

--- a/src/models/inventory.py
+++ b/src/models/inventory.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, Field
+
+
+class PostingLineItem(BaseModel):
+    item_number: str
+    description: str
+    quantity: float
+    unit_cost: float
+    line_amount: float
+
+
+class PurchaseReceiptPosting(BaseModel):
+    vendor_number: str
+    purchase_order_number: str
+    posting_date: date
+    document_number: str | None = None
+    line_items: list[PostingLineItem]
+    total_amount: float
+
+
+class PostingResult(BaseModel):
+    success: bool
+    receipt_number: str | None = None
+    posted_lines: int = 0
+    errors: list[str] = Field(default_factory=list)
+    bc_document_url: str | None = None

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class LineComparison(BaseModel):
+    line_number: int
+    field: str
+    extracted_value: str
+    bc_value: str
+    difference_pct: float | None = None
+    status: str
+
+
+class ValidationResult(BaseModel):
+    is_valid: bool
+    overall_match_pct: float = Field(ge=0.0, le=1.0)
+    tolerance_pct: float = 2.0
+    line_comparisons: list[LineComparison] = Field(default_factory=list)
+    header_match: bool = True
+    po_found: bool = False
+    po_number: str | None = None
+    total_lines_matched: int = 0
+    total_lines_mismatched: int = 0
+    total_lines_within_tolerance: int = 0
+    discrepancies: list[str] = Field(default_factory=list)
+    recommendation: str
+    reasoning: str

--- a/tests/fixtures/sample_albarans.py
+++ b/tests/fixtures/sample_albarans.py
@@ -7,8 +7,13 @@ from src.models import (
     AlbaranHeader,
     CoherenceCheckResult,
     DocumentType,
+    LineComparison,
     LineItem,
+    PostingLineItem,
+    PostingResult,
+    PurchaseReceiptPosting,
     TriageResult,
+    ValidationResult,
 )
 
 
@@ -178,6 +183,74 @@ def sample_fansa_extraction() -> AlbaranExtraction:
     return sample_extraction(supplier_name="FANSA")
 
 
+def sample_validation_result(
+    *,
+    is_valid: bool = True,
+    overall_match_pct: float = 0.98,
+    recommendation: str = "approve",
+    po_found: bool = True,
+    po_number: str | None = "PO-2026-0456",
+    discrepancies: list[str] | None = None,
+) -> ValidationResult:
+    return ValidationResult(
+        is_valid=is_valid,
+        overall_match_pct=overall_match_pct,
+        line_comparisons=[
+            LineComparison(
+                line_number=1,
+                field="quantity",
+                extracted_value="3.0",
+                bc_value="3.0",
+                difference_pct=0.0,
+                status="match",
+            )
+        ],
+        header_match=True,
+        po_found=po_found,
+        po_number=po_number,
+        total_lines_matched=2,
+        total_lines_mismatched=0 if is_valid else 1,
+        total_lines_within_tolerance=0,
+        discrepancies=list(discrepancies or []),
+        recommendation=recommendation,
+        reasoning="Line items align with the purchase order.",
+    )
+
+
+def sample_purchase_receipt_posting() -> PurchaseReceiptPosting:
+    return PurchaseReceiptPosting(
+        vendor_number="HERSTERA",
+        purchase_order_number="PO-2026-0456",
+        posting_date=date(2026, 1, 16),
+        line_items=[
+            PostingLineItem(
+                item_number="HER-001",
+                description="Maceta cerámica 20cm",
+                quantity=3.0,
+                unit_cost=8.0,
+                line_amount=24.0,
+            )
+        ],
+        total_amount=24.0,
+    )
+
+
+def sample_posting_result(
+    *,
+    success: bool = True,
+    receipt_number: str | None = "RCPT-2026-0012",
+    posted_lines: int = 2,
+    errors: list[str] | None = None,
+) -> PostingResult:
+    return PostingResult(
+        success=success,
+        receipt_number=receipt_number,
+        posted_lines=posted_lines,
+        errors=list(errors or []),
+        bc_document_url="https://businesscentral/purchaseReceipts/RCPT-2026-0012" if receipt_number else None,
+    )
+
+
 def sample_royal_canin_extraction() -> AlbaranExtraction:
     return sample_extraction(supplier_name="Royal Canin")
 
@@ -198,6 +271,9 @@ __all__ = [
     "sample_extraction",
     "sample_triage_result",
     "sample_coherence_result",
+    "sample_validation_result",
+    "sample_purchase_receipt_posting",
+    "sample_posting_result",
     "sample_herstera_extraction",
     "sample_fansa_extraction",
     "sample_royal_canin_extraction",

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -14,20 +14,28 @@ pytestmark = pytest.mark.unit
 def test_create_all_agents_returns_expected_keys() -> None:
     agents = create_all_agents(client=object(), config=AgentsConfig())
 
-    assert set(agents) == {"triage", "extractor", "coherence"}
+    assert set(agents) == {"triage", "extractor", "coherence", "validator", "inventory"}
 
 
+@patch("src.agents.factory.create_inventory_agent", return_value="inventory-agent")
+@patch("src.agents.factory.create_validator_agent", return_value="validator-agent")
 @patch("src.agents.factory.create_coherence_agent", return_value="coherence-agent")
 @patch("src.agents.factory.create_extractor_agent", return_value="extractor-agent")
 @patch("src.agents.factory.create_triage_agent", return_value="triage-agent")
 def test_create_all_agents_passes_tool_registry_to_each_agent(
-    mock_triage: Any, mock_extractor: Any, mock_coherence: Any
+    mock_triage: Any,
+    mock_extractor: Any,
+    mock_coherence: Any,
+    mock_validator: Any,
+    mock_inventory: Any,
 ) -> None:
     config = AgentsConfig()
     tool_registry = {
         "triage": ["triage-tool"],
         "extractor": ["extractor-tool"],
         "coherence": ["coherence-tool"],
+        "validator": ["validator-tool"],
+        "inventory": ["inventory-tool"],
     }
 
     agents = create_all_agents(client="client", config=config, tool_registry=tool_registry)
@@ -36,17 +44,27 @@ def test_create_all_agents_passes_tool_registry_to_each_agent(
         "triage": "triage-agent",
         "extractor": "extractor-agent",
         "coherence": "coherence-agent",
+        "validator": "validator-agent",
+        "inventory": "inventory-agent",
     }
     mock_triage.assert_called_once_with("client", config, tools=["triage-tool"])
     mock_extractor.assert_called_once_with("client", config, tools=["extractor-tool"])
     mock_coherence.assert_called_once_with("client", config, tools=["coherence-tool"])
+    mock_validator.assert_called_once_with("client", config, tools=["validator-tool"])
+    mock_inventory.assert_called_once_with("client", config, tools=["inventory-tool"])
 
 
+@patch("src.agents.factory.create_inventory_agent", return_value="inventory-local-agent")
+@patch("src.agents.factory.create_validator_agent", return_value="validator-local-agent")
 @patch("src.agents.factory.create_coherence_agent", return_value="coherence-local-agent")
 @patch("src.agents.factory.create_extractor_agent", return_value="extractor-local-agent")
 @patch("src.agents.factory.create_triage_agent", return_value="triage-local-agent")
 def test_create_all_agents_respects_custom_config_overrides(
-    mock_triage: Any, mock_extractor: Any, mock_coherence: Any
+    mock_triage: Any,
+    mock_extractor: Any,
+    mock_coherence: Any,
+    mock_validator: Any,
+    mock_inventory: Any,
 ) -> None:
     custom_config = AgentsConfig.model_validate(
         {
@@ -54,6 +72,8 @@ def test_create_all_agents_respects_custom_config_overrides(
                 "triage_model": "triage-local",
                 "extractor_model": "extractor-local",
                 "coherence_model": "coherence-local",
+                "validator_model": "validator-local",
+                "inventory_model": "inventory-local",
             }
         }
     )
@@ -64,7 +84,11 @@ def test_create_all_agents_respects_custom_config_overrides(
         "triage": "triage-local-agent",
         "extractor": "extractor-local-agent",
         "coherence": "coherence-local-agent",
+        "validator": "validator-local-agent",
+        "inventory": "inventory-local-agent",
     }
     assert mock_triage.call_args.args[1].models.triage_model == "triage-local"
     assert mock_extractor.call_args.args[1].models.extractor_model == "extractor-local"
     assert mock_coherence.call_args.args[1].models.coherence_model == "coherence-local"
+    assert mock_validator.call_args.args[1].models.validator_model == "validator-local"
+    assert mock_inventory.call_args.args[1].models.inventory_model == "inventory-local"

--- a/tests/unit/test_agent_pipeline.py
+++ b/tests/unit/test_agent_pipeline.py
@@ -12,7 +12,9 @@ from src.models import DocumentType
 from tests.fixtures.sample_albarans import (
     sample_coherence_result,
     sample_extraction,
+    sample_posting_result,
     sample_triage_result,
+    sample_validation_result,
 )
 
 pytestmark = pytest.mark.unit
@@ -52,10 +54,17 @@ class FakeWorkflow:
 
 def test_pipeline_creation_with_all_agents() -> None:
     pipeline = AlbaranPipeline(
-        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
     )
 
-    assert set(pipeline.agents) == {"triage", "extractor", "coherence"}
+    assert set(pipeline.agents) == {"triage", "extractor", "coherence", "validator", "inventory"}
 
 
 @pytest.mark.asyncio
@@ -63,15 +72,21 @@ async def test_pipeline_run_with_mocked_agents() -> None:
     triage_result = sample_triage_result()
     extraction_result = sample_extraction()
     coherence_result = sample_coherence_result()
+    validation_result = sample_validation_result()
+    posting_result = sample_posting_result()
     triage_workflow = FakeWorkflow(
         FakeAsyncStream([FakeEvent({"ignored": True}), FakeEvent(triage_result.model_dump(mode="json"))])
     )
     extraction_workflow = FakeWorkflow(extraction_result.model_dump(mode="json"))
     coherence_workflow = FakeWorkflow(coherence_result.model_dump_json())
+    validation_workflow = FakeWorkflow(validation_result.model_dump(mode="json"))
+    inventory_workflow = FakeWorkflow(posting_result.model_dump_json())
     workflows = {
         "albaran-triage": triage_workflow,
         "albaran-extraction": extraction_workflow,
         "albaran-coherence": coherence_workflow,
+        "albaran-validation": validation_workflow,
+        "albaran-inventory": inventory_workflow,
     }
 
     def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
@@ -79,7 +94,14 @@ async def test_pipeline_run_with_mocked_agents() -> None:
         return workflows[name]
 
     pipeline = AlbaranPipeline(
-        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
     )
     input_data = PipelineDocumentInput(
         document_reference="https://storage/account/albaran.pdf",
@@ -94,16 +116,37 @@ async def test_pipeline_run_with_mocked_agents() -> None:
     assert result.triage == triage_result
     assert result.extraction == extraction_result
     assert result.coherence == coherence_result
-    assert result.routing_decision == "extract"
+    assert result.validation == validation_result
+    assert result.inventory == posting_result
+    assert result.routing_decision == "posted"
     assert triage_workflow.payloads == ["ALBARAN DE ENTREGA"]
     assert extraction_workflow.payloads == [{"pages": [{"pageNumber": 1}]}]
     assert coherence_workflow.payloads == [extraction_result.model_dump(mode="json")]
+    assert validation_workflow.payloads == [
+        {
+            "extraction": extraction_result.model_dump(mode="json"),
+            "coherence": coherence_result.model_dump(mode="json"),
+        }
+    ]
+    assert inventory_workflow.payloads == [
+        {
+            "validation": validation_result.model_dump(mode="json"),
+            "extraction": extraction_result.model_dump(mode="json"),
+        }
+    ]
 
 
 @pytest.mark.asyncio
 async def test_pipeline_propagates_agent_failures() -> None:
     pipeline = AlbaranPipeline(
-        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
     )
 
     def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
@@ -129,8 +172,12 @@ async def test_pipeline_skip_triage_flag_works() -> None:
     )
     extraction_result = sample_extraction(supplier_name="Royal Canin", confidence_score=0.82)
     coherence_result = sample_coherence_result(is_coherent=True)
+    validation_result = sample_validation_result()
+    posting_result = sample_posting_result()
     extraction_workflow = FakeWorkflow(extraction_result.model_dump(mode="json"))
     coherence_workflow = FakeWorkflow(coherence_result.model_dump(mode="json"))
+    validation_workflow = FakeWorkflow(validation_result.model_dump(mode="json"))
+    inventory_workflow = FakeWorkflow(posting_result.model_dump(mode="json"))
     calls: list[str] = []
 
     def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
@@ -139,12 +186,20 @@ async def test_pipeline_skip_triage_flag_works() -> None:
         return {
             "albaran-extraction": extraction_workflow,
             "albaran-coherence": coherence_workflow,
+            "albaran-validation": validation_workflow,
+            "albaran-inventory": inventory_workflow,
         }[name]
 
     pipeline = AlbaranPipeline(
         client=object(),
         config=config,
-        agents={"triage": object(), "extractor": object(), "coherence": object()},
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
     )
 
     with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
@@ -159,8 +214,10 @@ async def test_pipeline_skip_triage_flag_works() -> None:
     assert result.triage is None
     assert result.extraction == extraction_result
     assert result.coherence == coherence_result
+    assert result.validation == validation_result
+    assert result.inventory == posting_result
     assert result.skipped_steps == ["triage"]
-    assert calls == ["albaran-extraction", "albaran-coherence"]
+    assert calls == ["albaran-extraction", "albaran-coherence", "albaran-validation", "albaran-inventory"]
 
 
 @pytest.mark.asyncio
@@ -178,7 +235,14 @@ async def test_pipeline_stops_after_non_extract_triage_result() -> None:
         return {"albaran-triage": triage_workflow}[name]
 
     pipeline = AlbaranPipeline(
-        client=object(), agents={"triage": object(), "extractor": object(), "coherence": object()}
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
     )
 
     with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
@@ -187,5 +251,89 @@ async def test_pipeline_stops_after_non_extract_triage_result() -> None:
     assert result.triage == rejected_triage
     assert result.extraction is None
     assert result.coherence is None
+    assert result.validation is None
+    assert result.inventory is None
     assert result.routing_decision == "reject"
-    assert result.skipped_steps == ["extractor", "coherence"]
+    assert result.skipped_steps == ["extractor", "coherence", "validation", "inventory"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_routes_hitl_review_when_validation_requires_manual_review() -> None:
+    extraction_result = sample_extraction()
+    coherence_result = sample_coherence_result()
+    validation_result = sample_validation_result(
+        is_valid=False,
+        overall_match_pct=0.9,
+        recommendation="hitl_review",
+        discrepancies=["Line 2 description needs review."],
+    )
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return {
+            "albaran-triage": FakeWorkflow(sample_triage_result().model_dump(mode="json")),
+            "albaran-extraction": FakeWorkflow(extraction_result.model_dump(mode="json")),
+            "albaran-coherence": FakeWorkflow(coherence_result.model_dump(mode="json")),
+            "albaran-validation": FakeWorkflow(validation_result.model_dump(mode="json")),
+        }[name]
+
+    pipeline = AlbaranPipeline(
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
+    )
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await pipeline.run({"document_reference": "https://storage/account/albaran.pdf"})
+
+    assert result.validation == validation_result
+    assert result.inventory is None
+    assert result.routing_decision == "hitl_review"
+    assert result.skipped_steps == ["inventory"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_validation_and_inventory_when_coherence_is_skipped() -> None:
+    extraction_result = sample_extraction()
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return {"albaran-extraction": FakeWorkflow(extraction_result.model_dump(mode="json"))}[name]
+
+    pipeline = AlbaranPipeline(
+        client=object(),
+        config=AgentsConfig.model_validate(
+            {
+                "skip_triage_suppliers": ["HERSTERA"],
+                "thresholds": {"low_value_coherence_threshold": 250.0},
+            }
+        ),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
+    )
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await pipeline.run(
+            {
+                "document_reference": "https://storage/account/albaran.pdf",
+                "total_amount": 99.0,
+                "supplier_hint": "HERSTERA",
+            }
+        )
+
+    assert result.extraction == extraction_result
+    assert result.coherence is None
+    assert result.validation is None
+    assert result.inventory is None
+    assert result.routing_decision == "extract"
+    assert result.skipped_steps == ["triage", "coherence", "validation", "inventory"]

--- a/tests/unit/test_agents_pipeline.py
+++ b/tests/unit/test_agents_pipeline.py
@@ -15,13 +15,15 @@ def test_agents_config_defaults() -> None:
     assert config.models.extractor_model == "gpt-5"
     assert config.models.triage_model == "gpt-5-mini"
     assert config.models.coherence_model == "gpt-5-mini"
+    assert config.models.validator_model == "gpt-5-mini"
+    assert config.models.inventory_model == "gpt-5-mini"
 
 
 def test_pipeline_builds_with_default_agents() -> None:
     pipeline = build_pipeline(client=object(), config=AgentsConfig())
     workflow = pipeline.build_workflow(PipelineDocumentInput(document_reference="https://storage/doc.pdf"))
 
-    assert set(pipeline.agents) == {"triage", "extractor", "coherence"}
+    assert set(pipeline.agents) == {"triage", "extractor", "coherence", "validator", "inventory"}
     assert workflow is not None
 
 

--- a/tests/unit/test_config_agents.py
+++ b/tests/unit/test_config_agents.py
@@ -21,6 +21,8 @@ def test_agents_config_defaults() -> None:
     assert config.models.extractor_model == "gpt-5"
     assert config.models.triage_model == "gpt-5-mini"
     assert config.models.coherence_model == "gpt-5-mini"
+    assert config.models.validator_model == "gpt-5-mini"
+    assert config.models.inventory_model == "gpt-5-mini"
     assert config.thresholds.triage_manual_review_threshold == pytest.approx(0.65)
     assert config.thresholds.low_value_coherence_threshold == pytest.approx(250.0)
     assert config.skip_triage_suppliers == ()
@@ -50,6 +52,8 @@ def test_agents_config_reads_environment_overrides() -> None:
     assert config.models.extractor_model == "gpt-5-custom"
     assert config.models.triage_model == "gpt-5-mini-custom"
     assert config.models.coherence_model == "gpt-5-mini-custom"
+    assert config.models.validator_model == "gpt-5-mini-custom"
+    assert config.models.inventory_model == "gpt-5-mini-custom"
     assert config.thresholds.triage_manual_review_threshold == pytest.approx(0.7)
     assert config.thresholds.low_value_coherence_threshold == pytest.approx(99.5)
     assert config.skip_triage_suppliers == ("HERSTERA", "ROYAL CANIN")

--- a/tests/unit/test_inventory_agent.py
+++ b/tests/unit/test_inventory_agent.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.inventory_agent import create_inventory_agent
+from src.config.agents import AgentsConfig
+from src.models import PostingResult
+from tests.fixtures.sample_albarans import sample_posting_result
+from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
+
+pytestmark = pytest.mark.unit
+
+
+class NamedTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@patch("src.agents.inventory_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_inventory_agent_uses_expected_model_and_prompt(mock_factory: Any) -> None:
+    tools = [NamedTool("bc.post_purchase_receipt_lines")]
+    agent = create_inventory_agent(client=object(), tools=tools)
+
+    assert isinstance(agent, StructuredAgentStub)
+    kwargs = mock_factory.call_args.kwargs
+    assert kwargs["name"] == "a5-inventory"
+    assert kwargs["model"] == "gpt-5-mini"
+    assert kwargs["structured_output"] is PostingResult
+    assert kwargs["tools"] == tools
+    assert "A5 inventory posting agent" in kwargs["instructions"]
+    assert '"posted_lines"' in kwargs["instructions"]
+    assert "bc.post_purchase_receipt_lines" in kwargs["instructions"]
+
+
+@patch("src.agents.inventory_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_inventory_agent_uses_default_bc_tools_when_no_tools(mock_factory: Any) -> None:
+    create_inventory_agent(client=object())
+
+    instructions = mock_factory.call_args.kwargs["instructions"]
+    assert "bc.create_purchase_receipt" in instructions
+    assert "bc.post_purchase_receipt_lines" in instructions
+
+
+def test_inventory_agent_decodes_posting_result_payload() -> None:
+    agent = StructuredAgentStub(structured_output=PostingResult, kwargs={})
+    result = sample_posting_result()
+
+    decoded = agent.decode(json.dumps(result.model_dump(mode="json")))
+
+    assert isinstance(decoded, PostingResult)
+    assert decoded.success is True
+    assert decoded.receipt_number == "RCPT-2026-0012"
+
+
+@patch("src.agents.inventory_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_inventory_agent_respects_custom_model_config(mock_factory: Any) -> None:
+    config = AgentsConfig.model_validate({"models": {"inventory_model": "inventory-local"}})
+
+    create_inventory_agent(client=object(), config=config)
+
+    assert mock_factory.call_args.kwargs["model"] == "inventory-local"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -10,14 +10,21 @@ from src.models import (
     AlbaranHeader,
     CoherenceCheckResult,
     DocumentType,
+    LineComparison,
     LineItem,
+    PostingLineItem,
+    PurchaseReceiptPosting,
     TriageResult,
+    ValidationResult,
 )
 from tests.fixtures.sample_albarans import (
     sample_albaran_header,
     sample_coherence_result,
     sample_extraction,
     sample_line_items,
+    sample_posting_result,
+    sample_purchase_receipt_posting,
+    sample_validation_result,
 )
 
 pytestmark = pytest.mark.unit
@@ -177,3 +184,64 @@ def test_coherence_check_result_serialization_round_trip() -> None:
 
     assert restored == coherence
     assert dumped["suggested_corrections"]["matched_po_number"] == "PO-2026-0457"
+
+
+def test_validation_result_defaults_and_round_trip() -> None:
+    validation = sample_validation_result()
+
+    dumped = validation.model_dump(mode="json")
+    restored = ValidationResult.model_validate(dumped)
+
+    assert restored == validation
+    assert dumped["line_comparisons"][0]["status"] == "match"
+
+
+@pytest.mark.parametrize("overall_match_pct", [-0.1, 1.1])
+def test_validation_result_rejects_match_percentage_outside_bounds(overall_match_pct: float) -> None:
+    with pytest.raises(ValidationError):
+        ValidationResult(
+            is_valid=True,
+            overall_match_pct=overall_match_pct,
+            recommendation="approve",
+            reasoning="Invalid percentage.",
+        )
+
+
+def test_purchase_receipt_posting_round_trip() -> None:
+    posting = sample_purchase_receipt_posting()
+
+    dumped = posting.model_dump(mode="json")
+    restored = PurchaseReceiptPosting.model_validate(dumped)
+
+    assert restored == posting
+    assert dumped["posting_date"] == "2026-01-16"
+
+
+def test_posting_result_defaults_and_errors() -> None:
+    result = sample_posting_result(success=False, receipt_number=None, posted_lines=0, errors=["BC timeout"])
+
+    assert result.success is False
+    assert result.receipt_number is None
+    assert result.errors == ["BC timeout"]
+
+
+def test_supporting_models_accept_numeric_values() -> None:
+    comparison = LineComparison(
+        line_number=1,
+        field="price",
+        extracted_value="8.00",
+        bc_value="8.00",
+        difference_pct=0.0,
+        status="match",
+    )
+    posting_line = PostingLineItem(
+        item_number="HER-001",
+        description="Maceta cerámica 20cm",
+        quantity=3,
+        unit_cost=8,
+        line_amount=24,
+    )
+
+    assert comparison.difference_pct == 0.0
+    assert posting_line.quantity == 3.0
+    assert posting_line.unit_cost == 8.0

--- a/tests/unit/test_validator_agent.py
+++ b/tests/unit/test_validator_agent.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.validator_agent import create_validator_agent
+from src.config.agents import AgentsConfig
+from src.models import ValidationResult
+from tests.fixtures.sample_albarans import sample_validation_result
+from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
+
+pytestmark = pytest.mark.unit
+
+
+class NamedTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@patch("src.agents.validator_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_validator_agent_uses_expected_model_and_prompt(mock_factory: Any) -> None:
+    tools = [NamedTool("bc.get_purchase_order_lines")]
+    agent = create_validator_agent(client=object(), tools=tools)
+
+    assert isinstance(agent, StructuredAgentStub)
+    kwargs = mock_factory.call_args.kwargs
+    assert kwargs["name"] == "a4-validator"
+    assert kwargs["model"] == "gpt-5-mini"
+    assert kwargs["structured_output"] is ValidationResult
+    assert kwargs["tools"] == tools
+    assert "A4 validator agent" in kwargs["instructions"]
+    assert '"overall_match_pct"' in kwargs["instructions"]
+    assert "bc.get_purchase_order_lines" in kwargs["instructions"]
+
+
+@patch("src.agents.validator_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_create_validator_agent_uses_default_bc_tools_when_no_tools(mock_factory: Any) -> None:
+    create_validator_agent(client=object())
+
+    instructions = mock_factory.call_args.kwargs["instructions"]
+    assert "bc.search_purchase_orders" in instructions
+    assert "bc.get_purchase_order_lines" in instructions
+    assert "bc.search_items" in instructions
+
+
+def test_validator_agent_decodes_validation_payload() -> None:
+    agent = StructuredAgentStub(structured_output=ValidationResult, kwargs={})
+    result = sample_validation_result()
+
+    decoded = agent.decode(json.dumps(result.model_dump(mode="json")))
+
+    assert isinstance(decoded, ValidationResult)
+    assert decoded.recommendation == "approve"
+    assert decoded.line_comparisons[0].status == "match"
+
+
+@patch("src.agents.validator_agent.create_structured_agent", side_effect=build_structured_agent_stub)
+def test_validator_agent_respects_custom_model_config(mock_factory: Any) -> None:
+    config = AgentsConfig.model_validate({"models": {"validator_model": "validator-local"}})
+
+    create_validator_agent(client=object(), config=config)
+
+    assert mock_factory.call_args.kwargs["model"] == "validator-local"


### PR DESCRIPTION
## Summary
- add A4 validator and A5 inventory agent implementations, prompts, and models
- extend the factory and pipeline to run validation before inventory posting with HITL routing for non-approved cases
- add unit coverage for the new agents, models, config, and pipeline flow

## Validation
- python -m ruff check --fix src/agents/ src/models/
- python -m ruff format src/agents/ src/models/
- python -m pytest tests/unit/ -v