### PR TITLE
feat(services): orchestrator ACA app + A4-A5 tests + pipeline docs (#24, #26, #29)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,7 @@ Complete documentation for the project:
   - [Core agents technical specification](architecture/agents-technical-spec.md)
   - [Prompt engineering for core agents](architecture/prompt-engineering.md)
   - [Core agent data models](architecture/data-models.md)
+  - [Validation + inventory specification](architecture/validation-inventory-spec.md)
+  - [Orchestrator ACA application specification](architecture/orchestrator-spec.md)
 - **operations/** - Runbooks and operational procedures
 - **user/** - User manuals and guides

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,8 +2,9 @@
 
 Architecture decisions and system design documentation.
 
-- System overview
-- Component interactions
-- Agent coordination strategy
-- Data flow diagrams
-- Integration patterns
+- [Architecture decision record](architecture-decision-record.md)
+- [Core agents technical specification](agents-technical-spec.md)
+- [Core agent data models](data-models.md)
+- [Validation + inventory specification](validation-inventory-spec.md)
+- [Orchestrator ACA application specification](orchestrator-spec.md)
+- Prompt engineering and integration patterns

--- a/docs/architecture/orchestrator-spec.md
+++ b/docs/architecture/orchestrator-spec.md
@@ -1,0 +1,59 @@
+# Orchestrator ACA application specification
+
+## Overview
+
+The orchestrator is an Azure Container Apps-hosted FastAPI service in `src/services/orchestrator/` that owns the document-processing runtime.
+
+## Components
+
+- `main.py` — FastAPI app entry point and `/process` manual trigger
+- `handler.py` — Service Bus queue consumer and DLQ behavior
+- `orchestration.py` — blob download, OCR, pipeline execution, Cosmos persistence, HITL routing
+- `health.py` — liveness and readiness endpoints
+- `config.py` — environment-driven configuration for Azure dependencies
+
+## Azure integration
+
+All Azure access uses **`DefaultAzureCredential` only**.
+
+Configured dependencies:
+
+- Service Bus namespace + extraction queue
+- Cosmos DB endpoint + processing database/container
+- Storage account URL for blob-backed PDFs
+- Azure OpenAI endpoint for agent runtime
+- Document Intelligence endpoint for OCR
+
+## Message flow
+
+```mermaid
+flowchart LR
+    A[Event Grid blob event] --> B[Flow 0 dedup]
+    B --> C[Service Bus extraction queue]
+    C --> D[ACA orchestrator handler]
+    D --> E[Blob download]
+    E --> F[Document Intelligence OCR]
+    F --> G[A1→A5 AlbaranPipeline]
+    G --> H[Cosmos processing record]
+    G --> I{Validator decision}
+    I -->|approve| J[Inventory post]
+    I -->|hitl_review| K[HITL queue]
+    I -->|reject| L[Stop]
+```
+
+## Health checks
+
+- `GET /health` — simple liveness response
+- `GET /health/ready` — validates orchestrator configuration and Azure client construction for credential, Service Bus, Cosmos, Storage, and Document Intelligence
+
+## Error handling + DLQ strategy
+
+1. Queue payloads are deserialized into `OrchestrationRequest`.
+2. Any processing failure updates Cosmos with `status=failed`.
+3. Messages are abandoned while delivery count is below the configured retry limit.
+4. Messages exceeding the retry limit are dead-lettered with an `orchestration_failed` reason.
+5. `hitl_review` results are persisted as `hitl_pending` and copied to the HITL queue.
+
+## Manual trigger path
+
+`POST /process` accepts a blob URL plus metadata, runs the same orchestration flow, and returns the persisted orchestration result for ad hoc replay and testing.

--- a/docs/architecture/validation-inventory-spec.md
+++ b/docs/architecture/validation-inventory-spec.md
@@ -1,0 +1,96 @@
+# Validation + inventory technical specification
+
+## A4 Validator
+
+### Purpose
+
+The validator agent compares the structured A1/A3 extraction output against Business Central purchase order data before anything can be posted downstream.
+
+### Model and output contract
+
+- **Runtime agent:** `src/agents/validator_agent.py`
+- **Structured output:** `src/models/validation.py::ValidationResult`
+- **Default model:** `gpt-5-mini`
+
+The validator returns:
+
+- document-level validity (`is_valid`)
+- `overall_match_pct` as a 0-1 score
+- line-level comparisons and discrepancy notes
+- a downstream recommendation: `approve`, `hitl_review`, or `reject`
+
+### Tolerance rules
+
+Numeric comparisons use a **2% tolerance** by default.
+
+- exact matches → `match`
+- inside tolerance → `tolerance`
+- outside tolerance → `mismatch`
+- missing counterpart values → `missing_in_bc` / `missing_in_extraction`
+
+### Recommendation logic
+
+- `overall_match_pct > 0.95` → `approve`
+- `0.80 <= overall_match_pct <= 0.95` → `hitl_review`
+- `overall_match_pct < 0.80` → `reject`
+
+## A5 Inventory
+
+### Purpose
+
+The inventory agent posts approved receipts into Business Central only after A4 produces an approved validation.
+
+### Model and output contract
+
+- **Runtime agent:** `src/agents/inventory_agent.py`
+- **Structured output:** `src/models/inventory.py::PostingResult`
+- **Default model:** `gpt-5-mini`
+
+The posting payload centers on `PurchaseReceiptPosting` and `PostingLineItem`, and the response records:
+
+- `success`
+- BC `receipt_number`
+- `posted_lines`
+- `bc_document_url`
+- `errors`
+
+### Business Central posting flow
+
+1. Confirm validation is approved.
+2. Map supplier, PO, posting date, and validated lines into a purchase receipt payload.
+3. Create the receipt in Business Central.
+4. Post confirmed lines.
+5. Return the final receipt number or a failure payload.
+
+### Error recovery
+
+If BC posting fails after receipt creation, the agent must return a failure payload and trigger compensating action / operator follow-up rather than silently continuing.
+
+## Full A1→A5 flow
+
+```mermaid
+flowchart TD
+    A[A2 Triage] -->|extract| B[A1 Extractor]
+    A -->|reject/manual review| Z[Stop]
+    B --> C[A3 Coherence]
+    C --> D[A4 Validator]
+    D -->|approve| E[A5 Inventory]
+    D -->|hitl_review| F[HITL queue]
+    D -->|reject| G[Stop without posting]
+    E --> H[Cosmos completed]
+    F --> I[Cosmos hitl_pending]
+    G --> J[Cosmos failed]
+```
+
+## Handoff decision tree
+
+```text
+if triage.routing_decision != "extract":
+    stop
+elif validator.recommendation == "approve":
+    post to inventory
+elif validator.recommendation == "hitl_review":
+    send to HITL queue
+else:
+    reject and stop
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,12 @@ dependencies = [
     "azure-cosmos>=4.9.0",
     "azure-identity>=1.20.0",
     "azure-servicebus>=7.13.0",
+    "azure-storage-blob>=12.24.0",
+    "fastapi>=0.115.0",
     "mcp>=1.12.4",
+    "openai>=1.58.1",
     "pydantic>=2.11.0",
+    "uvicorn>=0.34.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agents/inventory_agent.py
+++ b/src/agents/inventory_agent.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from src.config.agents import AgentsConfig, get_agents_config
 from src.models.inventory import PostingResult
+from src.models.validation import ValidationResult
 
 from ._maf_compat import create_structured_agent
 from .prompts import INVENTORY_SYSTEM_PROMPT
@@ -39,3 +40,37 @@ def create_inventory_agent(
         tools=resolved_tools,
         handoffs=["user"],
     )
+
+
+def should_process_inventory(validation_result: ValidationResult | dict[str, Any] | None) -> bool:
+    if validation_result is None:
+        return False
+    normalized_result = validation_result
+    if not isinstance(validation_result, ValidationResult):
+        normalized_result = ValidationResult.model_validate(validation_result)
+    return normalized_result.is_valid and normalized_result.recommendation == "approve"
+
+
+def build_posting_failure_result(
+    error: Exception | str,
+    *,
+    receipt_number: str | None = None,
+    posted_lines: int = 0,
+    bc_document_url: str | None = None,
+) -> PostingResult:
+    message = str(error).strip() or "Business Central posting failed."
+    return PostingResult(
+        success=False,
+        receipt_number=receipt_number,
+        posted_lines=posted_lines,
+        errors=[message],
+        bc_document_url=bc_document_url,
+    )
+
+
+__all__ = [
+    "DEFAULT_INVENTORY_TOOL_NAMES",
+    "build_posting_failure_result",
+    "create_inventory_agent",
+    "should_process_inventory",
+]

--- a/src/agents/validator_agent.py
+++ b/src/agents/validator_agent.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 from src.config.agents import AgentsConfig, get_agents_config
-from src.models.validation import ValidationResult
+from src.models.validation import ValidationResult, compare_line_values, recommend_validation_action
 
 from ._maf_compat import create_structured_agent
 from .prompts import VALIDATOR_SYSTEM_PROMPT
@@ -40,3 +40,11 @@ def create_validator_agent(
         tools=resolved_tools,
         handoffs=["a5-inventory", "user"],
     )
+
+
+__all__ = [
+    "DEFAULT_VALIDATOR_TOOL_NAMES",
+    "compare_line_values",
+    "create_validator_agent",
+    "recommend_validation_action",
+]

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
+
 from pydantic import BaseModel, Field
+
+APPROVAL_MATCH_THRESHOLD = 0.95
+HITL_REVIEW_THRESHOLD = 0.80
+DEFAULT_TOLERANCE_PCT = 2.0
 
 
 class LineComparison(BaseModel):
@@ -15,7 +21,7 @@ class LineComparison(BaseModel):
 class ValidationResult(BaseModel):
     is_valid: bool
     overall_match_pct: float = Field(ge=0.0, le=1.0)
-    tolerance_pct: float = 2.0
+    tolerance_pct: float = DEFAULT_TOLERANCE_PCT
     line_comparisons: list[LineComparison] = Field(default_factory=list)
     header_match: bool = True
     po_found: bool = False
@@ -26,3 +32,81 @@ class ValidationResult(BaseModel):
     discrepancies: list[str] = Field(default_factory=list)
     recommendation: str
     reasoning: str
+
+
+def _to_decimal(value: str | float | int | None) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def calculate_difference_pct(
+    extracted_value: str | float | int | None, bc_value: str | float | int | None
+) -> float | None:
+    extracted_decimal = _to_decimal(extracted_value)
+    bc_decimal = _to_decimal(bc_value)
+    if extracted_decimal is None or bc_decimal is None:
+        return None
+    if bc_decimal == 0:
+        return 0.0 if extracted_decimal == 0 else 100.0
+    difference_ratio = abs(extracted_decimal - bc_decimal) / abs(bc_decimal)
+    return float(difference_ratio * Decimal("100"))
+
+
+def compare_line_values(
+    *,
+    line_number: int,
+    field: str,
+    extracted_value: str | float | int | None,
+    bc_value: str | float | int | None,
+    tolerance_pct: float = DEFAULT_TOLERANCE_PCT,
+) -> LineComparison:
+    extracted_text = "" if extracted_value is None else str(extracted_value)
+    bc_text = "" if bc_value is None else str(bc_value)
+
+    if extracted_value is None and bc_value is not None:
+        return LineComparison(
+            line_number=line_number,
+            field=field,
+            extracted_value=extracted_text,
+            bc_value=bc_text,
+            difference_pct=None,
+            status="missing_in_extraction",
+        )
+    if bc_value is None and extracted_value is not None:
+        return LineComparison(
+            line_number=line_number,
+            field=field,
+            extracted_value=extracted_text,
+            bc_value=bc_text,
+            difference_pct=None,
+            status="missing_in_bc",
+        )
+
+    difference_pct = calculate_difference_pct(extracted_value, bc_value)
+    if extracted_text == bc_text or difference_pct == 0.0:
+        status = "match"
+    elif difference_pct is not None and difference_pct <= tolerance_pct:
+        status = "tolerance"
+    else:
+        status = "mismatch"
+
+    return LineComparison(
+        line_number=line_number,
+        field=field,
+        extracted_value=extracted_text,
+        bc_value=bc_text,
+        difference_pct=difference_pct,
+        status=status,
+    )
+
+
+def recommend_validation_action(overall_match_pct: float) -> str:
+    if overall_match_pct > APPROVAL_MATCH_THRESHOLD:
+        return "approve"
+    if overall_match_pct >= HITL_REVIEW_THRESHOLD:
+        return "hitl_review"
+    return "reject"

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Backend service package."""

--- a/src/services/orchestrator/__init__.py
+++ b/src/services/orchestrator/__init__.py
@@ -1,0 +1,13 @@
+from .config import OrchestratorConfig, get_orchestrator_config
+from .main import app, create_app
+from .orchestration import OrchestrationRequest, OrchestrationResult, OrchestratorService
+
+__all__ = [
+    "OrchestrationRequest",
+    "OrchestrationResult",
+    "OrchestratorConfig",
+    "OrchestratorService",
+    "app",
+    "create_app",
+    "get_orchestrator_config",
+]

--- a/src/services/orchestrator/config.py
+++ b/src/services/orchestrator/config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _get_env(name: str, default: str) -> str:
+    return os.getenv(name, default)
+
+
+def _get_bool_env(name: str, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().casefold() in {"1", "true", "yes", "on"}
+
+
+class OrchestratorConfig(BaseModel):
+    service_bus_namespace: str = Field(default_factory=lambda: _get_env("SERVICE_BUS_NAMESPACE", "verdecora-dev"))
+    extraction_queue_name: str = Field(default_factory=lambda: _get_env("EXTRACTION_QUEUE_NAME", "extraction"))
+    hitl_queue_name: str = Field(default_factory=lambda: _get_env("HITL_QUEUE_NAME", "hitl-review"))
+    cosmos_endpoint: str = Field(default_factory=lambda: _get_env("COSMOS_ENDPOINT", "https://localhost:8081"))
+    database_name: str = Field(default_factory=lambda: _get_env("DATABASE_NAME", "verdecora"))
+    processing_container_name: str = Field(
+        default_factory=lambda: _get_env("PROCESSING_CONTAINER_NAME", "processing-records")
+    )
+    storage_account_url: str = Field(
+        default_factory=lambda: _get_env("STORAGE_ACCOUNT_URL", "https://examplestorage.blob.core.windows.net")
+    )
+    azure_openai_endpoint: str = Field(
+        default_factory=lambda: _get_env("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+    )
+    azure_openai_api_version: str = Field(default_factory=lambda: _get_env("AZURE_OPENAI_API_VERSION", "2024-10-21"))
+    docintell_endpoint: str = Field(
+        default_factory=lambda: _get_env("DOCINTELL_ENDPOINT", "https://example.cognitiveservices.azure.com/")
+    )
+    service_bus_polling_enabled: bool = Field(
+        default_factory=lambda: _get_bool_env("SERVICE_BUS_POLLING_ENABLED", True)
+    )
+    service_bus_poll_interval_seconds: float = Field(
+        default_factory=lambda: float(_get_env("SERVICE_BUS_POLL_INTERVAL_SECONDS", "5"))
+    )
+    max_receive_batch_size: int = Field(default_factory=lambda: int(_get_env("SERVICE_BUS_BATCH_SIZE", "5")))
+    max_delivery_attempts: int = Field(default_factory=lambda: int(_get_env("MAX_DELIVERY_ATTEMPTS", "5")))
+
+    @property
+    def service_bus_fully_qualified_namespace(self) -> str:
+        if "." in self.service_bus_namespace:
+            return self.service_bus_namespace
+        return f"{self.service_bus_namespace}.servicebus.windows.net"
+
+    def create_credential(self) -> Any:
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional in local unit-test environments.
+            raise RuntimeError(
+                "azure-identity is required to create Managed Identity credentials for the orchestrator."
+            ) from exc
+
+        return DefaultAzureCredential(exclude_interactive_browser_credential=True)
+
+
+@lru_cache(maxsize=1)
+def get_orchestrator_config() -> OrchestratorConfig:
+    return OrchestratorConfig()

--- a/src/services/orchestrator/handler.py
+++ b/src/services/orchestrator/handler.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from .orchestration import OrchestrationError, OrchestrationRequest, OrchestrationResult, OrchestratorService
+
+
+class QueueMessageError(ValueError):
+    """Raised when a Service Bus payload cannot be converted into an orchestration request."""
+
+
+def deserialize_message(message: Any) -> OrchestrationRequest:
+    if hasattr(message, "body"):
+        body = b"".join(bytes(part) for part in message.body)
+    else:
+        body = message
+
+    if isinstance(body, bytes):
+        payload: Any = json.loads(body.decode("utf-8"))
+    elif isinstance(body, str):
+        payload = json.loads(body)
+    else:
+        payload = body
+
+    try:
+        return OrchestrationRequest.model_validate(payload)
+    except Exception as exc:  # pragma: no cover - defensive parsing path.
+        raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+
+
+async def handle_message(
+    orchestrator: OrchestratorService,
+    *,
+    receiver: Any,
+    message: Any,
+) -> OrchestrationResult:
+    request = deserialize_message(message)
+    try:
+        result = await orchestrator.process_document(request)
+    except OrchestrationError as exc:
+        if getattr(message, "delivery_count", 1) >= orchestrator.config.max_delivery_attempts:
+            await receiver.dead_letter_message(
+                message,
+                reason="orchestration_failed",
+                error_description=str(exc),
+            )
+        else:
+            await receiver.abandon_message(message)
+        return exc.result
+
+    await receiver.complete_message(message)
+    return result
+
+
+async def consume_extraction_queue(orchestrator: OrchestratorService, *, max_wait_time: int = 5) -> int:
+    service_bus_client = orchestrator.dependencies.get_service_bus_client()
+    async with service_bus_client.get_queue_receiver(queue_name=orchestrator.config.extraction_queue_name) as receiver:
+        messages = await receiver.receive_messages(
+            max_message_count=orchestrator.config.max_receive_batch_size,
+            max_wait_time=max_wait_time,
+        )
+        for message in messages:
+            await handle_message(orchestrator, receiver=receiver, message=message)
+        return len(messages)
+
+
+async def run_queue_consumer(orchestrator: OrchestratorService, stop_event: asyncio.Event) -> None:
+    while not stop_event.is_set():
+        received = await consume_extraction_queue(orchestrator)
+        if received > 0:
+            continue
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=orchestrator.config.service_bus_poll_interval_seconds)
+        except TimeoutError:
+            continue

--- a/src/services/orchestrator/health.py
+++ b/src/services/orchestrator/health.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .orchestration import OrchestratorService
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/health/ready")
+async def readiness(request: Request) -> JSONResponse:
+    orchestrator = cast(OrchestratorService, request.app.state.orchestrator)
+    readiness_payload = await orchestrator.check_readiness()
+    status_code = 200 if bool(readiness_payload.get("ready")) else 503
+    return JSONResponse(status_code=status_code, content=cast(dict[str, Any], readiness_payload))

--- a/src/services/orchestrator/main.py
+++ b/src/services/orchestrator/main.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from typing import AsyncIterator, cast
+
+from fastapi import FastAPI, HTTPException, Request
+
+from .config import OrchestratorConfig, get_orchestrator_config
+from .handler import run_queue_consumer
+from .health import router as health_router
+from .orchestration import OrchestrationError, OrchestrationRequest, OrchestratorService
+
+
+class ManualProcessRequest(OrchestrationRequest):
+    pass
+
+
+def create_app(config: OrchestratorConfig | None = None) -> FastAPI:
+    resolved_config = config or get_orchestrator_config()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        orchestrator = OrchestratorService(config=resolved_config)
+        stop_event = asyncio.Event()
+        consumer_task: asyncio.Task[None] | None = None
+        app.state.orchestrator = orchestrator
+        app.state.consumer_stop_event = stop_event
+
+        if resolved_config.service_bus_polling_enabled:
+            consumer_task = asyncio.create_task(run_queue_consumer(orchestrator, stop_event))
+            app.state.consumer_task = consumer_task
+
+        try:
+            yield
+        finally:
+            stop_event.set()
+            if consumer_task is not None:
+                consumer_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await consumer_task
+            await orchestrator.close()
+
+    app = FastAPI(title="Verdecora Agentic Orchestrator", lifespan=lifespan)
+    app.include_router(health_router)
+
+    @app.post("/process")
+    async def process_document(payload: ManualProcessRequest, request: Request) -> dict[str, object]:
+        orchestrator = cast(OrchestratorService, request.app.state.orchestrator)
+        try:
+            result = await orchestrator.process_document(payload)
+        except OrchestrationError as exc:
+            raise HTTPException(status_code=500, detail=exc.result.model_dump(mode="json")) from exc
+        return result.model_dump(mode="json")
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("src.services.orchestrator.main:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/orchestrator/orchestration.py
+++ b/src/services/orchestrator/orchestration.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+
+from src.agents.pipeline import AlbaranPipeline, PipelineDocumentInput
+from src.config.agents import get_agents_config
+
+from .config import OrchestratorConfig, get_orchestrator_config
+
+
+class OrchestrationRequest(BaseModel):
+    blob_url: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    processing_id: str | None = None
+
+
+class OrchestrationResult(BaseModel):
+    processing_id: str
+    blob_url: str
+    status: str
+    routing_decision: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    pipeline_result: dict[str, Any] = Field(default_factory=dict)
+    downloaded_bytes: int = 0
+    error: str | None = None
+
+
+class OrchestrationError(RuntimeError):
+    def __init__(self, message: str, *, result: OrchestrationResult) -> None:
+        super().__init__(message)
+        self.result = result
+
+
+class AzureDependencySet:
+    def __init__(self, config: OrchestratorConfig) -> None:
+        self.config = config
+        self._credential: Any | None = None
+        self._cosmos_client: Any | None = None
+        self._service_bus_client: Any | None = None
+
+    def get_credential(self) -> Any:
+        if self._credential is None:
+            self._credential = self.config.create_credential()
+        return self._credential
+
+    def get_service_bus_client(self) -> Any:
+        if self._service_bus_client is None:
+            try:
+                from azure.servicebus.aio import ServiceBusClient
+            except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional runtime dependency.
+                raise RuntimeError("azure-servicebus is required for Service Bus queue processing.") from exc
+            self._service_bus_client = ServiceBusClient(
+                fully_qualified_namespace=self.config.service_bus_fully_qualified_namespace,
+                credential=self.get_credential(),
+            )
+        return self._service_bus_client
+
+    def get_cosmos_client(self) -> Any:
+        if self._cosmos_client is None:
+            try:
+                from azure.cosmos.aio import CosmosClient
+            except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional runtime dependency.
+                raise RuntimeError("azure-cosmos is required for orchestrator processing records.") from exc
+            self._cosmos_client = CosmosClient(self.config.cosmos_endpoint, credential=self.get_credential())
+        return self._cosmos_client
+
+    async def get_processing_container(self) -> Any:
+        cosmos_client = self.get_cosmos_client()
+        database_client = cosmos_client.get_database_client(self.config.database_name)
+        return database_client.get_container_client(self.config.processing_container_name)
+
+    async def check_ready(self) -> dict[str, Any]:
+        checks: dict[str, str] = {}
+        errors: dict[str, str] = {}
+
+        for name, factory in {
+            "credential": self.get_credential,
+            "cosmos": self.get_cosmos_client,
+            "service_bus": self.get_service_bus_client,
+        }.items():
+            try:
+                factory()
+            except Exception as exc:  # pragma: no cover - best-effort readiness verification.
+                errors[name] = str(exc)
+            else:
+                checks[name] = "configured"
+
+        try:
+            from azure.storage.blob.aio import BlobClient
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional runtime dependency.
+            errors["storage"] = str(exc)
+        else:
+            checks["storage"] = f"ready:{BlobClient.__name__}"
+
+        try:
+            from src.mcp.content_understanding_mcp.server import get_document_intelligence_client
+        except Exception as exc:  # pragma: no cover - optional runtime dependency.
+            errors["document_intelligence"] = str(exc)
+        else:
+            try:
+                await asyncio.to_thread(get_document_intelligence_client)
+            except Exception as exc:  # pragma: no cover - best-effort readiness verification.
+                errors["document_intelligence"] = str(exc)
+            else:
+                checks["document_intelligence"] = "configured"
+
+        return {"ready": not errors, "checks": checks, "errors": errors}
+
+    async def close(self) -> None:
+        for attribute_name in ("_service_bus_client", "_cosmos_client", "_credential"):
+            resource = getattr(self, attribute_name)
+            if resource is not None and hasattr(resource, "close"):
+                maybe_close = resource.close()
+                if asyncio.iscoroutine(maybe_close):
+                    await maybe_close
+
+
+class OrchestratorService:
+    def __init__(self, config: OrchestratorConfig | None = None, *, agent_client: Any | None = None) -> None:
+        self.config = config or get_orchestrator_config()
+        self.dependencies = AzureDependencySet(self.config)
+        self.agent_client = agent_client or self._build_agent_client()
+        self.pipeline = AlbaranPipeline(client=self.agent_client, config=get_agents_config())
+
+    def _build_agent_client(self) -> Any:
+        try:
+            from azure.identity import get_bearer_token_provider
+            from openai import AsyncAzureOpenAI
+        except ModuleNotFoundError:
+            return object()
+
+        token_provider = get_bearer_token_provider(
+            self.dependencies.get_credential(),
+            "https://cognitiveservices.azure.com/.default",
+        )
+        return AsyncAzureOpenAI(
+            azure_endpoint=self.config.azure_openai_endpoint,
+            api_version=self.config.azure_openai_api_version,
+            azure_ad_token_provider=token_provider,
+        )
+
+    async def close(self) -> None:
+        if hasattr(self.agent_client, "close"):
+            maybe_close = self.agent_client.close()
+            if asyncio.iscoroutine(maybe_close):
+                await maybe_close
+        await self.dependencies.close()
+
+    async def check_readiness(self) -> dict[str, Any]:
+        readiness = await self.dependencies.check_ready()
+        readiness["queue_name"] = self.config.extraction_queue_name
+        readiness["hitl_queue_name"] = self.config.hitl_queue_name
+        return readiness
+
+    def _build_processing_id(self, request: OrchestrationRequest) -> str:
+        if request.processing_id:
+            return request.processing_id
+        digest = hashlib.sha1(
+            json.dumps({"blob_url": request.blob_url, "metadata": request.metadata}, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        return digest
+
+    async def download_blob(self, blob_url: str) -> bytes:
+        try:
+            from azure.storage.blob.aio import BlobClient
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional runtime dependency.
+            raise RuntimeError("azure-storage-blob is required for blob downloads.") from exc
+
+        blob_client = BlobClient.from_blob_url(blob_url, credential=self.dependencies.get_credential())
+        try:
+            downloader = await blob_client.download_blob()
+            return await downloader.readall()
+        finally:
+            await blob_client.close()
+
+    async def analyze_document(self, blob_url: str) -> dict[str, Any]:
+        from src.mcp.content_understanding_mcp.server import run_analysis, to_key_value_pairs, to_tables
+
+        analysis_result = await asyncio.to_thread(run_analysis, blob_url, "prebuilt-layout")
+        return {
+            "content": analysis_result.content,
+            "page_count": len(analysis_result.pages or []),
+            "tables": [table.model_dump(mode="json") for table in to_tables(analysis_result)],
+            "key_value_pairs": [pair.model_dump(mode="json") for pair in to_key_value_pairs(analysis_result)],
+        }
+
+    async def _write_processing_record(self, result: OrchestrationResult) -> None:
+        container = await self.dependencies.get_processing_container()
+        record = result.model_dump(mode="json")
+        record["id"] = result.processing_id
+        await container.upsert_item(record)
+
+    async def _write_processing_status(
+        self,
+        *,
+        processing_id: str,
+        blob_url: str,
+        status: str,
+        metadata: dict[str, Any],
+        routing_decision: str = "processing",
+        error: str | None = None,
+    ) -> None:
+        await self._write_processing_record(
+            OrchestrationResult(
+                processing_id=processing_id,
+                blob_url=blob_url,
+                status=status,
+                routing_decision=routing_decision,
+                metadata=metadata,
+                error=error,
+            )
+        )
+
+    async def _send_hitl_message(self, result: OrchestrationResult) -> None:
+        try:
+            from azure.servicebus import ServiceBusMessage
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional runtime dependency.
+            raise RuntimeError("azure-servicebus is required for HITL handoff messages.") from exc
+
+        sender_payload = json.dumps(result.model_dump(mode="json"), ensure_ascii=False)
+        service_bus_client = self.dependencies.get_service_bus_client()
+        async with service_bus_client.get_queue_sender(queue_name=self.config.hitl_queue_name) as sender:
+            await sender.send_messages(ServiceBusMessage(sender_payload, content_type="application/json"))
+
+    def _extract_total_amount(self, metadata: dict[str, Any]) -> float | None:
+        raw_total = metadata.get("total_amount")
+        if raw_total is None:
+            return None
+        try:
+            return float(raw_total)
+        except (TypeError, ValueError):
+            return None
+
+    def _build_pipeline_input(
+        self,
+        *,
+        blob_url: str,
+        metadata: dict[str, Any],
+        ocr_payload: dict[str, Any],
+    ) -> PipelineDocumentInput:
+        return PipelineDocumentInput(
+            document_reference=blob_url,
+            raw_text=str(ocr_payload.get("content") or "") or None,
+            ocr_payload=ocr_payload,
+            supplier_id=self._get_optional_str(metadata, "supplier_id"),
+            supplier_hint=self._get_optional_str(metadata, "supplier_hint"),
+            total_amount=self._extract_total_amount(metadata),
+            metadata=metadata,
+        )
+
+    def _resolve_status(self, routing_decision: str) -> str:
+        if routing_decision in {"posted", "approve"}:
+            return "completed"
+        if routing_decision == "hitl_review":
+            return "hitl_pending"
+        return "failed"
+
+    def _get_optional_str(self, payload: dict[str, Any], key: str) -> str | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    async def process_document(self, request: OrchestrationRequest | dict[str, Any]) -> OrchestrationResult:
+        normalized_request = request
+        if not isinstance(request, OrchestrationRequest):
+            normalized_request = OrchestrationRequest.model_validate(request)
+
+        processing_id = self._build_processing_id(normalized_request)
+        await self._write_processing_status(
+            processing_id=processing_id,
+            blob_url=normalized_request.blob_url,
+            status="processing",
+            metadata=normalized_request.metadata,
+        )
+
+        try:
+            blob_bytes = await self.download_blob(normalized_request.blob_url)
+            ocr_payload = await self.analyze_document(normalized_request.blob_url)
+            pipeline_result = await self.pipeline.run(
+                self._build_pipeline_input(
+                    blob_url=normalized_request.blob_url,
+                    metadata=normalized_request.metadata,
+                    ocr_payload=ocr_payload,
+                )
+            )
+            result = OrchestrationResult(
+                processing_id=processing_id,
+                blob_url=normalized_request.blob_url,
+                status=self._resolve_status(pipeline_result.routing_decision),
+                routing_decision=pipeline_result.routing_decision,
+                metadata=normalized_request.metadata,
+                pipeline_result=pipeline_result.model_dump(mode="json"),
+                downloaded_bytes=len(blob_bytes),
+            )
+            await self._write_processing_record(result)
+            if result.status == "hitl_pending":
+                await self._send_hitl_message(result)
+            return result
+        except Exception as exc:
+            failure_result = OrchestrationResult(
+                processing_id=processing_id,
+                blob_url=normalized_request.blob_url,
+                status="failed",
+                routing_decision="failed",
+                metadata=normalized_request.metadata,
+                error=str(exc),
+            )
+            await self._write_processing_record(failure_result)
+            raise OrchestrationError(
+                f"Processing failed for {normalized_request.blob_url}", result=failure_result
+            ) from exc
+
+
+def blob_path_from_url(blob_url: str) -> tuple[str, str]:
+    parsed_url = urlparse(blob_url)
+    path_segments = [segment for segment in parsed_url.path.split("/") if segment]
+    if len(path_segments) < 2:
+        raise ValueError(f"Blob URL must include container and blob path: {blob_url}")
+    return path_segments[0], "/".join(path_segments[1:])

--- a/tests/fixtures/sample_validations.py
+++ b/tests/fixtures/sample_validations.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.models.inventory import PostingLineItem, PostingResult, PurchaseReceiptPosting
+from src.models.validation import LineComparison, ValidationResult
+
+
+def sample_line_comparison(*, status: str = "match", difference_pct: float | None = 0.0) -> LineComparison:
+    return LineComparison(
+        line_number=1,
+        field="quantity",
+        extracted_value="10",
+        bc_value="10",
+        difference_pct=difference_pct,
+        status=status,
+    )
+
+
+def sample_validation(*, overall_match_pct: float = 0.98, recommendation: str = "approve") -> ValidationResult:
+    return ValidationResult(
+        is_valid=recommendation == "approve",
+        overall_match_pct=overall_match_pct,
+        line_comparisons=[sample_line_comparison()],
+        header_match=True,
+        po_found=True,
+        po_number="PO-2026-0456",
+        total_lines_matched=1,
+        total_lines_mismatched=0,
+        total_lines_within_tolerance=0,
+        discrepancies=[],
+        recommendation=recommendation,
+        reasoning="Synthetic validation fixture.",
+    )
+
+
+def sample_posting_line_item() -> PostingLineItem:
+    return PostingLineItem(
+        item_number="HER-001",
+        description="Maceta cerámica 20cm",
+        quantity=3.0,
+        unit_cost=8.0,
+        line_amount=24.0,
+    )
+
+
+def sample_purchase_receipt_posting() -> PurchaseReceiptPosting:
+    return PurchaseReceiptPosting(
+        vendor_number="HERSTERA",
+        purchase_order_number="PO-2026-0456",
+        posting_date=date(2026, 1, 16),
+        document_number="ALB-2026-0001",
+        line_items=[sample_posting_line_item()],
+        total_amount=24.0,
+    )
+
+
+def sample_posting_result(*, success: bool = True, errors: list[str] | None = None) -> PostingResult:
+    return PostingResult(
+        success=success,
+        receipt_number="RCPT-2026-0012" if success else None,
+        posted_lines=1 if success else 0,
+        errors=list(errors or []),
+        bc_document_url="https://businesscentral/purchaseReceipts/RCPT-2026-0012" if success else None,
+    )

--- a/tests/unit/test_full_pipeline.py
+++ b/tests/unit/test_full_pipeline.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.pipeline import AlbaranPipeline, PipelineDocumentInput
+from src.models import DocumentType
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_posting_result, sample_validation
+
+pytestmark = pytest.mark.unit
+
+
+class FakeEvent:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+class FakeAsyncStream:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeWorkflow:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.payloads: list[Any] = []
+
+    def run(self, payload: Any, *, stream: bool) -> Any:
+        assert stream is True
+        self.payloads.append(payload)
+        return self.response
+
+
+def build_pipeline() -> AlbaranPipeline:
+    return AlbaranPipeline(
+        client=object(),
+        agents={
+            "triage": object(),
+            "extractor": object(),
+            "coherence": object(),
+            "validator": object(),
+            "inventory": object(),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_happy_path_posts_inventory() -> None:
+    triage_result = sample_triage_result()
+    extraction_result = sample_extraction()
+    coherence_result = sample_coherence_result()
+    validation_result = sample_validation(overall_match_pct=0.99, recommendation="approve")
+    posting_result = sample_posting_result(success=True)
+    workflows = {
+        "albaran-triage": FakeWorkflow(FakeAsyncStream([FakeEvent(triage_result.model_dump(mode="json"))])),
+        "albaran-extraction": FakeWorkflow(extraction_result.model_dump(mode="json")),
+        "albaran-coherence": FakeWorkflow(coherence_result.model_dump(mode="json")),
+        "albaran-validation": FakeWorkflow(validation_result.model_dump(mode="json")),
+        "albaran-inventory": FakeWorkflow(posting_result.model_dump(mode="json")),
+    }
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return workflows[name]
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await build_pipeline().run(
+            PipelineDocumentInput(document_reference="https://storage/account/albaran.pdf")
+        )
+
+    assert result.routing_decision == "posted"
+    assert result.validation == validation_result
+    assert result.inventory == posting_result
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_routes_to_hitl_when_validation_requires_review() -> None:
+    validation_result = sample_validation(overall_match_pct=0.9, recommendation="hitl_review")
+    workflows = {
+        "albaran-triage": FakeWorkflow(sample_triage_result().model_dump(mode="json")),
+        "albaran-extraction": FakeWorkflow(sample_extraction().model_dump(mode="json")),
+        "albaran-coherence": FakeWorkflow(sample_coherence_result().model_dump(mode="json")),
+        "albaran-validation": FakeWorkflow(validation_result.model_dump(mode="json")),
+    }
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return workflows[name]
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await build_pipeline().run(
+            PipelineDocumentInput(document_reference="https://storage/account/albaran.pdf")
+        )
+
+    assert result.routing_decision == "hitl_review"
+    assert result.inventory is None
+    assert result.skipped_steps == ["inventory"]
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_stops_after_reject_decision() -> None:
+    rejected_triage = sample_triage_result(
+        document_type=DocumentType.UNKNOWN,
+        confidence=0.22,
+        routing_decision="reject",
+        reasoning="The document is not a delivery note.",
+    )
+
+    def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+        assert participants
+        return {"albaran-triage": FakeWorkflow(rejected_triage.model_dump(mode="json"))}[name]
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build_sequential_workflow):
+        result = await build_pipeline().run(
+            PipelineDocumentInput(document_reference="https://storage/account/flyer.pdf")
+        )
+
+    assert result.routing_decision == "reject"
+    assert result.extraction is None
+    assert result.validation is None
+    assert result.inventory is None

--- a/tests/unit/test_inventory_agent.py
+++ b/tests/unit/test_inventory_agent.py
@@ -6,10 +6,14 @@ from unittest.mock import patch
 
 import pytest
 
-from src.agents.inventory_agent import create_inventory_agent
+from src.agents.inventory_agent import (
+    build_posting_failure_result,
+    create_inventory_agent,
+    should_process_inventory,
+)
 from src.config.agents import AgentsConfig
 from src.models import PostingResult
-from tests.fixtures.sample_albarans import sample_posting_result
+from tests.fixtures.sample_validations import sample_posting_result, sample_validation
 from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
 
 pytestmark = pytest.mark.unit
@@ -63,3 +67,18 @@ def test_inventory_agent_respects_custom_model_config(mock_factory: Any) -> None
     create_inventory_agent(client=object(), config=config)
 
     assert mock_factory.call_args.kwargs["model"] == "inventory-local"
+
+
+def test_inventory_agent_only_processes_approved_validations() -> None:
+    assert should_process_inventory(sample_validation(overall_match_pct=0.98, recommendation="approve")) is True
+    assert should_process_inventory(sample_validation(overall_match_pct=0.9, recommendation="hitl_review")) is False
+    assert should_process_inventory(sample_validation(overall_match_pct=0.7, recommendation="reject")) is False
+
+
+def test_inventory_agent_returns_failure_payload_on_bc_posting_error() -> None:
+    result = build_posting_failure_result(RuntimeError("Business Central posting failed"), receipt_number="TEMP-001")
+
+    assert result.success is False
+    assert result.receipt_number == "TEMP-001"
+    assert result.posted_lines == 0
+    assert result.errors == ["Business Central posting failed"]

--- a/tests/unit/test_inventory_models.py
+++ b/tests/unit/test_inventory_models.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from src.models.inventory import PostingLineItem, PostingResult, PurchaseReceiptPosting
+from tests.fixtures.sample_validations import (
+    sample_posting_line_item,
+    sample_posting_result,
+    sample_purchase_receipt_posting,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_posting_line_item_round_trip() -> None:
+    line_item = sample_posting_line_item()
+
+    restored = PostingLineItem.model_validate(line_item.model_dump(mode="json"))
+
+    assert restored == line_item
+    assert restored.line_amount == 24.0
+
+
+def test_purchase_receipt_posting_round_trip() -> None:
+    posting = sample_purchase_receipt_posting()
+
+    restored = PurchaseReceiptPosting.model_validate(posting.model_dump(mode="json"))
+
+    assert restored == posting
+    assert restored.document_number == "ALB-2026-0001"
+
+
+def test_posting_result_round_trip() -> None:
+    result = sample_posting_result(success=True)
+
+    restored = PostingResult.model_validate(result.model_dump(mode="json"))
+
+    assert restored == result
+    assert restored.posted_lines == 1
+
+
+def test_posting_line_item_accepts_integer_inputs() -> None:
+    line_item = PostingLineItem(
+        item_number="HER-001",
+        description="Maceta cerámica 20cm",
+        quantity=3,
+        unit_cost=8,
+        line_amount=24,
+    )
+
+    assert line_item.quantity == 3.0
+    assert line_item.unit_cost == 8.0
+    assert line_item.line_amount == 24.0

--- a/tests/unit/test_validation_models.py
+++ b/tests/unit/test_validation_models.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from src.models.validation import ValidationResult, compare_line_values
+from tests.fixtures.sample_validations import sample_line_comparison, sample_validation
+
+pytestmark = pytest.mark.unit
+
+
+def test_line_comparison_serializes_round_trip() -> None:
+    comparison = sample_line_comparison(status="tolerance", difference_pct=1.75)
+
+    restored = type(comparison).model_validate(comparison.model_dump(mode="json"))
+
+    assert restored == comparison
+    assert restored.status == "tolerance"
+    assert restored.difference_pct == 1.75
+
+
+def test_validation_result_serializes_with_empty_comparisons() -> None:
+    validation = ValidationResult(
+        is_valid=False,
+        overall_match_pct=0.8,
+        tolerance_pct=0.0,
+        line_comparisons=[],
+        header_match=False,
+        po_found=False,
+        po_number=None,
+        total_lines_matched=0,
+        total_lines_mismatched=0,
+        total_lines_within_tolerance=0,
+        discrepancies=["Manual review required."],
+        recommendation="hitl_review",
+        reasoning="No comparisons were available.",
+    )
+
+    restored = ValidationResult.model_validate(validation.model_dump(mode="json"))
+
+    assert restored == validation
+    assert restored.line_comparisons == []
+    assert restored.tolerance_pct == 0.0
+
+
+def test_compare_line_values_uses_zero_tolerance_as_strict_match() -> None:
+    comparison = compare_line_values(
+        line_number=3,
+        field="unit_price",
+        extracted_value=10.01,
+        bc_value=10.0,
+        tolerance_pct=0.0,
+    )
+
+    assert comparison.status == "mismatch"
+    assert comparison.difference_pct == pytest.approx(0.1)
+
+
+def test_sample_validation_round_trip() -> None:
+    validation = sample_validation()
+
+    restored = ValidationResult.model_validate(validation.model_dump(mode="json"))
+
+    assert restored == validation
+    assert restored.line_comparisons[0].status == "match"

--- a/tests/unit/test_validator_agent.py
+++ b/tests/unit/test_validator_agent.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
-from src.agents.validator_agent import create_validator_agent
+from src.agents.validator_agent import compare_line_values, create_validator_agent, recommend_validation_action
 from src.config.agents import AgentsConfig
 from src.models import ValidationResult
-from tests.fixtures.sample_albarans import sample_validation_result
+from tests.fixtures.sample_validations import sample_validation
 from tests.unit.agent_test_helpers import StructuredAgentStub, build_structured_agent_stub
 
 pytestmark = pytest.mark.unit
@@ -48,7 +48,7 @@ def test_create_validator_agent_uses_default_bc_tools_when_no_tools(mock_factory
 
 def test_validator_agent_decodes_validation_payload() -> None:
     agent = StructuredAgentStub(structured_output=ValidationResult, kwargs={})
-    result = sample_validation_result()
+    result = sample_validation()
 
     decoded = agent.decode(json.dumps(result.model_dump(mode="json")))
 
@@ -64,3 +64,44 @@ def test_validator_agent_respects_custom_model_config(mock_factory: Any) -> None
     create_validator_agent(client=object(), config=config)
 
     assert mock_factory.call_args.kwargs["model"] == "validator-local"
+
+
+@pytest.mark.parametrize(
+    ("extracted_value", "bc_value", "tolerance_pct", "expected_status"),
+    [
+        (10, 10, 2.0, "match"),
+        (10.1, 10, 2.0, "tolerance"),
+        (12, 10, 2.0, "mismatch"),
+    ],
+)
+def test_compare_line_values_handles_match_mismatch_and_tolerance(
+    extracted_value: float,
+    bc_value: float,
+    tolerance_pct: float,
+    expected_status: str,
+) -> None:
+    comparison = compare_line_values(
+        line_number=1,
+        field="quantity",
+        extracted_value=extracted_value,
+        bc_value=bc_value,
+        tolerance_pct=tolerance_pct,
+    )
+
+    assert comparison.status == expected_status
+
+
+@pytest.mark.parametrize(
+    ("overall_match_pct", "expected_recommendation"),
+    [
+        (0.96, "approve"),
+        (0.95, "hitl_review"),
+        (0.80, "hitl_review"),
+        (0.79, "reject"),
+    ],
+)
+def test_recommend_validation_action_respects_thresholds(
+    overall_match_pct: float,
+    expected_recommendation: str,
+) -> None:
+    assert recommend_validation_action(overall_match_pct) == expected_recommendation


### PR DESCRIPTION
## Summary
- add the ACA-oriented orchestrator service with FastAPI entrypoint, Service Bus handling, Cosmos persistence, OCR, and HITL queue routing
- expand A4/A5 coverage with validator, inventory, validation model, inventory model, and full pipeline handoff tests
- document the validator/inventory flow and orchestrator architecture in docs

## Validation
- python -m ruff check --fix pyproject.toml src\agents\inventory_agent.py src\agents\validator_agent.py src\models\validation.py src\services tests\fixtures\sample_validations.py tests\unit\test_inventory_agent.py tests\unit\test_validator_agent.py tests\unit\test_validation_models.py tests\unit\test_inventory_models.py tests\unit\test_full_pipeline.py
- python -m ruff format src\agents\inventory_agent.py src\agents\validator_agent.py src\models\validation.py src\services tests\fixtures\sample_validations.py tests\unit\test_inventory_agent.py tests\unit\test_validator_agent.py tests\unit\test_validation_models.py tests\unit\test_inventory_models.py tests\unit\test_full_pipeline.py
- python -m pytest tests/unit/ -v