### PR TITLE
test(e2e): E2E pipeline tests — happy path, HITL, reject (#27)

### DIFF
--- a/src/services/orchestrator/handler.py
+++ b/src/services/orchestrator/handler.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 from typing import Any
 
+from src.services.flow0_dedup.models import ForwardedExtractionMessage
+
 from .orchestration import OrchestrationError, OrchestrationRequest, OrchestrationResult, OrchestratorService
 
 
@@ -24,10 +26,37 @@ def deserialize_message(message: Any) -> OrchestrationRequest:
     else:
         payload = body
 
-    try:
-        return OrchestrationRequest.model_validate(payload)
-    except Exception as exc:  # pragma: no cover - defensive parsing path.
-        raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+    if isinstance(payload, dict) and "albaran_id" in payload:
+        try:
+            forwarded = ForwardedExtractionMessage.model_validate(payload)
+        except Exception as exc:  # pragma: no cover - defensive parsing path.
+            raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+    else:
+        try:
+            return OrchestrationRequest.model_validate(payload)
+        except Exception:
+            try:
+                forwarded = ForwardedExtractionMessage.model_validate(payload)
+            except Exception as exc:  # pragma: no cover - defensive parsing path.
+                raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+
+    metadata = dict(forwarded.metadata)
+    metadata.update(
+        {
+            "dedup_key": forwarded.dedup_key,
+            "blob_path": forwarded.blob_path,
+            "blob_name": forwarded.blob_name,
+            "blob_etag": forwarded.blob_etag,
+            "store_id": forwarded.store_id,
+            "event_id": forwarded.event_id,
+            "event_time": forwarded.event_time.isoformat(),
+        }
+    )
+    return OrchestrationRequest(
+        processing_id=forwarded.albaran_id,
+        blob_url=forwarded.blob_url,
+        metadata=metadata,
+    )
 
 
 async def handle_message(

--- a/src/services/orchestrator/orchestration.py
+++ b/src/services/orchestrator/orchestration.py
@@ -259,6 +259,8 @@ class OrchestratorService:
             return "completed"
         if routing_decision == "hitl_review":
             return "hitl_pending"
+        if routing_decision == "reject":
+            return "rejected"
         return "failed"
 
     def _get_optional_str(self, payload: dict[str, Any], key: str) -> str | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,13 +29,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     skip_integration = pytest.mark.skip(reason="need --run-integration option to run")
     skip_e2e = pytest.mark.skip(reason="need --run-e2e option to run")
-    run_integration = config.getoption("--run-integration")
-    run_e2e = config.getoption("--run-e2e")
+    invocation_args = [str(arg).replace("\\", "/") for arg in config.invocation_params.args]
+    explicit_integration_selection = any("tests/integration" in arg for arg in invocation_args)
+    explicit_e2e_selection = any("tests/e2e" in arg for arg in invocation_args)
+    run_integration = config.getoption("--run-integration") or explicit_integration_selection
+    run_e2e = config.getoption("--run-e2e") or explicit_e2e_selection
 
     for item in items:
         item_path = Path(str(item.path))
@@ -69,9 +70,7 @@ def bc_mcp_read_client(sample_po_data: dict[str, object]) -> SimpleNamespace:
     first_line = sample_po_data["purchaseLines"][0]
     return SimpleNamespace(
         get_purchase_order=AsyncMock(return_value=sample_po_data),
-        get_purchase_order_lines=AsyncMock(
-            return_value=sample_po_data["purchaseLines"]
-        ),
+        get_purchase_order_lines=AsyncMock(return_value=sample_po_data["purchaseLines"]),
         get_vendor=AsyncMock(
             return_value={
                 "number": sample_po_data["vendorNumber"],
@@ -90,16 +89,12 @@ def bc_mcp_read_client(sample_po_data: dict[str, object]) -> SimpleNamespace:
 @pytest.fixture()
 def bc_mcp_write_client() -> SimpleNamespace:
     return SimpleNamespace(
-        post_purchase_receipt=AsyncMock(
-            return_value={"status": "posted", "posted_receipt_id": "PR-2026-000123"}
-        )
+        post_purchase_receipt=AsyncMock(return_value={"status": "posted", "posted_receipt_id": "PR-2026-000123"})
     )
 
 
 @pytest.fixture()
-def bc_mcp_clients(
-    bc_mcp_read_client: SimpleNamespace, bc_mcp_write_client: SimpleNamespace
-) -> SimpleNamespace:
+def bc_mcp_clients(bc_mcp_read_client: SimpleNamespace, bc_mcp_write_client: SimpleNamespace) -> SimpleNamespace:
     return SimpleNamespace(read=bc_mcp_read_client, write=bc_mcp_write_client)
 
 
@@ -112,9 +107,7 @@ def cosmos_db_client(sample_albaran_data: dict[str, object]) -> SimpleNamespace:
         query_items=MagicMock(return_value=[sample_albaran_data]),
     )
     database = SimpleNamespace(get_container_client=MagicMock(return_value=container))
-    return SimpleNamespace(
-        get_database_client=MagicMock(return_value=database), close=AsyncMock()
-    )
+    return SimpleNamespace(get_database_client=MagicMock(return_value=database), close=AsyncMock())
 
 
 @pytest.fixture()

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test package for mocked pipeline scenarios."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,23 +1,162 @@
 from __future__ import annotations
 
-import os
+import json
+from collections.abc import AsyncIterator, Callable
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
+
+from src.agents.pipeline import AlbaranPipeline
+from src.services.flow0_dedup.dedup_handler import Flow0DedupHandler
+from src.services.orchestrator.config import OrchestratorConfig
+from src.services.orchestrator.orchestration import OrchestratorService
 
 pytestmark = pytest.mark.e2e
 
 
-def _e2e_enabled() -> bool:
-    return os.getenv("RUN_E2E_PIPELINE", "").lower() in {"1", "true", "yes", "on"}
+class FakeEvent:
+    def __init__(self, data: Any) -> None:
+        self.data = data
 
 
-@pytest.fixture(autouse=True)
-def skip_when_e2e_services_unavailable() -> None:
-    if not _e2e_enabled():
-        pytest.skip(
-            "E2E services unavailable. Set RUN_E2E_PIPELINE=1 to enable the pipeline skeleton."
+class FakeAsyncStream:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeWorkflow:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.payloads: list[Any] = []
+
+    def run(self, payload: Any, *, stream: bool) -> Any:
+        assert stream is True
+        self.payloads.append(payload)
+        return self.response
+
+
+class SharedCosmosStore:
+    def __init__(self) -> None:
+        self.items: dict[str, dict[str, Any]] = {}
+
+
+class SyncCosmosContainer:
+    def __init__(self, store: SharedCosmosStore) -> None:
+        self._store = store
+
+    def query_items(self, *, parameters: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
+        parameter_map = {parameter["name"]: parameter["value"] for parameter in parameters}
+        dedup_key = parameter_map.get("@dedup_key")
+        blob_name = parameter_map.get("@blob_name")
+        event_date = parameter_map.get("@event_date")
+        matches = [
+            item
+            for item in self._store.items.values()
+            if item.get("dedup_key") == dedup_key
+            or (item.get("blob_name") == blob_name and item.get("event_date") == event_date)
+        ]
+        return matches[:1]
+
+    def upsert_item(self, *, body: dict[str, Any]) -> dict[str, Any]:
+        self._store.items[str(body["id"])] = dict(body)
+        return dict(body)
+
+
+class AsyncCosmosContainer:
+    def __init__(self, store: SharedCosmosStore) -> None:
+        self._store = store
+
+    async def upsert_item(self, body: dict[str, Any]) -> dict[str, Any]:
+        self._store.items[str(body["id"])] = dict(body)
+        return dict(body)
+
+
+class FakeFlow0Sender:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_messages(self, message: Any) -> None:
+        body = b"".join(bytes(part) for part in message.body)
+        self.messages.append(json.loads(body.decode("utf-8")))
+
+
+class FakeQueueSender:
+    def __init__(self, queue_name: str, sent_messages: list[dict[str, Any]]) -> None:
+        self._queue_name = queue_name
+        self._sent_messages = sent_messages
+
+    async def __aenter__(self) -> "FakeQueueSender":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def send_messages(self, message: Any) -> None:
+        body = b"".join(bytes(part) for part in message.body)
+        self._sent_messages.append({"queue_name": self._queue_name, "payload": json.loads(body.decode("utf-8"))})
+
+
+class FakeAsyncServiceBusClient:
+    def __init__(self) -> None:
+        self.sent_messages: list[dict[str, Any]] = []
+
+    def get_queue_sender(self, *, queue_name: str) -> FakeQueueSender:
+        return FakeQueueSender(queue_name, self.sent_messages)
+
+
+class FakeDependencies:
+    def __init__(self, store: SharedCosmosStore, service_bus_client: FakeAsyncServiceBusClient) -> None:
+        self._container = AsyncCosmosContainer(store)
+        self._service_bus_client = service_bus_client
+
+    async def get_processing_container(self) -> AsyncCosmosContainer:
+        return self._container
+
+    def get_service_bus_client(self) -> FakeAsyncServiceBusClient:
+        return self._service_bus_client
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeReceivedMessage:
+    def __init__(self, payload: dict[str, Any], *, delivery_count: int = 1) -> None:
+        self.body = [json.dumps(payload).encode("utf-8")]
+        self.delivery_count = delivery_count
+
+
+class FakeReceiver:
+    def __init__(self) -> None:
+        self.completed_messages: list[FakeReceivedMessage] = []
+        self.abandoned_messages: list[FakeReceivedMessage] = []
+        self.dead_lettered_messages: list[dict[str, Any]] = []
+
+    async def complete_message(self, message: FakeReceivedMessage) -> None:
+        self.completed_messages.append(message)
+
+    async def abandon_message(self, message: FakeReceivedMessage) -> None:
+        self.abandoned_messages.append(message)
+
+    async def dead_letter_message(self, message: FakeReceivedMessage, *, reason: str, error_description: str) -> None:
+        self.dead_lettered_messages.append(
+            {"message": message, "reason": reason, "error_description": error_description}
         )
+
+
+def _to_workflow_response(response: Any) -> Any:
+    if isinstance(response, list):
+        return FakeAsyncStream([FakeEvent(item) for item in response])
+    return response
 
 
 @pytest.fixture(scope="session")
@@ -29,8 +168,8 @@ def full_pipeline_test_skeleton(
         "stages": [
             "blob-created-event",
             "flow-0-dedup",
-            "agent-a1-extraction",
-            "agent-a2-triage",
+            "agent-a1-triage",
+            "agent-a2-extraction",
             "agent-a3-coherence",
             "agent-a4-validator",
             "agent-a5-inventory",
@@ -41,5 +180,96 @@ def full_pipeline_test_skeleton(
             "albaran_id": sample_albaran_data["id"],
             "purchase_order": sample_po_data["number"],
         },
-        "expected_terminal_states": ["inventariado", "rechazado", "escalado"],
+        "expected_terminal_states": [
+            "inventariado",
+            "rechazado",
+            "escalado",
+            "completed",
+            "rejected",
+            "hitl_pending",
+        ],
     }
+
+
+@pytest.fixture()
+def sample_blob_event() -> dict[str, Any]:
+    return {
+        "id": "evt-e2e-001",
+        "eventType": "Microsoft.Storage.BlobCreated",
+        "subject": "/blobServices/default/containers/albaranes-raw/blobs/2026/05/tienda_007/albaran-herstera.pdf",
+        "eventTime": "2026-05-04T08:12:33Z",
+        "data": {
+            "eTag": '"0x8DEADBEEF"',
+            "contentType": "application/pdf",
+            "contentLength": 2048,
+            "url": "https://storage.blob.core.windows.net/albaranes-raw/2026/05/tienda_007/albaran-herstera.pdf",
+            "metadata": {"blob_hash": "hash-e2e-001", "source": "pytest"},
+        },
+    }
+
+
+@pytest.fixture()
+def ocr_payload() -> dict[str, Any]:
+    return {
+        "content": "ALBARAN DE ENTREGA HERSTERA PO-2026-0456",
+        "page_count": 1,
+        "tables": [{"row_count": 2, "column_count": 5}],
+        "key_value_pairs": [{"key": "purchase_order", "value": "PO-2026-0456", "confidence": 0.99}],
+    }
+
+
+@pytest.fixture()
+def cosmos_store() -> SharedCosmosStore:
+    return SharedCosmosStore()
+
+
+@pytest.fixture()
+def flow0_handler(cosmos_store: SharedCosmosStore) -> tuple[Flow0DedupHandler, FakeFlow0Sender]:
+    sender = FakeFlow0Sender()
+    handler = Flow0DedupHandler(SyncCosmosContainer(cosmos_store), sender)
+    return handler, sender
+
+
+@pytest.fixture()
+def fake_receiver() -> FakeReceiver:
+    return FakeReceiver()
+
+
+@pytest.fixture()
+def workflow_factory() -> Callable[[dict[str, Any]], tuple[dict[str, FakeWorkflow], Callable[..., FakeWorkflow]]]:
+    def _build(responses: dict[str, Any]) -> tuple[dict[str, FakeWorkflow], Callable[..., FakeWorkflow]]:
+        workflows = {name: FakeWorkflow(_to_workflow_response(response)) for name, response in responses.items()}
+
+        def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+            assert participants
+            return workflows[name]
+
+        return workflows, fake_build_sequential_workflow
+
+    return _build
+
+
+@pytest.fixture()
+def orchestrator_factory(
+    cosmos_store: SharedCosmosStore, ocr_payload: dict[str, Any]
+) -> Callable[[], tuple[OrchestratorService, FakeAsyncServiceBusClient]]:
+    def _build() -> tuple[OrchestratorService, FakeAsyncServiceBusClient]:
+        config = OrchestratorConfig(service_bus_polling_enabled=False)
+        service = OrchestratorService(config=config, agent_client=object())
+        service_bus_client = FakeAsyncServiceBusClient()
+        service.dependencies = FakeDependencies(cosmos_store, service_bus_client)
+        service.pipeline = AlbaranPipeline(
+            client=object(),
+            agents={
+                "triage": object(),
+                "extractor": object(),
+                "coherence": object(),
+                "validator": object(),
+                "inventory": object(),
+            },
+        )
+        service.download_blob = AsyncMock(return_value=b"%PDF-1.7 mocked pdf bytes")
+        service.analyze_document = AsyncMock(return_value=ocr_payload)
+        return service, service_bus_client
+
+    return _build

--- a/tests/e2e/test_hitl_path_e2e.py
+++ b/tests/e2e/test_hitl_path_e2e.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_validation
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_hitl_path_e2e_stops_pipeline_and_notifies_hitl_queue(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    validation_result = sample_validation(overall_match_pct=0.88, recommendation="hitl_review")
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [sample_triage_result().model_dump(mode="json")],
+            "albaran-extraction": sample_extraction().model_dump(mode="json"),
+            "albaran-coherence": sample_coherence_result().model_dump(mode="json"),
+            "albaran-validation": validation_result.model_dump(mode="json"),
+        }
+    )
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.status == "hitl_pending"
+    assert result.routing_decision == "hitl_review"
+    assert result.pipeline_result["inventory"] is None
+    assert cosmos_store.items[result.processing_id]["status"] == "hitl_pending"
+    assert fake_receiver.completed_messages == [message]
+    assert len(service_bus_client.sent_messages) == 1
+    assert service_bus_client.sent_messages[0]["queue_name"] == orchestrator.config.hitl_queue_name
+    assert service_bus_client.sent_messages[0]["payload"]["processing_id"] == result.processing_id
+    assert workflows["albaran-validation"].payloads

--- a/tests/e2e/test_pipeline_e2e.py
+++ b/tests/e2e/test_pipeline_e2e.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_posting_result, sample_validation
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_pipeline_e2e_happy_path_updates_cosmos_and_preserves_agent_handoffs(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+    ocr_payload: dict[str, object],
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    triage_result = sample_triage_result()
+    extraction_result = sample_extraction()
+    coherence_result = sample_coherence_result()
+    validation_result = sample_validation(overall_match_pct=0.99, recommendation="approve")
+    posting_result = sample_posting_result(success=True)
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [triage_result.model_dump(mode="json")],
+            "albaran-extraction": extraction_result.model_dump(mode="json"),
+            "albaran-coherence": coherence_result.model_dump(mode="json"),
+            "albaran-validation": validation_result.model_dump(mode="json"),
+            "albaran-inventory": posting_result.model_dump(mode="json"),
+        }
+    )
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.processing_id == forwarded_payload["albaran_id"]
+    assert result.status == "completed"
+    assert result.routing_decision == "posted"
+    assert result.pipeline_result["inventory"]["receipt_number"] == posting_result.receipt_number
+    assert cosmos_store.items[result.processing_id]["status"] == "completed"
+    assert fake_receiver.completed_messages == [message]
+    assert not service_bus_client.sent_messages
+
+    assert workflows["albaran-triage"].payloads == [ocr_payload["content"]]
+    assert workflows["albaran-extraction"].payloads == [ocr_payload]
+    assert workflows["albaran-coherence"].payloads == [extraction_result.model_dump(mode="json")]
+    assert workflows["albaran-validation"].payloads == [
+        {
+            "extraction": extraction_result.model_dump(mode="json"),
+            "coherence": coherence_result.model_dump(mode="json"),
+        }
+    ]
+    assert workflows["albaran-inventory"].payloads == [
+        {
+            "validation": validation_result.model_dump(mode="json"),
+            "extraction": extraction_result.model_dump(mode="json"),
+        }
+    ]

--- a/tests/e2e/test_reject_path_e2e.py
+++ b/tests/e2e/test_reject_path_e2e.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.models import DocumentType
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_triage_result
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_reject_path_e2e_stops_after_triage_and_marks_record_rejected(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    rejected_triage = sample_triage_result(
+        document_type=DocumentType.UNKNOWN,
+        confidence=0.18,
+        routing_decision="reject",
+        reasoning="Documento desconocido; no corresponde a un albarán.",
+    )
+    workflows, fake_build = workflow_factory({"albaran-triage": [rejected_triage.model_dump(mode="json")]})
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.status == "rejected"
+    assert result.routing_decision == "reject"
+    assert result.pipeline_result["extraction"] is None
+    assert result.pipeline_result["validation"] is None
+    assert cosmos_store.items[result.processing_id]["status"] == "rejected"
+    assert fake_receiver.completed_messages == [message]
+    assert workflows["albaran-triage"].payloads
+    assert not service_bus_client.sent_messages


### PR DESCRIPTION
## Summary\n- add mocked E2E fixtures for Flow 0 dedup + orchestrator + A1-A5 pipeline coverage\n- cover happy path, HITL diversion, and reject termination scenarios\n- let explicit tests/e2e invocations run without requiring --run-e2e\n\n## Validation\n- python -m ruff check tests\\conftest.py tests\\e2e src\\services\\orchestrator\\handler.py src\\services\\orchestrator\\orchestration.py\n- python -m pytest tests\\e2e -v\n- python -m pytest tests\\unit tests\\e2e -v