### PR TITLE
feat(hitl): Bicep ACS Email + HITL security + user manual (#36, #37, #38)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,6 @@ Complete documentation for the project:
   - [Validation + inventory specification](architecture/validation-inventory-spec.md)
   - [Orchestrator ACA application specification](architecture/orchestrator-spec.md)
 - **operations/** - Runbooks and operational procedures
+- **security/** - Security baselines, RBAC matrices, and HITL hardening guidance
 - **user/** - User manuals and guides
+  - [Manual de revisión HITL](user/hitl-user-manual.md)

--- a/docs/security/identity-matrix.md
+++ b/docs/security/identity-matrix.md
@@ -9,7 +9,7 @@
 - **Key Vault authorization model:** Azure RBAC mode only.
 - **BC MCP authentication:** OAuth 2.0 Authorization Code + PKCE with delegated user identity.
 
-> **Exception handling:** `acs-connection-string` and `github-runner-pat` are tracked as temporary operational exceptions because the delivery scope explicitly requires placeholder secrets for them. They must remain disabled for production use unless a security review re-approves them.
+> **Exception handling:** `github-runner-pat` remains a temporary operational exception for bootstrap automation. HITL email and PDF access use managed identity end-to-end and do not require ACS connection strings or storage account keys.
 
 ## Managed identity matrix
 
@@ -20,17 +20,26 @@
 | Agentic orchestrator | `agentic-orchestrator` | Service Bus namespace | Azure Service Bus Data Receiver | Consume queue/topic messages that resume or advance orchestration. |
 | Agentic orchestrator | `agentic-orchestrator` | Blob Storage account | Storage Blob Data Reader | Read inbound albarán PDFs and related blob metadata. |
 | Agentic orchestrator | `agentic-orchestrator` | Key Vault | Key Vault Secrets User | Read BC OAuth client secret and any approved non-MI exceptions at runtime. |
+| Agentic orchestrator | `agentic-orchestrator` | Azure Communication Services | Contributor | Send HITL emails through ACS while the platform lacks a narrower RBAC role for managed-identity email operations. |
 | Communication agent | `communication-agent` | Azure Communication Services | Azure Communication Services Contributor | Send and manage HITL email traffic and related ACS configuration operations. |
 | Communication agent | `communication-agent` | Cosmos DB NoSQL account | Cosmos DB Built-in Data Contributor | Persist outbound communication state, reminders, and approval metadata. |
 | Communication agent | `communication-agent` | Service Bus namespace | Azure Service Bus Data Sender | Publish HITL reminders, escalations, and approval outcome events. |
 | Communication agent | `communication-agent` | Key Vault | Key Vault Secrets User | Read approved secrets needed for BC delegated auth or controlled operational exceptions. |
 | HITL web form | `hitl-webform` | Cosmos DB NoSQL account | Cosmos DB Built-in Data Contributor | Record operator decisions, comments, and audit timestamps. |
+| HITL web form | `hitl-webform` | Blob Storage account | Storage Blob Data Contributor | Generate User Delegation Keys and serve read-only SAS URLs for original PDFs without storage account keys. |
 | HITL web form | `hitl-webform` | Service Bus namespace | Azure Service Bus Data Sender | Resume workflows after human approval, rejection, or modification. |
 | HITL web form | `hitl-webform` | Key Vault | Key Vault Secrets User | Read approved secret-backed configuration without embedding credentials in code. |
 | Flow 0 worker | `flow0-worker` | Cosmos DB NoSQL account | Cosmos DB Built-in Data Contributor | Write deduplication records and initial ingestion state. |
 | Flow 0 worker | `flow0-worker` | Service Bus namespace | Azure Service Bus Data Sender | Publish `albaran.recibido` events after deduplication. |
 | Flow 0 worker | `flow0-worker` | Blob Storage account | Storage Blob Data Reader | Read source PDFs and blob metadata during ingestion. |
 | Flow 0 worker | `flow0-worker` | Key Vault | Key Vault Secrets User | Read approved non-MI exceptions from Key Vault without exposing them in deployments. |
+
+## HITL security controls
+
+- **Authentication:** the HITL web form validates Entra ID access tokens from the `Authorization` header against the tenant JWKS endpoint and enforces the `Verdecora.StoreManager` application role before allowing approve/reject/modify decisions.
+- **PDF access:** reviewers receive short-lived, read-only SAS URLs generated with a User Delegation Key obtained through managed identity; storage account keys remain disabled.
+- **Auditability:** every decision and every PDF access event is written to Cosmos DB with reviewer identity, IP address, action, and correlation ID.
+- **Email domain:** development environments use the ACS Azure-managed sender domain (`AzureManagedDomain` / `*.azurecomm.net`). Production should switch to a customer-managed sender domain with DNS validation.
 
 ## BC OAuth 2.0 + PKCE configuration guide
 
@@ -59,12 +68,13 @@
 | Secret | Rotation target | Policy recommendation |
 |---|---|---|
 | `bc-oauth-client-secret` | Every 90 days (or shorter if tenant policy requires it) | Maintain overlapping secret versions, rotate before expiry, validate the new secret in dev first, and alert at 30/7/1 days before expiration. |
-| `acs-connection-string` | Every 30 days until MI-based access is available | Treat as a temporary exception, scope usage to the communication workload only, and remove once the ACS integration supports a no-secret pattern. |
 | `github-runner-pat` | Every 7-30 days, bootstrap use only | Prefer GitHub App or OIDC as the long-term replacement; if PAT use is unavoidable, keep scopes minimal, short-lived, and monitored. |
 
 ### Operational controls
 
 - Enable Key Vault diagnostics to Log Analytics and alert on `SecretNearExpiry`, `SecretGet`, and unauthorized access patterns.
+- Monitor Entra sign-in logs for the HITL application and alert on denied requests caused by missing `Verdecora.StoreManager` role assignments.
+- Track Cosmos audit writes and SAS generation events with correlation IDs so every reviewer action can be reconstructed end-to-end.
 - Use Key Vault versioning so rotations do not require destructive updates.
 - Require dual control for production secret rotation and document the rollback procedure before each change window.
 - Review RBAC assignments quarterly to ensure every managed identity still needs its granted scope.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -6,3 +6,4 @@ User manuals and guides.
 - User workflows
 - API documentation
 - Configuration guides
+- [Manual de Usuario — Revisión de Albaranes](hitl-user-manual.md)

--- a/docs/user/hitl-user-manual.md
+++ b/docs/user/hitl-user-manual.md
@@ -1,0 +1,54 @@
+# Manual de Usuario — Revisión de Albaranes
+
+## ¿Qué es el sistema de revisión?
+El sistema de revisión HITL (*Human in the Loop*) ayuda a validar albaranes cuando la automatización detecta discrepancias entre el documento recibido, el pedido de compra y las reglas de negocio de Verdecora. Su intervención permite confirmar si la mercancía es correcta, si debe rechazarse o si hay que ajustar cantidades antes de continuar el flujo.
+
+## ¿Cuándo recibiré un email?
+Recibirá un correo cuando el sistema detecte alguna de estas situaciones:
+- Diferencias entre el albarán y el pedido de compra.
+- Cantidades o importes fuera de tolerancia.
+- Datos incompletos o incoherentes que requieren validación humana.
+- Casos bloqueados durante más tiempo del esperado y que necesitan una respuesta prioritaria.
+
+## ¿Cómo reviso un albarán?
+1. Abra el enlace incluido en el email.
+2. Inicie sesión con su cuenta corporativa de Verdecora si el sistema se lo solicita.
+3. Revise las discrepancias marcadas en rojo.
+4. Compare la información detectada con el PDF original del albarán.
+5. Seleccione una acción: **Aprobar**, **Rechazar** o **Modificar**.
+6. Añada un comentario cuando sea necesario para dejar trazabilidad.
+7. Envíe la decisión para que el flujo continúe.
+
+## ¿Qué significa cada opción?
+- **Aprobar**: confirma que el albarán puede seguir el proceso sin cambios.
+- **Rechazar**: indica que el documento no es válido y debe revisarse fuera del sistema.
+- **Modificar**: permite corregir datos concretos (por ejemplo, cantidades) antes de continuar.
+
+## ¿Qué pasa si no respondo?
+- **24 horas**: recibirá un recordatorio automático.
+- **48 horas**: el caso se escalará al responsable asignado.
+- **72 horas**: se enviará un aviso final y el caso quedará señalado como pendiente crítico.
+
+## Buenas prácticas de seguridad
+- Utilice siempre su cuenta corporativa de Verdecora.
+- No reenvíe el enlace del correo a personas no autorizadas.
+- Abra el PDF original únicamente desde el enlace seguro incluido en la revisión.
+- Cierre la sesión o el navegador compartido al terminar.
+- Si detecta un acceso no esperado, notifíquelo al equipo técnico y no tome una decisión hasta confirmarlo.
+
+## Preguntas frecuentes
+
+### ¿Puedo revisar el mismo albarán desde el móvil?
+Sí, siempre que acceda con su cuenta corporativa y desde una conexión segura.
+
+### ¿Qué ocurre si el enlace del PDF no funciona?
+Solicite una nueva revisión o contacte con soporte. Los enlaces al PDF caducan por seguridad.
+
+### ¿Puedo cambiar una decisión ya enviada?
+No directamente. Si necesita corregir una decisión, contacte con el responsable del flujo o con soporte para reabrir el caso.
+
+### ¿Qué hago si no tengo permiso para aprobar o rechazar?
+Verifique que pertenece al rol de encargado de tienda. Si el problema continúa, abra una incidencia con el equipo de plataforma.
+
+### ¿Se registra mi actividad?
+Sí. El sistema guarda quién accede, qué decisión toma y cuándo lo hace para cumplir los requisitos de auditoría.

--- a/infra/modules/acs.bicep
+++ b/infra/modules/acs.bicep
@@ -1,0 +1,77 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for Azure Communication Services resources.')
+param location string
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  region: location
+  'managed-by': 'bicep'
+}
+
+var communicationServiceName = 'verdecora-acs-${environment}'
+var emailServiceName = 'verdecora-email-${environment}'
+var azureManagedDomainResourceName = 'AzureManagedDomain'
+
+resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
+  name: emailServiceName
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Europe'
+  }
+}
+
+resource azureManagedSenderDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
+  parent: emailService
+  name: azureManagedDomainResourceName
+  location: 'global'
+  tags: tags
+  properties: {
+    domainManagement: 'AzureManaged'
+    userEngagementTracking: 'Disabled'
+  }
+}
+
+resource communicationService 'Microsoft.Communication/communicationServices@2026-03-18' = {
+  name: communicationServiceName
+  location: 'global'
+  tags: tags
+  properties: {
+    dataLocation: 'Europe'
+    disableLocalAuth: true
+    linkedDomains: [
+      azureManagedSenderDomain.id
+    ]
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+/*
+resource productionSenderDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
+  parent: emailService
+  name: 'mail.verdecora.example'
+  location: 'global'
+  tags: tags
+  properties: {
+    domainManagement: 'CustomerManaged'
+    userEngagementTracking: 'Disabled'
+  }
+}
+*/
+
+@description('Azure Communication Services resource id.')
+output acsId string = communicationService.id
+
+@description('Azure Communication Services resource name.')
+output acsName string = communicationService.name
+
+@description('Azure Communication Services endpoint.')
+output acsEndpoint string = 'https://${communicationService.properties.hostName}'
+
+@description('Resolved sender domain used by ACS email.')
+output emailSenderDomain string = azureManagedSenderDomain.properties.fromSenderDomain

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -46,7 +46,9 @@ var cosmosBuiltInDataContributorRoleDefinitionId = '00000000-0000-0000-0000-0000
 var serviceBusDataSenderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
 var serviceBusDataReceiverRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e36647ef-1570-4e4c-ae03-a6bda23981cb')
 var storageBlobDataReaderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1')
+var storageBlobDataContributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
 var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+var contributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
 var communicationServicesContributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2495237a-0d06-4fc0-b5ef-8a60a7cb5773')
 var cognitiveServicesOpenAIUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
 var cognitiveServicesUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
@@ -230,6 +232,16 @@ resource flow0WorkerBlobReaderRoleAssignment 'Microsoft.Authorization/roleAssign
   }
 }
 
+resource hitlWebformBlobContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployUserAssignedIdentities) {
+  name: guid(storageAccount.id, hitlWebformIdentity!.name, storageBlobDataContributorRoleDefinitionId)
+  scope: storageAccount
+  properties: {
+    principalId: hitlWebformIdentity!.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleDefinitionId
+  }
+}
+
 resource agenticOrchestratorKeyVaultSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployUserAssignedIdentities && !empty(keyVaultName)) {
   name: guid(keyVault.id, agenticOrchestratorIdentity!.name, keyVaultSecretsUserRoleDefinitionId)
   scope: keyVault
@@ -277,6 +289,16 @@ resource communicationAgentCommunicationServicesContributorRoleAssignment 'Micro
     principalId: communicationAgentIdentity!.properties.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: communicationServicesContributorRoleDefinitionId
+  }
+}
+
+resource agenticOrchestratorCommunicationServicesContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployUserAssignedIdentities && !empty(communicationServiceName)) {
+  name: guid(communicationService.id, agenticOrchestratorIdentity!.name, contributorRoleDefinitionId)
+  scope: communicationService
+  properties: {
+    principalId: agenticOrchestratorIdentity!.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinitionId
   }
 }
 
@@ -360,6 +382,16 @@ resource orchestratorSystemAssignedDocIntellRoleAssignment 'Microsoft.Authorizat
   }
 }
 
+resource orchestratorSystemAssignedCommunicationServicesContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(orchestratorPrincipalId) && !empty(communicationServiceName)) {
+  name: guid(communicationService.id, orchestratorPrincipalId, contributorRoleDefinitionId, 'system')
+  scope: communicationService
+  properties: {
+    principalId: orchestratorPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinitionId
+  }
+}
+
 resource flow0SystemAssignedCosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = if (!empty(flow0WorkerPrincipalId)) {
   parent: cosmosAccount
   name: guid(cosmosAccount.id, flow0WorkerPrincipalId, cosmosBuiltInDataContributorRoleDefinitionId, 'system')
@@ -397,6 +429,16 @@ resource flow0SystemAssignedBlobReaderRoleAssignment 'Microsoft.Authorization/ro
     principalId: flow0WorkerPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: storageBlobDataReaderRoleDefinitionId
+  }
+}
+
+resource hitlWebformSystemAssignedBlobContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(hitlWebformPrincipalId)) {
+  name: guid(storageAccount.id, hitlWebformPrincipalId, storageBlobDataContributorRoleDefinitionId, 'system')
+  scope: storageAccount
+  properties: {
+    principalId: hitlWebformPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleDefinitionId
   }
 }
 

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -113,6 +113,18 @@ module docIntell './docintell.bicep' = {
   ]
 }
 
+module acs './acs.bicep' = {
+  name: 'acs'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
 module containerApps './container-apps.bicep' = {
   name: 'containerApps'
   scope: az.resourceGroup(resourceGroupName)
@@ -158,6 +170,7 @@ module identity './identity.bicep' = {
     serviceBusNamespaceName: serviceBus.outputs.serviceBusNamespaceName
     storageAccountName: storage.outputs.storageAccountName
     keyVaultName: keyVault.outputs.keyVaultName
+    communicationServiceName: acs.outputs.acsName
     openAiAccountName: openAi.outputs.openaiAccountName
     docIntellAccountName: docIntell.outputs.docIntellAccountName
     deployUserAssignedIdentities: false
@@ -214,6 +227,15 @@ output applicationInsightsId string = monitoring.outputs.applicationInsightsId
 
 @description('Application Insights connection string.')
 output applicationInsightsConnectionString string = monitoring.outputs.applicationInsightsConnectionString
+
+@description('Azure Communication Services resource id.')
+output acsId string = acs.outputs.acsId
+
+@description('Azure Communication Services endpoint.')
+output acsEndpoint string = acs.outputs.acsEndpoint
+
+@description('Azure-managed sender domain for HITL email.')
+output emailSenderDomain string = acs.outputs.emailSenderDomain
 
 @description('Azure OpenAI account id.')
 output openaiAccountId string = openAi.outputs.openaiAccountId

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "mcp>=1.12.4",
     "openai>=1.58.1",
     "pydantic>=2.11.0",
+    "PyJWT[crypto]>=2.10.1",
     "uvicorn>=0.34.0",
 ]
 

--- a/src/services/hitl_webform/__init__.py
+++ b/src/services/hitl_webform/__init__.py
@@ -1,0 +1,13 @@
+from .audit import AuditLogger, HITLDecision
+from .sas import generate_pdf_sas_url
+from .security import EntraTokenValidator, TokenClaims, TokenValidationError, extract_bearer_token
+
+__all__ = [
+    "AuditLogger",
+    "EntraTokenValidator",
+    "HITLDecision",
+    "TokenClaims",
+    "TokenValidationError",
+    "extract_bearer_token",
+    "generate_pdf_sas_url",
+]

--- a/src/services/hitl_webform/audit.py
+++ b/src/services/hitl_webform/audit.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Protocol
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.config.security import get_managed_identity_credential
+
+LOGGER = logging.getLogger("hitl.audit")
+
+
+class CosmosContainer(Protocol):
+    async def upsert_item(self, body: dict[str, Any]) -> Any:  # pragma: no cover - protocol definition
+        ...
+
+
+class HITLDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    albaran_id: str
+    action: str
+    reviewer_email: str
+    comment: str | None = None
+    modified_quantity: float | None = None
+    store_id: str | None = None
+    decided_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class AuditLogger:
+    """Write immutable HITL audit records to Cosmos DB using managed identity."""
+
+    def __init__(
+        self,
+        cosmos_endpoint: str | None = None,
+        *,
+        database_name: str = "albaranes-db",
+        container_name: str = "hitl-audit",
+        container_client: CosmosContainer | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._cosmos_endpoint = cosmos_endpoint
+        self._database_name = database_name
+        self._container_name = container_name
+        self._container_client = container_client
+        self._logger = logger or LOGGER
+        self._cosmos_client: Any | None = None
+
+    async def log_decision(self, decision: HITLDecision, reviewer_ip: str, correlation_id: str) -> None:
+        event_time = decision.decided_at.astimezone(UTC)
+        document = {
+            "id": f"{decision.albaran_id}:decision:{uuid4()}",
+            "pk": decision.albaran_id,
+            "eventType": "hitl.decision",
+            "albaranId": decision.albaran_id,
+            "action": decision.action,
+            "reviewerEmail": decision.reviewer_email.casefold(),
+            "reviewerIp": reviewer_ip,
+            "comment": decision.comment,
+            "modifiedQuantity": decision.modified_quantity,
+            "storeId": decision.store_id,
+            "correlationId": correlation_id,
+            "createdAt": event_time.isoformat(),
+        }
+        await self._write_event(document)
+        self._logger.info(
+            "Recorded HITL decision audit event",
+            extra={
+                "correlation_id": correlation_id,
+                "albaran_id": decision.albaran_id,
+                "reviewer_email": decision.reviewer_email.casefold(),
+                "action": decision.action,
+            },
+        )
+
+    async def log_pdf_access(self, albaran_id: str, user_email: str, correlation_id: str) -> None:
+        event_time = datetime.now(UTC)
+        document = {
+            "id": f"{albaran_id}:pdf-access:{uuid4()}",
+            "pk": albaran_id,
+            "eventType": "hitl.pdf_access",
+            "albaranId": albaran_id,
+            "userEmail": user_email.casefold(),
+            "correlationId": correlation_id,
+            "createdAt": event_time.isoformat(),
+        }
+        await self._write_event(document)
+        self._logger.info(
+            "Recorded HITL PDF access audit event",
+            extra={
+                "correlation_id": correlation_id,
+                "albaran_id": albaran_id,
+                "user_email": user_email.casefold(),
+            },
+        )
+
+    async def _write_event(self, document: dict[str, Any]) -> None:
+        container_client = await self._get_container_client()
+        await container_client.upsert_item(body=document)
+
+    async def _get_container_client(self) -> CosmosContainer:
+        if self._container_client is not None:
+            return self._container_client
+
+        if not self._cosmos_endpoint:
+            raise RuntimeError("cosmos_endpoint is required when no container_client is supplied.")
+
+        from azure.cosmos.aio import CosmosClient
+
+        if self._cosmos_client is None:
+            self._cosmos_client = CosmosClient(
+                url=self._cosmos_endpoint,
+                credential=get_managed_identity_credential(),
+            )
+
+        database_client = self._cosmos_client.get_database_client(self._database_name)
+        self._container_client = database_client.get_container_client(self._container_name)
+        return self._container_client
+
+    async def close(self) -> None:
+        if self._cosmos_client is not None:
+            await self._cosmos_client.close()
+            self._cosmos_client = None

--- a/src/services/hitl_webform/sas.py
+++ b/src/services/hitl_webform/sas.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from azure.storage.blob import BlobSasPermissions, BlobServiceClient, generate_blob_sas
+
+from src.config.security import get_managed_identity_credential
+
+
+def generate_pdf_sas_url(storage_account_url: str, container: str, blob_name: str, expiry_hours: int = 1) -> str:
+    """Generate a short-lived read-only SAS URL using a User Delegation Key."""
+
+    if expiry_hours <= 0:
+        raise ValueError("expiry_hours must be greater than zero.")
+
+    credential = get_managed_identity_credential()
+    blob_service_client = BlobServiceClient(account_url=storage_account_url, credential=credential)
+    blob_client = blob_service_client.get_blob_client(container=container, blob=blob_name)
+
+    start_time = datetime.now(UTC) - timedelta(minutes=5)
+    expiry_time = start_time + timedelta(hours=expiry_hours, minutes=5)
+    delegation_key = blob_service_client.get_user_delegation_key(start_time, expiry_time)
+    sas_token = generate_blob_sas(
+        account_name=blob_service_client.account_name,
+        container_name=container,
+        blob_name=blob_name,
+        user_delegation_key=delegation_key,
+        permission=BlobSasPermissions(read=True),
+        start=start_time,
+        expiry=expiry_time,
+        protocol="https",
+    )
+    return f"{blob_client.url}?{sas_token}"

--- a/src/services/hitl_webform/security.py
+++ b/src/services/hitl_webform/security.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import jwt
+from jwt import InvalidTokenError, PyJWKClient
+from pydantic import BaseModel, ConfigDict, Field
+
+REVIEWER_ROLE = "Verdecora.StoreManager"
+
+
+class TokenValidationError(RuntimeError):
+    """Raised when an Entra access token cannot be trusted."""
+
+
+class TokenClaims(BaseModel):
+    """Normalized claims extracted from an Entra access token."""
+
+    model_config = ConfigDict(frozen=True)
+
+    subject: str = Field(alias="sub")
+    issuer: str = Field(alias="iss")
+    audience: str | list[str] = Field(alias="aud")
+    email: str
+    roles: tuple[str, ...] = ()
+    raw_claims: dict[str, Any] = Field(default_factory=dict)
+
+
+def extract_bearer_token(authorization_header: str) -> str:
+    """Extract the JWT from a standard Authorization header value."""
+
+    scheme, _, token = authorization_header.partition(" ")
+    if scheme.casefold() != "bearer" or not token.strip():
+        raise TokenValidationError("Expected an Authorization header with the format: Bearer <token>.")
+    return token.strip()
+
+
+class EntraTokenValidator:
+    """Validate Entra-issued JWTs for the HITL webform."""
+
+    def __init__(self, tenant_id: str, client_id: str):
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.issuer = f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+        self.jwks_url = f"{self.issuer}/discovery/v2.0/keys"
+        self._jwks_client = PyJWKClient(self.jwks_url)
+
+    async def validate_token(self, token: str) -> TokenClaims:
+        """Validate a JWT signature, issuer, and audience through the tenant JWKS endpoint."""
+
+        try:
+            signing_key = await asyncio.to_thread(self._jwks_client.get_signing_key_from_jwt, token)
+            decoded = await asyncio.to_thread(
+                jwt.decode,
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=self.client_id,
+                issuer=self.issuer,
+                options={"require": ["exp", "iat", "nbf", "aud", "iss", "sub"]},
+            )
+        except InvalidTokenError as exc:
+            raise TokenValidationError("The Entra access token is invalid or expired.") from exc
+
+        email = self._resolve_email(decoded)
+        roles = self._coerce_roles(decoded.get("roles"))
+        return TokenClaims.model_validate(
+            {
+                **decoded,
+                "email": email,
+                "roles": roles,
+                "raw_claims": dict(decoded),
+            }
+        )
+
+    def require_role(self, claims: TokenClaims, role: str) -> bool:
+        """Return whether the validated token carries the required application role."""
+
+        required_role = role.casefold()
+        return any(existing_role.casefold() == required_role for existing_role in claims.roles)
+
+    def _resolve_email(self, decoded: Mapping[str, Any]) -> str:
+        for candidate_key in ("preferred_username", "email", "upn"):
+            candidate = decoded.get(candidate_key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip().casefold()
+        raise TokenValidationError("The Entra access token does not contain a usable reviewer email claim.")
+
+    def _coerce_roles(self, roles: Any) -> tuple[str, ...]:
+        if roles is None:
+            return ()
+        if isinstance(roles, str):
+            normalized_roles: Sequence[str] = [roles]
+        elif isinstance(roles, Sequence) and not isinstance(roles, (bytes, bytearray)):
+            normalized_roles = [str(role) for role in roles if str(role).strip()]
+        else:
+            raise TokenValidationError("The Entra access token contains an invalid roles claim.")
+        return tuple(role.strip() for role in normalized_roles if role.strip())

--- a/src/services/orchestrator/handler.py
+++ b/src/services/orchestrator/handler.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 from typing import Any
 
+from src.services.flow0_dedup.models import ForwardedExtractionMessage
+
 from .orchestration import OrchestrationError, OrchestrationRequest, OrchestrationResult, OrchestratorService
 
 
@@ -24,10 +26,37 @@ def deserialize_message(message: Any) -> OrchestrationRequest:
     else:
         payload = body
 
-    try:
-        return OrchestrationRequest.model_validate(payload)
-    except Exception as exc:  # pragma: no cover - defensive parsing path.
-        raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+    if isinstance(payload, dict) and "albaran_id" in payload:
+        try:
+            forwarded = ForwardedExtractionMessage.model_validate(payload)
+        except Exception as exc:  # pragma: no cover - defensive parsing path.
+            raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+    else:
+        try:
+            return OrchestrationRequest.model_validate(payload)
+        except Exception:
+            try:
+                forwarded = ForwardedExtractionMessage.model_validate(payload)
+            except Exception as exc:  # pragma: no cover - defensive parsing path.
+                raise QueueMessageError("Invalid Service Bus payload for orchestration.") from exc
+
+    metadata = dict(forwarded.metadata)
+    metadata.update(
+        {
+            "dedup_key": forwarded.dedup_key,
+            "blob_path": forwarded.blob_path,
+            "blob_name": forwarded.blob_name,
+            "blob_etag": forwarded.blob_etag,
+            "store_id": forwarded.store_id,
+            "event_id": forwarded.event_id,
+            "event_time": forwarded.event_time.isoformat(),
+        }
+    )
+    return OrchestrationRequest(
+        processing_id=forwarded.albaran_id,
+        blob_url=forwarded.blob_url,
+        metadata=metadata,
+    )
 
 
 async def handle_message(

--- a/src/services/orchestrator/orchestration.py
+++ b/src/services/orchestrator/orchestration.py
@@ -259,6 +259,8 @@ class OrchestratorService:
             return "completed"
         if routing_decision == "hitl_review":
             return "hitl_pending"
+        if routing_decision == "reject":
+            return "rejected"
         return "failed"
 
     def _get_optional_str(self, payload: dict[str, Any], key: str) -> str | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,13 +29,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     skip_integration = pytest.mark.skip(reason="need --run-integration option to run")
     skip_e2e = pytest.mark.skip(reason="need --run-e2e option to run")
-    run_integration = config.getoption("--run-integration")
-    run_e2e = config.getoption("--run-e2e")
+    invocation_args = [str(arg).replace("\\", "/") for arg in config.invocation_params.args]
+    explicit_integration_selection = any("tests/integration" in arg for arg in invocation_args)
+    explicit_e2e_selection = any("tests/e2e" in arg for arg in invocation_args)
+    run_integration = config.getoption("--run-integration") or explicit_integration_selection
+    run_e2e = config.getoption("--run-e2e") or explicit_e2e_selection
 
     for item in items:
         item_path = Path(str(item.path))
@@ -69,9 +70,7 @@ def bc_mcp_read_client(sample_po_data: dict[str, object]) -> SimpleNamespace:
     first_line = sample_po_data["purchaseLines"][0]
     return SimpleNamespace(
         get_purchase_order=AsyncMock(return_value=sample_po_data),
-        get_purchase_order_lines=AsyncMock(
-            return_value=sample_po_data["purchaseLines"]
-        ),
+        get_purchase_order_lines=AsyncMock(return_value=sample_po_data["purchaseLines"]),
         get_vendor=AsyncMock(
             return_value={
                 "number": sample_po_data["vendorNumber"],
@@ -90,16 +89,12 @@ def bc_mcp_read_client(sample_po_data: dict[str, object]) -> SimpleNamespace:
 @pytest.fixture()
 def bc_mcp_write_client() -> SimpleNamespace:
     return SimpleNamespace(
-        post_purchase_receipt=AsyncMock(
-            return_value={"status": "posted", "posted_receipt_id": "PR-2026-000123"}
-        )
+        post_purchase_receipt=AsyncMock(return_value={"status": "posted", "posted_receipt_id": "PR-2026-000123"})
     )
 
 
 @pytest.fixture()
-def bc_mcp_clients(
-    bc_mcp_read_client: SimpleNamespace, bc_mcp_write_client: SimpleNamespace
-) -> SimpleNamespace:
+def bc_mcp_clients(bc_mcp_read_client: SimpleNamespace, bc_mcp_write_client: SimpleNamespace) -> SimpleNamespace:
     return SimpleNamespace(read=bc_mcp_read_client, write=bc_mcp_write_client)
 
 
@@ -112,9 +107,7 @@ def cosmos_db_client(sample_albaran_data: dict[str, object]) -> SimpleNamespace:
         query_items=MagicMock(return_value=[sample_albaran_data]),
     )
     database = SimpleNamespace(get_container_client=MagicMock(return_value=container))
-    return SimpleNamespace(
-        get_database_client=MagicMock(return_value=database), close=AsyncMock()
-    )
+    return SimpleNamespace(get_database_client=MagicMock(return_value=database), close=AsyncMock())
 
 
 @pytest.fixture()

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test package for mocked pipeline scenarios."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,23 +1,162 @@
 from __future__ import annotations
 
-import os
+import json
+from collections.abc import AsyncIterator, Callable
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
+
+from src.agents.pipeline import AlbaranPipeline
+from src.services.flow0_dedup.dedup_handler import Flow0DedupHandler
+from src.services.orchestrator.config import OrchestratorConfig
+from src.services.orchestrator.orchestration import OrchestratorService
 
 pytestmark = pytest.mark.e2e
 
 
-def _e2e_enabled() -> bool:
-    return os.getenv("RUN_E2E_PIPELINE", "").lower() in {"1", "true", "yes", "on"}
+class FakeEvent:
+    def __init__(self, data: Any) -> None:
+        self.data = data
 
 
-@pytest.fixture(autouse=True)
-def skip_when_e2e_services_unavailable() -> None:
-    if not _e2e_enabled():
-        pytest.skip(
-            "E2E services unavailable. Set RUN_E2E_PIPELINE=1 to enable the pipeline skeleton."
+class FakeAsyncStream:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeWorkflow:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.payloads: list[Any] = []
+
+    def run(self, payload: Any, *, stream: bool) -> Any:
+        assert stream is True
+        self.payloads.append(payload)
+        return self.response
+
+
+class SharedCosmosStore:
+    def __init__(self) -> None:
+        self.items: dict[str, dict[str, Any]] = {}
+
+
+class SyncCosmosContainer:
+    def __init__(self, store: SharedCosmosStore) -> None:
+        self._store = store
+
+    def query_items(self, *, parameters: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
+        parameter_map = {parameter["name"]: parameter["value"] for parameter in parameters}
+        dedup_key = parameter_map.get("@dedup_key")
+        blob_name = parameter_map.get("@blob_name")
+        event_date = parameter_map.get("@event_date")
+        matches = [
+            item
+            for item in self._store.items.values()
+            if item.get("dedup_key") == dedup_key
+            or (item.get("blob_name") == blob_name and item.get("event_date") == event_date)
+        ]
+        return matches[:1]
+
+    def upsert_item(self, *, body: dict[str, Any]) -> dict[str, Any]:
+        self._store.items[str(body["id"])] = dict(body)
+        return dict(body)
+
+
+class AsyncCosmosContainer:
+    def __init__(self, store: SharedCosmosStore) -> None:
+        self._store = store
+
+    async def upsert_item(self, body: dict[str, Any]) -> dict[str, Any]:
+        self._store.items[str(body["id"])] = dict(body)
+        return dict(body)
+
+
+class FakeFlow0Sender:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_messages(self, message: Any) -> None:
+        body = b"".join(bytes(part) for part in message.body)
+        self.messages.append(json.loads(body.decode("utf-8")))
+
+
+class FakeQueueSender:
+    def __init__(self, queue_name: str, sent_messages: list[dict[str, Any]]) -> None:
+        self._queue_name = queue_name
+        self._sent_messages = sent_messages
+
+    async def __aenter__(self) -> "FakeQueueSender":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def send_messages(self, message: Any) -> None:
+        body = b"".join(bytes(part) for part in message.body)
+        self._sent_messages.append({"queue_name": self._queue_name, "payload": json.loads(body.decode("utf-8"))})
+
+
+class FakeAsyncServiceBusClient:
+    def __init__(self) -> None:
+        self.sent_messages: list[dict[str, Any]] = []
+
+    def get_queue_sender(self, *, queue_name: str) -> FakeQueueSender:
+        return FakeQueueSender(queue_name, self.sent_messages)
+
+
+class FakeDependencies:
+    def __init__(self, store: SharedCosmosStore, service_bus_client: FakeAsyncServiceBusClient) -> None:
+        self._container = AsyncCosmosContainer(store)
+        self._service_bus_client = service_bus_client
+
+    async def get_processing_container(self) -> AsyncCosmosContainer:
+        return self._container
+
+    def get_service_bus_client(self) -> FakeAsyncServiceBusClient:
+        return self._service_bus_client
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeReceivedMessage:
+    def __init__(self, payload: dict[str, Any], *, delivery_count: int = 1) -> None:
+        self.body = [json.dumps(payload).encode("utf-8")]
+        self.delivery_count = delivery_count
+
+
+class FakeReceiver:
+    def __init__(self) -> None:
+        self.completed_messages: list[FakeReceivedMessage] = []
+        self.abandoned_messages: list[FakeReceivedMessage] = []
+        self.dead_lettered_messages: list[dict[str, Any]] = []
+
+    async def complete_message(self, message: FakeReceivedMessage) -> None:
+        self.completed_messages.append(message)
+
+    async def abandon_message(self, message: FakeReceivedMessage) -> None:
+        self.abandoned_messages.append(message)
+
+    async def dead_letter_message(self, message: FakeReceivedMessage, *, reason: str, error_description: str) -> None:
+        self.dead_lettered_messages.append(
+            {"message": message, "reason": reason, "error_description": error_description}
         )
+
+
+def _to_workflow_response(response: Any) -> Any:
+    if isinstance(response, list):
+        return FakeAsyncStream([FakeEvent(item) for item in response])
+    return response
 
 
 @pytest.fixture(scope="session")
@@ -29,8 +168,8 @@ def full_pipeline_test_skeleton(
         "stages": [
             "blob-created-event",
             "flow-0-dedup",
-            "agent-a1-extraction",
-            "agent-a2-triage",
+            "agent-a1-triage",
+            "agent-a2-extraction",
             "agent-a3-coherence",
             "agent-a4-validator",
             "agent-a5-inventory",
@@ -41,5 +180,96 @@ def full_pipeline_test_skeleton(
             "albaran_id": sample_albaran_data["id"],
             "purchase_order": sample_po_data["number"],
         },
-        "expected_terminal_states": ["inventariado", "rechazado", "escalado"],
+        "expected_terminal_states": [
+            "inventariado",
+            "rechazado",
+            "escalado",
+            "completed",
+            "rejected",
+            "hitl_pending",
+        ],
     }
+
+
+@pytest.fixture()
+def sample_blob_event() -> dict[str, Any]:
+    return {
+        "id": "evt-e2e-001",
+        "eventType": "Microsoft.Storage.BlobCreated",
+        "subject": "/blobServices/default/containers/albaranes-raw/blobs/2026/05/tienda_007/albaran-herstera.pdf",
+        "eventTime": "2026-05-04T08:12:33Z",
+        "data": {
+            "eTag": '"0x8DEADBEEF"',
+            "contentType": "application/pdf",
+            "contentLength": 2048,
+            "url": "https://storage.blob.core.windows.net/albaranes-raw/2026/05/tienda_007/albaran-herstera.pdf",
+            "metadata": {"blob_hash": "hash-e2e-001", "source": "pytest"},
+        },
+    }
+
+
+@pytest.fixture()
+def ocr_payload() -> dict[str, Any]:
+    return {
+        "content": "ALBARAN DE ENTREGA HERSTERA PO-2026-0456",
+        "page_count": 1,
+        "tables": [{"row_count": 2, "column_count": 5}],
+        "key_value_pairs": [{"key": "purchase_order", "value": "PO-2026-0456", "confidence": 0.99}],
+    }
+
+
+@pytest.fixture()
+def cosmos_store() -> SharedCosmosStore:
+    return SharedCosmosStore()
+
+
+@pytest.fixture()
+def flow0_handler(cosmos_store: SharedCosmosStore) -> tuple[Flow0DedupHandler, FakeFlow0Sender]:
+    sender = FakeFlow0Sender()
+    handler = Flow0DedupHandler(SyncCosmosContainer(cosmos_store), sender)
+    return handler, sender
+
+
+@pytest.fixture()
+def fake_receiver() -> FakeReceiver:
+    return FakeReceiver()
+
+
+@pytest.fixture()
+def workflow_factory() -> Callable[[dict[str, Any]], tuple[dict[str, FakeWorkflow], Callable[..., FakeWorkflow]]]:
+    def _build(responses: dict[str, Any]) -> tuple[dict[str, FakeWorkflow], Callable[..., FakeWorkflow]]:
+        workflows = {name: FakeWorkflow(_to_workflow_response(response)) for name, response in responses.items()}
+
+        def fake_build_sequential_workflow(*, name: str, participants: list[Any]) -> FakeWorkflow:
+            assert participants
+            return workflows[name]
+
+        return workflows, fake_build_sequential_workflow
+
+    return _build
+
+
+@pytest.fixture()
+def orchestrator_factory(
+    cosmos_store: SharedCosmosStore, ocr_payload: dict[str, Any]
+) -> Callable[[], tuple[OrchestratorService, FakeAsyncServiceBusClient]]:
+    def _build() -> tuple[OrchestratorService, FakeAsyncServiceBusClient]:
+        config = OrchestratorConfig(service_bus_polling_enabled=False)
+        service = OrchestratorService(config=config, agent_client=object())
+        service_bus_client = FakeAsyncServiceBusClient()
+        service.dependencies = FakeDependencies(cosmos_store, service_bus_client)
+        service.pipeline = AlbaranPipeline(
+            client=object(),
+            agents={
+                "triage": object(),
+                "extractor": object(),
+                "coherence": object(),
+                "validator": object(),
+                "inventory": object(),
+            },
+        )
+        service.download_blob = AsyncMock(return_value=b"%PDF-1.7 mocked pdf bytes")
+        service.analyze_document = AsyncMock(return_value=ocr_payload)
+        return service, service_bus_client
+
+    return _build

--- a/tests/e2e/test_hitl_path_e2e.py
+++ b/tests/e2e/test_hitl_path_e2e.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_validation
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_hitl_path_e2e_stops_pipeline_and_notifies_hitl_queue(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    validation_result = sample_validation(overall_match_pct=0.88, recommendation="hitl_review")
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [sample_triage_result().model_dump(mode="json")],
+            "albaran-extraction": sample_extraction().model_dump(mode="json"),
+            "albaran-coherence": sample_coherence_result().model_dump(mode="json"),
+            "albaran-validation": validation_result.model_dump(mode="json"),
+        }
+    )
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.status == "hitl_pending"
+    assert result.routing_decision == "hitl_review"
+    assert result.pipeline_result["inventory"] is None
+    assert cosmos_store.items[result.processing_id]["status"] == "hitl_pending"
+    assert fake_receiver.completed_messages == [message]
+    assert len(service_bus_client.sent_messages) == 1
+    assert service_bus_client.sent_messages[0]["queue_name"] == orchestrator.config.hitl_queue_name
+    assert service_bus_client.sent_messages[0]["payload"]["processing_id"] == result.processing_id
+    assert workflows["albaran-validation"].payloads

--- a/tests/e2e/test_pipeline_e2e.py
+++ b/tests/e2e/test_pipeline_e2e.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_posting_result, sample_validation
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_pipeline_e2e_happy_path_updates_cosmos_and_preserves_agent_handoffs(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+    ocr_payload: dict[str, object],
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    triage_result = sample_triage_result()
+    extraction_result = sample_extraction()
+    coherence_result = sample_coherence_result()
+    validation_result = sample_validation(overall_match_pct=0.99, recommendation="approve")
+    posting_result = sample_posting_result(success=True)
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [triage_result.model_dump(mode="json")],
+            "albaran-extraction": extraction_result.model_dump(mode="json"),
+            "albaran-coherence": coherence_result.model_dump(mode="json"),
+            "albaran-validation": validation_result.model_dump(mode="json"),
+            "albaran-inventory": posting_result.model_dump(mode="json"),
+        }
+    )
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.processing_id == forwarded_payload["albaran_id"]
+    assert result.status == "completed"
+    assert result.routing_decision == "posted"
+    assert result.pipeline_result["inventory"]["receipt_number"] == posting_result.receipt_number
+    assert cosmos_store.items[result.processing_id]["status"] == "completed"
+    assert fake_receiver.completed_messages == [message]
+    assert not service_bus_client.sent_messages
+
+    assert workflows["albaran-triage"].payloads == [ocr_payload["content"]]
+    assert workflows["albaran-extraction"].payloads == [ocr_payload]
+    assert workflows["albaran-coherence"].payloads == [extraction_result.model_dump(mode="json")]
+    assert workflows["albaran-validation"].payloads == [
+        {
+            "extraction": extraction_result.model_dump(mode="json"),
+            "coherence": coherence_result.model_dump(mode="json"),
+        }
+    ]
+    assert workflows["albaran-inventory"].payloads == [
+        {
+            "validation": validation_result.model_dump(mode="json"),
+            "extraction": extraction_result.model_dump(mode="json"),
+        }
+    ]

--- a/tests/e2e/test_reject_path_e2e.py
+++ b/tests/e2e/test_reject_path_e2e.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.models import DocumentType
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_triage_result
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_reject_path_e2e_stops_after_triage_and_marks_record_rejected(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    rejected_triage = sample_triage_result(
+        document_type=DocumentType.UNKNOWN,
+        confidence=0.18,
+        routing_decision="reject",
+        reasoning="Documento desconocido; no corresponde a un albarán.",
+    )
+    workflows, fake_build = workflow_factory({"albaran-triage": [rejected_triage.model_dump(mode="json")]})
+    orchestrator, service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert result.status == "rejected"
+    assert result.routing_decision == "reject"
+    assert result.pipeline_result["extraction"] is None
+    assert result.pipeline_result["validation"] is None
+    assert cosmos_store.items[result.processing_id]["status"] == "rejected"
+    assert fake_receiver.completed_messages == [message]
+    assert workflows["albaran-triage"].payloads
+    assert not service_bus_client.sent_messages

--- a/tests/unit/services/hitl_webform/test_audit.py
+++ b/tests/unit/services/hitl_webform/test_audit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.services.hitl_webform.audit import AuditLogger, HITLDecision  # noqa: E402
+
+
+class FakeContainer:
+    def __init__(self) -> None:
+        self.documents: list[dict[str, object]] = []
+
+    async def upsert_item(self, body: dict[str, object]) -> None:
+        self.documents.append(body)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_log_decision_persists_structured_audit_record() -> None:
+    container = FakeContainer()
+    logger = AuditLogger(container_client=container)
+
+    await logger.log_decision(
+        HITLDecision(
+            albaran_id="ALB-001",
+            action="approve",
+            reviewer_email="Manager@Verdecora.es",
+            comment="Mercancía correcta",
+            store_id="MAD-001",
+        ),
+        reviewer_ip="10.0.0.5",
+        correlation_id="corr-001",
+    )
+
+    assert container.documents[0]["pk"] == "ALB-001"
+    assert container.documents[0]["eventType"] == "hitl.decision"
+    assert container.documents[0]["reviewerEmail"] == "manager@verdecora.es"
+    assert container.documents[0]["correlationId"] == "corr-001"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_log_pdf_access_persists_sas_access_audit_record() -> None:
+    container = FakeContainer()
+    logger = AuditLogger(container_client=container)
+
+    await logger.log_pdf_access("ALB-002", "Store.Manager@Verdecora.es", "corr-002")
+
+    assert container.documents[0]["eventType"] == "hitl.pdf_access"
+    assert container.documents[0]["userEmail"] == "store.manager@verdecora.es"
+    assert container.documents[0]["albaranId"] == "ALB-002"

--- a/tests/unit/services/hitl_webform/test_sas.py
+++ b/tests/unit/services/hitl_webform/test_sas.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.services.hitl_webform import sas  # noqa: E402
+
+
+@pytest.mark.unit
+def test_generate_pdf_sas_url_uses_user_delegation_key(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeBlobServiceClient:
+        def __init__(self, *, account_url: str, credential: object) -> None:
+            captured["account_url"] = account_url
+            captured["credential"] = credential
+            self.account_name = "stverdecora"
+
+        def get_blob_client(self, *, container: str, blob: str):
+            captured["blob_ref"] = (container, blob)
+            return type("BlobClient", (), {"url": f"https://stverdecora.blob.core.windows.net/{container}/{blob}"})()
+
+        def get_user_delegation_key(self, start, expiry):
+            captured["delegation_window"] = (start, expiry)
+            return "delegation-key"
+
+    class FakeBlobSasPermissions:
+        def __init__(self, *, read: bool) -> None:
+            captured["read_permission"] = read
+
+    def fake_generate_blob_sas(**kwargs: object) -> str:
+        captured["sas_kwargs"] = kwargs
+        return "sig=token"
+
+    credential = object()
+    monkeypatch.setattr(sas, "BlobServiceClient", FakeBlobServiceClient)
+    monkeypatch.setattr(sas, "BlobSasPermissions", FakeBlobSasPermissions)
+    monkeypatch.setattr(sas, "generate_blob_sas", fake_generate_blob_sas)
+    monkeypatch.setattr(sas, "get_managed_identity_credential", lambda: credential)
+
+    sas_url = sas.generate_pdf_sas_url(
+        "https://stverdecora.blob.core.windows.net",
+        "albaranes-raw",
+        "alb-001.pdf",
+    )
+
+    assert captured["account_url"] == "https://stverdecora.blob.core.windows.net"
+    assert captured["credential"] is credential
+    assert captured["blob_ref"] == ("albaranes-raw", "alb-001.pdf")
+    assert captured["read_permission"] is True
+    assert captured["sas_kwargs"]["user_delegation_key"] == "delegation-key"
+    assert sas_url.endswith("?sig=token")
+
+
+@pytest.mark.unit
+def test_generate_pdf_sas_url_rejects_non_positive_expiry() -> None:
+    with pytest.raises(ValueError):
+        sas.generate_pdf_sas_url("https://stverdecora.blob.core.windows.net", "albaranes-raw", "alb-001.pdf", 0)

--- a/tests/unit/services/hitl_webform/test_security.py
+++ b/tests/unit/services/hitl_webform/test_security.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.services.hitl_webform import security  # noqa: E402
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_token_uses_jwks_and_extracts_claims(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeSigningKey:
+        key = "signing-key"
+
+    class FakePyJWKClient:
+        def __init__(self, jwks_url: str) -> None:
+            captured["jwks_url"] = jwks_url
+
+        def get_signing_key_from_jwt(self, token: str) -> FakeSigningKey:
+            captured["token"] = token
+            return FakeSigningKey()
+
+    def fake_decode(
+        token: str,
+        key: str,
+        *,
+        algorithms: list[str],
+        audience: str,
+        issuer: str,
+        options: dict[str, object],
+    ) -> dict[str, object]:
+        captured["decoded_with"] = {
+            "token": token,
+            "key": key,
+            "algorithms": algorithms,
+            "audience": audience,
+            "issuer": issuer,
+            "options": options,
+        }
+        return {
+            "sub": "user-123",
+            "iss": issuer,
+            "aud": audience,
+            "preferred_username": "Encargado@Verdecora.es",
+            "roles": ["Verdecora.StoreManager", "Verdecora.Observer"],
+            "exp": 9999999999,
+            "iat": 1,
+            "nbf": 1,
+        }
+
+    monkeypatch.setattr(security, "PyJWKClient", FakePyJWKClient)
+    monkeypatch.setattr(security.jwt, "decode", fake_decode)
+
+    validator = security.EntraTokenValidator(tenant_id="tenant-id", client_id="client-id")
+    claims = await validator.validate_token("header.payload.signature")
+
+    assert captured["jwks_url"] == "https://login.microsoftonline.com/tenant-id/v2.0/discovery/v2.0/keys"
+    assert claims.email == "encargado@verdecora.es"
+    assert claims.roles == ("Verdecora.StoreManager", "Verdecora.Observer")
+    assert validator.require_role(claims, "verdecora.storemanager") is True
+
+
+@pytest.mark.unit
+def test_extract_bearer_token_requires_expected_header_format() -> None:
+    assert security.extract_bearer_token("Bearer signed.jwt") == "signed.jwt"
+
+    with pytest.raises(security.TokenValidationError):
+        security.extract_bearer_token("Basic abc123")


### PR DESCRIPTION
## Summary
- add ACS + Email Communication Service infrastructure with Azure-managed sender domain outputs
- add HITL token validation, audit logging, and User Delegation Key SAS helpers with unit coverage
- add Spanish user manual and update security/documentation references

## Validation
- python -m ruff check --fix src/ tests/
- python -m ruff format src/ tests/
- python -m pytest tests/unit/ -v
- az bicep build --file infra\\modules\\main.bicep
- az bicep build --file infra\\modules\\acs.bicep