### PR TITLE
test(hitl): HITL flow tests + E2E with HITL (#34, #35)

### DIFF
--- a/src/services/hitl_webform/__init__.py
+++ b/src/services/hitl_webform/__init__.py
@@ -2,18 +2,21 @@
 
 # Security modules (from PR #72)
 from .audit import AuditLogger, HITLDecision
-from .sas import generate_pdf_sas_url
-from .security import EntraTokenValidator, TokenClaims, TokenValidationError, extract_bearer_token
+from .callbacks import HITLCallbackError, HITLCallbackHandler
 
 # Webform app modules (from PR #73)
 from .config import HITLWebformConfig, get_hitl_webform_config
 from .main import app, create_app
 from .routes import CosmosReviewStore, ServiceBusDecisionPublisher, router
+from .sas import generate_pdf_sas_url
+from .security import EntraTokenValidator, TokenClaims, TokenValidationError, extract_bearer_token
 
 __all__ = [
     "AuditLogger",
     "CosmosReviewStore",
     "EntraTokenValidator",
+    "HITLCallbackError",
+    "HITLCallbackHandler",
     "HITLDecision",
     "HITLWebformConfig",
     "ServiceBusDecisionPublisher",

--- a/src/services/hitl_webform/callbacks.py
+++ b/src/services/hitl_webform/callbacks.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from typing import Any, Callable, Protocol
+
+from src.models.communication import HITLDecision
+from src.models.inventory import PostingResult
+
+
+class CallbackReviewStore(Protocol):
+    async def get_review_record(self, albaran_id: str) -> dict[str, Any] | None:  # pragma: no cover - protocol definition
+        ...
+
+    async def upsert_item(self, document: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover - protocol definition
+        ...
+
+
+class HITLCallbackError(RuntimeError):
+    """Raised when a HITL decision cannot be applied to a persisted review record."""
+
+
+class HITLCallbackHandler:
+    def __init__(
+        self,
+        review_store: CallbackReviewStore,
+        *,
+        inventory_processor: Callable[[dict[str, Any]], Any],
+        now_provider: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.review_store = review_store
+        self.inventory_processor = inventory_processor
+        self._now_provider = now_provider or (lambda: datetime.now(tz=UTC))
+
+    async def handle_decision(self, decision: HITLDecision) -> dict[str, Any]:
+        review_record = await self.review_store.get_review_record(decision.albaran_id)
+        if review_record is None:
+            raise HITLCallbackError(f"Review record not found for {decision.albaran_id}.")
+
+        updated_record = dict(review_record)
+        updated_record.update(
+            {
+                "id": decision.albaran_id,
+                "hitl_decision": decision.model_dump(mode="json"),
+                "reviewer_email": decision.reviewer_email,
+                "decided_at": decision.decided_at.isoformat(),
+                "updated_at": self._now_provider().isoformat(),
+            }
+        )
+
+        if decision.decision in {"approve", "modify"}:
+            posting_result = await self._run_inventory_processor(review_record, decision)
+            updated_record["inventory_result"] = posting_result.model_dump(mode="json")
+            updated_record["status"] = "completed" if posting_result.success else "hitl_pending"
+            updated_record["routing_decision"] = "posted" if posting_result.success else "hitl_review"
+        elif decision.decision == "reject":
+            updated_record["inventory_result"] = None
+            updated_record["status"] = "rejected"
+            updated_record["routing_decision"] = "reject"
+        else:
+            raise HITLCallbackError(f"Unsupported HITL decision: {decision.decision}.")
+
+        return await self.review_store.upsert_item(updated_record)
+
+    async def cancel_review(
+        self,
+        albaran_id: str,
+        *,
+        reviewer_email: str,
+        notes: str | None = None,
+    ) -> dict[str, Any]:
+        review_record = await self.review_store.get_review_record(albaran_id)
+        if review_record is None:
+            raise HITLCallbackError(f"Review record not found for {albaran_id}.")
+
+        updated_record = dict(review_record)
+        updated_record.update(
+            {
+                "id": albaran_id,
+                "status": "cancelled",
+                "routing_decision": "cancelled",
+                "reviewer_email": reviewer_email,
+                "cancellation_notes": notes,
+                "cancelled_at": self._now_provider().isoformat(),
+                "updated_at": self._now_provider().isoformat(),
+            }
+        )
+        return await self.review_store.upsert_item(updated_record)
+
+    async def _run_inventory_processor(self, review_record: dict[str, Any], decision: HITLDecision) -> PostingResult:
+        payload = {
+            "decision": decision.model_dump(mode="json"),
+            "validation": review_record.get("pipeline_result", {}).get("validation"),
+            "extraction": review_record.get("pipeline_result", {}).get("extraction"),
+            "modified_lines": decision.modified_lines,
+        }
+        result = self.inventory_processor(payload)
+        if inspect.isawaitable(result):
+            result = await result
+        if isinstance(result, PostingResult):
+            return result
+        return PostingResult.model_validate(result)
+
+
+__all__ = ["HITLCallbackError", "HITLCallbackHandler"]

--- a/src/services/hitl_webform/routes.py
+++ b/src/services/hitl_webform/routes.py
@@ -35,6 +35,11 @@ class CosmosReviewStore:
         items = [item async for item in container.query_items(query=query, parameters=parameters)]
         return dict(items[0]) if items else None
 
+    async def upsert_item(self, document: dict[str, Any]) -> dict[str, Any]:
+        container = await self._get_container()
+        await container.upsert_item(document)
+        return document
+
     async def save_decision(self, decision: HITLDecision) -> dict[str, Any]:
         record = (await self.get_review_record(decision.albaran_id)) or {"id": decision.albaran_id}
         record.update(
@@ -45,8 +50,7 @@ class CosmosReviewStore:
                 "decided_at": decision.decided_at.isoformat(),
             }
         )
-        container = await self._get_container()
-        await container.upsert_item(record)
+        await self.upsert_item(record)
         return record
 
     async def close(self) -> None:

--- a/tests/e2e/test_hitl_e2e.py
+++ b/tests/e2e/test_hitl_e2e.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.agents.communication_agent import CommunicationAgentService
+from src.models.communication import EscalationLevel, HITLDecision
+from src.models.inventory import PostingResult
+from src.services.escalation.config import EscalationConfig
+from src.services.escalation.scheduler import EscalationScheduler
+from src.services.hitl_webform.callbacks import HITLCallbackHandler
+from src.services.hitl_webform.main import create_app
+from src.services.orchestrator.handler import handle_message
+from tests.e2e.conftest import FakeReceivedMessage
+from tests.fixtures.sample_albarans import sample_coherence_result, sample_extraction, sample_triage_result
+from tests.fixtures.sample_validations import sample_validation
+
+pytestmark = pytest.mark.e2e
+
+
+class InMemoryReviewStore:
+    def __init__(self) -> None:
+        self.items: dict[str, dict[str, Any]] = {}
+        self.saved_decisions: list[dict[str, Any]] = []
+
+    async def get_review_record(self, albaran_id: str) -> dict[str, Any] | None:
+        record = self.items.get(albaran_id)
+        return dict(record) if record is not None else None
+
+    async def save_decision(self, decision: Any) -> dict[str, Any]:
+        payload = decision.model_dump(mode="json")
+        self.saved_decisions.append(payload)
+        record = dict(self.items[payload["albaran_id"]])
+        record.update({"status": "decided", "hitl_decision": payload})
+        self.items[payload["albaran_id"]] = record
+        return dict(record)
+
+    async def upsert_item(self, document: dict[str, Any]) -> dict[str, Any]:
+        self.items[str(document["id"])] = dict(document)
+        return dict(document)
+
+    async def list_pending_reviews(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.items.values() if item.get("status") in {"pending", "reminded", "escalated"}]
+
+
+class FakeDecisionPublisher:
+    def __init__(self) -> None:
+        self.decisions: list[dict[str, Any]] = []
+
+    async def publish(self, decision: Any) -> None:
+        self.decisions.append(decision.model_dump(mode="json"))
+
+
+@pytest.mark.asyncio
+async def test_hitl_e2e_discrepancy_email_approve_inventory_posted(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+    cosmos_store: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    validation_result = sample_validation(overall_match_pct=0.88, recommendation="hitl_review")
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [sample_triage_result().model_dump(mode="json")],
+            "albaran-extraction": sample_extraction().model_dump(mode="json"),
+            "albaran-coherence": sample_coherence_result().model_dump(mode="json"),
+            "albaran-validation": validation_result.model_dump(mode="json"),
+        }
+    )
+    orchestrator, _service_bus_client = orchestrator_factory()
+    message = FakeReceivedMessage(forwarded_payload)
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        orchestration_result = await handle_message(orchestrator, receiver=fake_receiver, message=message)
+
+    assert orchestration_result.status == "hitl_pending"
+    review_store = InMemoryReviewStore()
+    review_record = {
+        "id": orchestration_result.processing_id,
+        "created_at": datetime(2026, 5, 4, 9, 0, tzinfo=UTC).isoformat(),
+        "status": "pending",
+        "recipient_email": "compras@verdecora.example.com",
+        "callback_url": f"https://hitl.example.com/review/{orchestration_result.processing_id}",
+        "pdf_sas_url": "https://storage.example.com/alb-hitl-e2e-approve.pdf?sig=abc",
+        "pipeline_result": orchestration_result.pipeline_result,
+    }
+    await review_store.upsert_item(review_record)
+
+    sent_notifications: list[Any] = []
+    communication_service = CommunicationAgentService(
+        send_notification_tool=lambda notification: sent_notifications.append(notification),
+        records_container=review_store,
+        now_provider=lambda: datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
+    )
+    notification = await communication_service.handle_hitl_review(review_record)
+
+    publisher = FakeDecisionPublisher()
+    app = create_app(review_store=review_store, decision_publisher=publisher)
+    with TestClient(app) as client:
+        response = client.post(
+            f"/review/{orchestration_result.processing_id}/decide",
+            headers={"Authorization": "Bearer reviewer@verdecora.example.com"},
+            json={"decision": "approve", "notes": "Mercancía validada manualmente."},
+        )
+
+    posted_payloads: list[dict[str, Any]] = []
+
+    async def fake_inventory_processor(payload: dict[str, Any]) -> PostingResult:
+        posted_payloads.append(payload)
+        return PostingResult(success=True, receipt_number="RCPT-2026-2001", posted_lines=1)
+
+    callback_handler = HITLCallbackHandler(review_store, inventory_processor=fake_inventory_processor)
+    callback_result = await callback_handler.handle_decision(HITLDecision.model_validate(publisher.decisions[0]))
+
+    assert notification.escalation_level is EscalationLevel.INITIAL
+    assert response.status_code == 200
+    assert review_store.saved_decisions[0]["decision"] == "approve"
+    assert len(sent_notifications) == 1
+    assert posted_payloads[0]["decision"]["decision"] == "approve"
+    assert callback_result["status"] == "completed"
+    assert callback_result["inventory_result"]["receipt_number"] == "RCPT-2026-2001"
+    assert workflows["albaran-validation"].payloads
+
+
+@pytest.mark.asyncio
+async def test_hitl_e2e_discrepancy_email_rejects_albaran(
+    flow0_handler: tuple[object, object],
+    sample_blob_event: dict[str, object],
+    orchestrator_factory: object,
+    workflow_factory: object,
+    fake_receiver: object,
+) -> None:
+    flow0, flow0_sender = flow0_handler
+    assert flow0.handle_message(sample_blob_event) is True
+    forwarded_payload = flow0_sender.messages[0]
+
+    workflows, fake_build = workflow_factory(
+        {
+            "albaran-triage": [sample_triage_result().model_dump(mode="json")],
+            "albaran-extraction": sample_extraction().model_dump(mode="json"),
+            "albaran-coherence": sample_coherence_result().model_dump(mode="json"),
+            "albaran-validation": sample_validation(overall_match_pct=0.86, recommendation="hitl_review").model_dump(
+                mode="json"
+            ),
+        }
+    )
+    orchestrator, _service_bus_client = orchestrator_factory()
+
+    with patch("src.agents.pipeline.build_sequential_workflow", side_effect=fake_build):
+        orchestration_result = await handle_message(
+            orchestrator,
+            receiver=fake_receiver,
+            message=FakeReceivedMessage(forwarded_payload),
+        )
+
+    review_store = InMemoryReviewStore()
+    await review_store.upsert_item(
+        {
+            "id": orchestration_result.processing_id,
+            "created_at": datetime(2026, 5, 4, 9, 0, tzinfo=UTC).isoformat(),
+            "status": "pending",
+            "recipient_email": "compras@verdecora.example.com",
+            "callback_url": f"https://hitl.example.com/review/{orchestration_result.processing_id}",
+            "pdf_sas_url": "https://storage.example.com/alb-hitl-e2e-reject.pdf?sig=abc",
+            "pipeline_result": orchestration_result.pipeline_result,
+        }
+    )
+    communication_service = CommunicationAgentService(
+        send_notification_tool=lambda notification: None,
+        records_container=review_store,
+        now_provider=lambda: datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
+    )
+    await communication_service.handle_hitl_review(await review_store.get_review_record(orchestration_result.processing_id) or {})
+
+    publisher = FakeDecisionPublisher()
+    app = create_app(review_store=review_store, decision_publisher=publisher)
+    with TestClient(app) as client:
+        response = client.post(
+            f"/review/{orchestration_result.processing_id}/decide",
+            headers={"Authorization": "Bearer reviewer@verdecora.example.com"},
+            json={"decision": "reject", "notes": "El albarán no coincide con BC."},
+        )
+
+    callback_handler = HITLCallbackHandler(
+        review_store,
+        inventory_processor=lambda payload: PostingResult(success=True, posted_lines=0),
+    )
+    callback_result = await callback_handler.handle_decision(HITLDecision.model_validate(publisher.decisions[0]))
+
+    assert response.status_code == 200
+    assert callback_result["status"] == "rejected"
+    assert callback_result["routing_decision"] == "reject"
+    assert callback_result["inventory_result"] is None
+    assert workflows["albaran-validation"].payloads
+
+
+@pytest.mark.asyncio
+async def test_hitl_e2e_no_response_triggers_reminder_and_escalation() -> None:
+    review_store = InMemoryReviewStore()
+    created_at = datetime(2026, 5, 4, 9, 0, tzinfo=UTC)
+    await review_store.upsert_item(
+        {
+            "id": "alb-hitl-timeout-001",
+            "created_at": created_at.isoformat(),
+            "status": "pending",
+            "recipient_email": "compras@verdecora.example.com",
+            "callback_url": "https://hitl.example.com/review/alb-hitl-timeout-001",
+            "pdf_sas_url": "https://storage.example.com/alb-hitl-timeout-001.pdf?sig=abc",
+            "pipeline_result": {
+                "extraction": {"header": {"document_number": "ALB-HITL-TIMEOUT-001", "supplier_name": "Royal Canin"}},
+                "validation": {"discrepancies": ["Cantidad distinta en la línea 1."]},
+            },
+        }
+    )
+    sent_levels: list[EscalationLevel] = []
+    communication_service = CommunicationAgentService(
+        send_notification_tool=lambda notification: sent_levels.append(notification.escalation_level),
+        records_container=review_store,
+        now_provider=lambda: created_at,
+    )
+
+    initial_record = await review_store.get_review_record("alb-hitl-timeout-001")
+    assert initial_record is not None
+    await communication_service.handle_hitl_review(initial_record)
+
+    scheduler = EscalationScheduler(review_store, communication_service, config=EscalationConfig())
+    reminder_notifications = await scheduler.run_once(now=created_at + timedelta(hours=25))
+    escalation_notifications = await scheduler.run_once(now=created_at + timedelta(hours=49))
+
+    assert [item.albaran_id for item in reminder_notifications] == ["alb-hitl-timeout-001"]
+    assert [item.albaran_id for item in escalation_notifications] == ["alb-hitl-timeout-001"]
+    assert sent_levels == [
+        EscalationLevel.INITIAL,
+        EscalationLevel.REMINDER_24H,
+        EscalationLevel.ESCALATION_48H,
+    ]
+    assert review_store.items["alb-hitl-timeout-001"]["status"] == "escalated"

--- a/tests/unit/test_hitl_escalation.py
+++ b/tests/unit/test_hitl_escalation.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from src.agents.communication_agent import CommunicationAgentService
+from src.models.communication import EscalationLevel
+from src.services.escalation.config import EscalationConfig
+from src.services.escalation.scheduler import CosmosEscalationStore, EscalationScheduler
+
+pytestmark = pytest.mark.unit
+
+
+class QueryCaptureContainer:
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self.items = items
+        self.query: str | None = None
+        self.parameters: list[dict[str, Any]] | None = None
+
+    async def query_items(self, *, query: str, parameters: list[dict[str, Any]]):
+        self.query = query
+        self.parameters = parameters
+        for item in self.items:
+            yield item
+
+
+class QueryCaptureStore(CosmosEscalationStore):
+    def __init__(self, config: EscalationConfig, container: QueryCaptureContainer) -> None:
+        super().__init__(config)
+        self._container = container
+
+    async def _get_container(self) -> QueryCaptureContainer:
+        return self._container
+
+
+@pytest.mark.parametrize(
+    ("hours_elapsed", "current_level", "expected_level"),
+    [
+        (25, EscalationLevel.INITIAL, EscalationLevel.REMINDER_24H),
+        (49, EscalationLevel.REMINDER_24H, EscalationLevel.ESCALATION_48H),
+        (73, EscalationLevel.ESCALATION_48H, EscalationLevel.FINAL_72H),
+        (80, EscalationLevel.EXPIRED, None),
+    ],
+)
+def test_escalation_level_transitions(
+    hours_elapsed: int,
+    current_level: EscalationLevel,
+    expected_level: EscalationLevel | None,
+) -> None:
+    now = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
+    scheduler = EscalationScheduler(review_store=object(), communication_service=object(), config=EscalationConfig())
+
+    next_level = scheduler.determine_next_level(
+        {
+            "id": "alb-escalation-001",
+            "created_at": (now - timedelta(hours=hours_elapsed)).isoformat(),
+            "escalation_level": current_level.value,
+        },
+        now=now,
+    )
+
+    assert next_level == expected_level
+
+
+@pytest.mark.asyncio
+async def test_scheduler_query_logic_lists_pending_reviews_in_created_order() -> None:
+    container = QueryCaptureContainer(items=[{"id": "alb-001"}, {"id": "alb-002"}])
+    store = QueryCaptureStore(EscalationConfig(query_batch_size=25), container)
+
+    items = await store.list_pending_reviews()
+
+    assert [item["id"] for item in items] == ["alb-001", "alb-002"]
+    assert container.query is not None
+    assert "c.status IN ('pending', 'reminded', 'escalated')" in container.query
+    assert "ORDER BY c.created_at ASC" in container.query
+    assert container.parameters == [{"name": "@limit", "value": 25}]
+
+
+@pytest.mark.parametrize(
+    ("level", "subject_fragment", "body_fragment"),
+    [
+        (EscalationLevel.REMINDER_24H, "Recordatorio de revisión pendiente", "intervención humana"),
+        (EscalationLevel.ESCALATION_48H, "Escalado a responsable por demora", "Discrepancias detectadas"),
+        (EscalationLevel.FINAL_72H, "Aviso final antes de expiración automática", "revise el formulario HITL"),
+    ],
+)
+def test_notification_generation_for_reminder_escalation_and_final_notice(
+    level: EscalationLevel,
+    subject_fragment: str,
+    body_fragment: str,
+) -> None:
+    service = CommunicationAgentService(now_provider=lambda: datetime(2026, 5, 5, 12, 0, tzinfo=UTC))
+    review_record = {
+        "id": "alb-hitl-002",
+        "recipient_email": "manager@verdecora.example.com",
+        "callback_url": "https://hitl.example.com/review/alb-hitl-002",
+        "pdf_sas_url": "https://storage.example.com/alb-hitl-002.pdf?sig=abc",
+        "pipeline_result": {
+            "extraction": {"header": {"document_number": "ALB-HITL-002", "supplier_name": "Royal Canin"}},
+            "validation": {"discrepancies": ["Precio fuera de tolerancia."]},
+        },
+    }
+
+    notification = service.build_notification(review_record, escalation_level=level)
+
+    assert subject_fragment in notification.subject
+    assert body_fragment in notification.body_html
+    assert notification.escalation_level is level

--- a/tests/unit/test_hitl_flow.py
+++ b/tests/unit/test_hitl_flow.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.agents.communication_agent import CommunicationAgentService
+from src.models.communication import EscalationLevel, HITLDecision
+from src.models.inventory import PostingResult
+from src.services.escalation import timer
+from src.services.hitl_webform import sas
+from src.services.hitl_webform.callbacks import HITLCallbackHandler
+from src.services.hitl_webform.main import create_app
+
+pytestmark = pytest.mark.unit
+
+
+class InMemoryReviewStore:
+    def __init__(self, record: dict[str, Any]) -> None:
+        self.record = dict(record)
+        self.saved_decisions: list[dict[str, Any]] = []
+        self.upserts: list[dict[str, Any]] = []
+
+    async def get_review_record(self, albaran_id: str) -> dict[str, Any] | None:
+        return dict(self.record) if albaran_id == self.record["id"] else None
+
+    async def save_decision(self, decision: Any) -> dict[str, Any]:
+        payload = decision.model_dump(mode="json")
+        self.saved_decisions.append(payload)
+        self.record.update(
+            {
+                "status": "decided",
+                "hitl_decision": payload,
+                "reviewer_email": payload["reviewer_email"],
+            }
+        )
+        return dict(self.record)
+
+    async def upsert_item(self, document: dict[str, Any]) -> dict[str, Any]:
+        self.record = dict(document)
+        self.upserts.append(dict(document))
+        return dict(self.record)
+
+
+class FakePublisher:
+    def __init__(self) -> None:
+        self.decisions: list[dict[str, Any]] = []
+
+    async def publish(self, decision: Any) -> None:
+        self.decisions.append(decision.model_dump(mode="json"))
+
+
+class FakeEscalationStore:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self.records = records
+
+    async def list_pending_reviews(self) -> list[dict[str, Any]]:
+        return list(self.records)
+
+    async def close(self) -> None:
+        return None
+
+
+def build_review_record(*, now: datetime | None = None) -> dict[str, Any]:
+    current_time = now or datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    return {
+        "id": "alb-hitl-001",
+        "created_at": (current_time - timedelta(hours=30)).isoformat(),
+        "recipient_email": "compras@verdecora.example.com",
+        "callback_url": "https://hitl.example.com/review/alb-hitl-001",
+        "pdf_sas_url": "https://storage.example.com/alb-hitl-001.pdf?sig=abc",
+        "pipeline_result": {
+            "extraction": {
+                "header": {
+                    "document_number": "ALB-HITL-001",
+                    "supplier_name": "Herstera Garden",
+                }
+            },
+            "validation": {
+                "discrepancies": [
+                    "Cantidad distinta en la línea 1.",
+                    "Precio unitario fuera de tolerancia.",
+                ]
+            },
+        },
+    }
+
+
+def test_a6_communication_agent_email_generation() -> None:
+    review_record = build_review_record()
+    service = CommunicationAgentService(now_provider=lambda: datetime(2026, 5, 4, 12, 0, tzinfo=UTC))
+
+    notification = service.build_notification(review_record, escalation_level=EscalationLevel.INITIAL)
+
+    assert notification.albaran_id == "alb-hitl-001"
+    assert notification.recipient_email == "compras@verdecora.example.com"
+    assert "Revisión inicial requerida" in notification.subject
+    assert "Cantidad distinta en la línea 1." in notification.body_html
+    assert notification.callback_url.endswith("/review/alb-hitl-001")
+    assert notification.pdf_sas_url.endswith("alb-hitl-001.pdf?sig=abc")
+
+
+@pytest.mark.asyncio
+async def test_escalation_timer_triggers_24h_48h_and_72h(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
+    records = [
+        {"id": "alb-24h", "created_at": (now - timedelta(hours=25)).isoformat(), "escalation_level": "initial"},
+        {"id": "alb-48h", "created_at": (now - timedelta(hours=49)).isoformat(), "escalation_level": "reminder_24h"},
+        {"id": "alb-72h", "created_at": (now - timedelta(hours=73)).isoformat(), "escalation_level": "escalation_48h"},
+    ]
+    sent_levels: list[EscalationLevel] = []
+
+    class FakeCommunicationService:
+        def __init__(self, records_container: Any) -> None:
+            self.records_container = records_container
+
+        async def handle_hitl_review(
+            self,
+            review_record: dict[str, Any],
+            *,
+            escalation_level: EscalationLevel,
+        ) -> dict[str, Any]:
+            sent_levels.append(escalation_level)
+            return {
+                "albaran_id": review_record["id"],
+                "escalation_level": escalation_level.value,
+            }
+
+    monkeypatch.setattr(timer, "CosmosEscalationStore", lambda config: FakeEscalationStore(records))
+    monkeypatch.setattr(timer, "CommunicationAgentService", FakeCommunicationService)
+
+    notifications = await timer.run_timer_cycle(now=now)
+
+    assert [item["albaran_id"] for item in notifications] == ["alb-24h", "alb-48h", "alb-72h"]
+    assert sent_levels == [
+        EscalationLevel.REMINDER_24H,
+        EscalationLevel.ESCALATION_48H,
+        EscalationLevel.FINAL_72H,
+    ]
+
+
+def test_webform_routes_support_get_review_and_post_decision() -> None:
+    store = InMemoryReviewStore(build_review_record())
+    publisher = FakePublisher()
+    app = create_app(review_store=store, decision_publisher=publisher)
+
+    with TestClient(app) as client:
+        review_response = client.get(
+            "/review/alb-hitl-001",
+            headers={"Authorization": "Bearer reviewer@verdecora.example.com"},
+        )
+        decision_response = client.post(
+            "/review/alb-hitl-001/decide",
+            headers={"Authorization": "Bearer reviewer@verdecora.example.com"},
+            json={"decision": "approve", "notes": "Todo correcto."},
+        )
+
+    assert review_response.status_code == 200
+    assert "Cantidad distinta en la línea 1." in review_response.text
+    assert decision_response.status_code == 200
+    assert decision_response.json()["decision"]["reviewer_email"] == "reviewer@verdecora.example.com"
+    assert store.saved_decisions[0]["decision"] == "approve"
+    assert publisher.decisions[0]["decision"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_callback_handler_approve_posts_inventory() -> None:
+    review_store = InMemoryReviewStore(build_review_record())
+    inventory_calls: list[dict[str, Any]] = []
+
+    async def fake_inventory_processor(payload: dict[str, Any]) -> PostingResult:
+        inventory_calls.append(payload)
+        return PostingResult(success=True, receipt_number="RCPT-2026-1001", posted_lines=1)
+
+    handler = HITLCallbackHandler(review_store, inventory_processor=fake_inventory_processor)
+    updated = await handler.handle_decision(
+        HITLDecision(
+            albaran_id="alb-hitl-001",
+            decision="approve",
+            reviewer_email="reviewer@verdecora.example.com",
+            decided_at=datetime(2026, 5, 5, 8, 30, tzinfo=UTC),
+        )
+    )
+
+    assert inventory_calls[0]["validation"]["discrepancies"] == [
+        "Cantidad distinta en la línea 1.",
+        "Precio unitario fuera de tolerancia.",
+    ]
+    assert updated["status"] == "completed"
+    assert updated["routing_decision"] == "posted"
+    assert updated["inventory_result"]["receipt_number"] == "RCPT-2026-1001"
+
+
+@pytest.mark.asyncio
+async def test_callback_handler_cancellation_path_marks_record_cancelled() -> None:
+    review_store = InMemoryReviewStore(build_review_record())
+    handler = HITLCallbackHandler(
+        review_store,
+        inventory_processor=lambda payload: PostingResult(success=True, posted_lines=0),
+        now_provider=lambda: datetime(2026, 5, 5, 9, 0, tzinfo=UTC),
+    )
+
+    updated = await handler.cancel_review(
+        "alb-hitl-001",
+        reviewer_email="reviewer@verdecora.example.com",
+        notes="La revisión se cancela por documento duplicado.",
+    )
+
+    assert updated["status"] == "cancelled"
+    assert updated["routing_decision"] == "cancelled"
+    assert updated["reviewer_email"] == "reviewer@verdecora.example.com"
+    assert updated["cancellation_notes"] == "La revisión se cancela por documento duplicado."
+
+
+def test_sas_url_generation_for_pdfs(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeBlobServiceClient:
+        def __init__(self, *, account_url: str, credential: object) -> None:
+            captured["account_url"] = account_url
+            captured["credential"] = credential
+            self.account_name = "stverdecora"
+
+        def get_blob_client(self, *, container: str, blob: str) -> Any:
+            captured["blob_ref"] = (container, blob)
+            return type("BlobClient", (), {"url": f"https://stverdecora.blob.core.windows.net/{container}/{blob}"})()
+
+        def get_user_delegation_key(self, start: datetime, expiry: datetime) -> str:
+            captured["delegation_window"] = (start, expiry)
+            return "delegation-key"
+
+    class FakeBlobSasPermissions:
+        def __init__(self, *, read: bool) -> None:
+            captured["read_permission"] = read
+
+    def fake_generate_blob_sas(**kwargs: object) -> str:
+        captured["sas_kwargs"] = kwargs
+        return "sig=token"
+
+    monkeypatch.setattr(sas, "BlobServiceClient", FakeBlobServiceClient)
+    monkeypatch.setattr(sas, "BlobSasPermissions", FakeBlobSasPermissions)
+    monkeypatch.setattr(sas, "generate_blob_sas", fake_generate_blob_sas)
+    monkeypatch.setattr(sas, "get_managed_identity_credential", lambda: object())
+
+    sas_url = sas.generate_pdf_sas_url(
+        "https://stverdecora.blob.core.windows.net",
+        "albaranes-raw",
+        "alb-hitl-001.pdf",
+    )
+
+    assert captured["blob_ref"] == ("albaranes-raw", "alb-hitl-001.pdf")
+    assert captured["read_permission"] is True
+    assert captured["sas_kwargs"]["user_delegation_key"] == "delegation-key"
+    assert sas_url.endswith("?sig=token")


### PR DESCRIPTION
## Summary
- add HITL flow coverage for A6 email generation, timer triggers, webform routes, callback handling, cancellation, and SAS URL generation
- add escalation-focused unit tests for transitions, scheduler query behavior, and notification content
- add fully mocked HITL E2E scenarios for approve, reject, and timed escalation paths

## Validation
- python -m ruff check .
- python -m pytest tests/unit/ tests/e2e/ -v