### PR TITLE
feat(ops): observability dashboards + alerting rules (#43, #44)

### DIFF
--- a/docs/operations/dashboards.md
+++ b/docs/operations/dashboards.md
@@ -1,0 +1,115 @@
+# Observability dashboards
+
+## Objetivo
+
+`infra/dashboards/overview-workbook.json` despliega un Azure Workbook operativo para seguir el flujo de albaranes, la salud de los agentes A1-A6 y la carga pendiente de HITL.
+
+El workbook está pensado para el entorno `rg-verdecoratest-dev` en `swedencentral`, usando Application Insights + Log Analytics ya definidos en `infra/modules/monitoring.bicep`.
+
+## Qué incluye el workbook
+
+- Volumen de procesamiento de albaranes por hora
+- Volumen de procesamiento de albaranes por día
+- Ratio de éxito, fallo y derivación a HITL
+- Desglose de latencia por agente (A1-A6)
+- Tipos de error más frecuentes
+- Revisiones HITL pendientes activas
+
+## Cómo desplegar el workbook
+
+### Opción 1: despliegue con ARM
+
+```powershell
+$resourceGroup = 'rg-verdecoratest-dev'
+$workspaceId = az monitor log-analytics workspace show `
+  --resource-group $resourceGroup `
+  --workspace-name log-albaranes-dev `
+  --query id -o tsv
+
+$appInsightsId = az monitor app-insights component show `
+  --app appi-albaranes-dev `
+  --resource-group $resourceGroup `
+  --query id -o tsv
+
+az deployment group create `
+  --resource-group $resourceGroup `
+  --template-file infra\dashboards\overview-workbook.json `
+  --parameters workbookDisplayName='Verdecora - Observabilidad general' `
+               workbookSourceId=$workspaceId `
+               logAnalyticsWorkspaceId=$workspaceId `
+               appInsightsComponentId=$appInsightsId
+```
+
+### Opción 2: importación manual desde Azure Portal
+
+1. Azure Portal → **Monitor** → **Workbooks**.
+2. Selecciona **+ New** → **Advanced Editor**.
+3. Copia el bloque `serializedData` generado por el template o despliega primero el ARM.
+4. Guarda el workbook con el nombre del entorno (`Verdecora - Observabilidad general`).
+
+## Suposiciones de telemetría
+
+Las consultas esperan dimensiones alineadas con la arquitectura actual:
+
+- `albaran_id` o `albaranId` para correlación de documentos
+- `result` / `routing_decision` para éxito, error o HITL
+- `agent_name` / `agent_id` para A1-A6
+- `error_type` para clasificar incidencias
+- `review_status` para elementos HITL pendientes
+
+Si la instrumentación usa otros nombres, ajusta las consultas KQL del workbook antes de publicarlo.
+
+## KQL de referencia
+
+### 1. Albarán processing timeline
+
+```kusto
+AppEvents
+| where TimeGenerated >= ago(24h)
+| extend dims = column_ifexists("Properties", dynamic({}))
+| extend albaranId = coalesce(tostring(dims["albaran_id"]), tostring(dims["albaranId"]), OperationId)
+| summarize Procesados = dcount(albaranId) by bin(TimeGenerated, 1h)
+| order by TimeGenerated asc
+```
+
+### 2. Agent performance breakdown
+
+```kusto
+AppDependencies
+| where TimeGenerated >= ago(24h)
+| extend dims = column_ifexists("Properties", dynamic({}))
+| extend agentName = coalesce(tostring(dims["agent_name"]), tostring(dims["agent_id"]), Name)
+| where agentName has_any ("A1", "A2", "A3", "A4", "A5", "A6", "extractor", "triage", "coherence", "validator", "inventory", "communication")
+| summarize P50_ms = percentile(DurationMs, 50), P95_ms = percentile(DurationMs, 95), Total = count() by agentName
+| order by P95_ms desc
+```
+
+### 3. Error investigation
+
+```kusto
+AppTraces
+| where TimeGenerated >= ago(6h)
+| where SeverityLevel >= 3
+| extend dims = column_ifexists("Properties", dynamic({}))
+| extend errorType = coalesce(tostring(dims["error_type"]), tostring(dims["exception_type"]), Message)
+| summarize Eventos = count() by errorType
+| top 20 by Eventos desc
+```
+
+### 4. HITL backlog monitoring
+
+```kusto
+AppEvents
+| where TimeGenerated >= ago(7d)
+| extend dims = column_ifexists("Properties", dynamic({}))
+| extend reviewStatus = coalesce(tostring(dims["review_status"]), tostring(dims["status"]), Name)
+| extend createdAt = todatetime(coalesce(tostring(dims["created_at"]), tostring(dims["createdAt"]), TimeGenerated))
+| where reviewStatus in ("pending", "reminded", "escalated")
+| summarize Pendientes = count(), MasAntiguo = min(createdAt)
+```
+
+## Recomendaciones operativas
+
+- Publica el workbook en cada entorno (`dev`, `test`, `prod`) con el prefijo del entorno.
+- Revisa semanalmente si las dimensiones de telemetría siguen alineadas con los nombres usados por las apps.
+- Usa este workbook junto con `infra/modules/alerts.bicep`: el dashboard sirve para diagnóstico, las alertas para reacción temprana.

--- a/infra/dashboards/overview-workbook.json
+++ b/infra/dashboards/overview-workbook.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "swedencentral",
+      "metadata": {
+        "description": "Azure region where the workbook resource will be stored."
+      }
+    },
+    "workbookDisplayName": {
+      "type": "string",
+      "defaultValue": "Verdecora - Observabilidad general",
+      "metadata": {
+        "description": "Workbook display name shown in Azure Monitor."
+      }
+    },
+    "workbookSourceId": {
+      "type": "string",
+      "defaultValue": "Azure Monitor",
+      "metadata": {
+        "description": "Primary resource id associated to the workbook (typically the Log Analytics workspace id)."
+      }
+    },
+    "logAnalyticsWorkspaceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Log Analytics workspace id used by workbook KQL queries."
+      }
+    },
+    "appInsightsComponentId": {
+      "type": "string",
+      "metadata": {
+        "description": "Application Insights component id used as a fallback data source."
+      }
+    }
+  },
+  "variables": {
+    "workbookResourceName": "[guid(resourceGroup().id, parameters('workbookDisplayName'))]",
+    "workbookDefinition": {
+      "version": "Notebook/1.0",
+      "isLocked": false,
+      "fallbackResourceIds": [
+        "[parameters('workbookSourceId')]",
+        "[parameters('logAnalyticsWorkspaceId')]",
+        "[parameters('appInsightsComponentId')]"
+      ],
+      "items": [
+        {
+          "name": "title",
+          "type": 1,
+          "content": {
+            "json": "# Verdecora · Observabilidad operativa\n\nSeguimiento de volumen, éxito, errores, latencia de agentes y backlog HITL para el flujo de albaranes."
+          }
+        },
+        {
+          "name": "processing-volume-hourly",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppEvents\n| where TimeGenerated >= ago(24h)\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend albaranId = coalesce(tostring(dims[\"albaran_id\"]), tostring(dims[\"albaranId\"]), OperationId)\n| summarize Albaranes = dcount(albaranId) by bin(TimeGenerated, 1h)\n| order by TimeGenerated asc",
+            "size": 0,
+            "title": "Albaranes procesados por hora",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "timechart"
+          }
+        },
+        {
+          "name": "processing-volume-daily",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppEvents\n| where TimeGenerated >= ago(14d)\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend albaranId = coalesce(tostring(dims[\"albaran_id\"]), tostring(dims[\"albaranId\"]), OperationId)\n| summarize Albaranes = dcount(albaranId) by bin(TimeGenerated, 1d)\n| order by TimeGenerated asc",
+            "size": 0,
+            "title": "Albaranes procesados por día",
+            "timeContext": {
+              "durationMs": 1209600000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "barchart"
+          }
+        },
+        {
+          "name": "success-rates",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppEvents\n| where TimeGenerated >= ago(24h)\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend result = coalesce(tostring(dims[\"result\"]), tostring(dims[\"routing_decision\"]), Name)\n| extend Resultado = case(result in (\"approve\", \"posted\", \"success\"), \"Éxito\", result in (\"hitl_review\", \"pending_hitl\", \"manual_review\"), \"HITL\", \"Fallo\")\n| summarize Eventos = count() by Resultado",
+            "size": 0,
+            "title": "Ratio de éxito, fallo y HITL",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "piechart"
+          }
+        },
+        {
+          "name": "agent-latency",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppDependencies\n| where TimeGenerated >= ago(24h)\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend customDimensions = column_ifexists(\"CustomDimensions\", dynamic({}))\n| extend agentName = coalesce(tostring(customDimensions[\"agent_name\"]), tostring(customDimensions[\"agent_id\"]), tostring(dims[\"agent_name\"]), tostring(dims[\"agent_id\"]), Name)\n| where agentName has_any (\"A1\", \"A2\", \"A3\", \"A4\", \"A5\", \"A6\", \"extractor\", \"triage\", \"coherence\", \"validator\", \"inventory\", \"communication\")\n| summarize Avg_ms = avg(DurationMs), P95_ms = percentile(DurationMs, 95), Total = count() by agentName\n| order by P95_ms desc",
+            "size": 0,
+            "title": "Latencia por agente (A1-A6)",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "table"
+          }
+        },
+        {
+          "name": "top-errors",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppTraces\n| where TimeGenerated >= ago(24h)\n| where SeverityLevel >= 3\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend ErrorType = coalesce(tostring(dims[\"error_type\"]), tostring(dims[\"exception_type\"]), Message)\n| summarize Errores = count() by ErrorType\n| top 10 by Errores desc",
+            "size": 0,
+            "title": "Top tipos de error",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "table"
+          }
+        },
+        {
+          "name": "hitl-backlog",
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "AppEvents\n| where TimeGenerated >= ago(7d)\n| extend dims = column_ifexists(\"Properties\", dynamic({}))\n| extend reviewStatus = coalesce(tostring(dims[\"review_status\"]), tostring(dims[\"status\"]), Name)\n| extend createdAt = todatetime(coalesce(tostring(dims[\"created_at\"]), tostring(dims[\"createdAt\"]), TimeGenerated))\n| where reviewStatus in (\"pending\", \"reminded\", \"escalated\")\n| summarize Pendientes = count(), MasAntiguo = min(createdAt)",
+            "size": 0,
+            "title": "Revisiones HITL pendientes activas",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "resourceIds": [
+              "[parameters('logAnalyticsWorkspaceId')]"
+            ],
+            "visualization": "table"
+          }
+        }
+      ]
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/workbooks",
+      "apiVersion": "2023-06-01",
+      "name": "[variables('workbookResourceName')]",
+      "location": "[parameters('location')]",
+      "kind": "shared",
+      "properties": {
+        "category": "workbook",
+        "displayName": "[parameters('workbookDisplayName')]",
+        "description": "Operational overview for Verdecora AI Agents albarán processing.",
+        "sourceId": "[parameters('workbookSourceId')]",
+        "version": "Notebook/1.0",
+        "serializedData": "[string(variables('workbookDefinition'))]"
+      }
+    }
+  ],
+  "outputs": {
+    "workbookResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/workbooks', variables('workbookResourceName'))]"
+    },
+    "workbookName": {
+      "type": "string",
+      "value": "[parameters('workbookDisplayName')]"
+    }
+  }
+}

--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -1,0 +1,367 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for monitor resources.')
+param location string
+
+@description('Application Insights resource id used for custom-metric alerts.')
+param applicationInsightsId string
+
+@description('Log Analytics workspace resource id used for KQL alerts.')
+param logAnalyticsWorkspaceId string
+
+@description('Service Bus namespace resource id used for queue-depth alerts.')
+param serviceBusNamespaceId string
+
+@description('Service Bus queue name monitored for processing backlog.')
+param processingQueueName string = 'extraccion-in'
+
+@description('Notification email for the ops team action group.')
+param opsEmailAddress string = 'ops@verdecora.example.com'
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  'managed-by': 'bicep'
+}
+
+var actionGroupName = 'ag-verdecora-ops-${environment}'
+var actionGroupShortName = 'vdcops${take(environment, 6)}'
+
+var bcMcpConnectionFailureQuery = '''
+AppTraces
+| where TimeGenerated >= ago(5m)
+| extend props = column_ifexists("Properties", dynamic({}))
+| extend message = tostring(Message)
+| extend serverName = coalesce(tostring(props["mcp_server"]), tostring(props["dependency.target"]), '')
+| where SeverityLevel >= 3
+| where message has_any ('BC MCP', 'Business Central MCP', 'connection failed', 'connection lost')
+    or serverName has 'bc-mcp'
+| summarize FailureCount = count()
+'''
+
+var docIntelligenceTimeoutRateQuery = '''
+let windowStart = ago(15m);
+let docintRequests = AppDependencies
+| where TimeGenerated >= windowStart
+| extend props = column_ifexists("Properties", dynamic({}))
+| where Name has 'Document Intelligence'
+    or Target has 'cognitiveservices'
+    or tostring(props["component"]) has 'document-intelligence';
+let totalRequests = toscalar(docintRequests | count);
+let timeoutRequests = toscalar(
+    docintRequests
+    | where ResultCode in ('408', '504')
+        or Name has 'timeout'
+        or tostring(props["error.type"]) has 'timeout'
+        or tostring(props["failure_reason"]) has 'timeout'
+        or (Success == false and tostring(props["exception.type"]) has 'Timeout')
+    | count
+);
+print TimeoutRatePct = iff(totalRequests == 0, 0.0, todouble(timeoutRequests) * 100.0 / todouble(totalRequests))
+'''
+
+var agentProcessingP95Query = '''
+AppDependencies
+| where TimeGenerated >= ago(15m)
+| extend props = column_ifexists("Properties", dynamic({}))
+| extend customDimensions = column_ifexists("CustomDimensions", dynamic({}))
+| extend agentName = coalesce(
+    tostring(customDimensions["agent_name"]),
+    tostring(customDimensions["agent_id"]),
+    tostring(props["agent_name"]),
+    tostring(props["agent_id"]),
+    Name
+)
+| where agentName has_any ('A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'extractor', 'triage', 'coherence', 'validator', 'inventory', 'communication')
+| summarize P95DurationSeconds = percentile(DurationMs, 95) / 1000.0
+'''
+
+resource opsActionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: actionGroupName
+  location: 'global'
+  tags: tags
+  properties: {
+    enabled: true
+    groupShortName: actionGroupShortName
+    emailReceivers: [
+      {
+        name: 'ops-email'
+        emailAddress: opsEmailAddress
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+resource errorRateAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'ma-verdecora-error-rate-${environment}'
+  location: 'global'
+  tags: tags
+  properties: {
+    description: 'Critical alert when the application emits a processing error-rate metric above 5% for 15 minutes.'
+    severity: 0
+    enabled: true
+    scopes: [
+      applicationInsightsId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.insights/components'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'processing-error-rate'
+          criterionType: 'StaticThresholdCriterion'
+          metricNamespace: 'microsoft.insights/components'
+          metricName: 'processing_error_rate_pct'
+          operator: 'GreaterThan'
+          threshold: 5
+          timeAggregation: 'Average'
+          skipMetricValidation: true
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: [
+      {
+        actionGroupId: opsActionGroup.id
+        webHookProperties: {
+          alert_key: 'processing-error-rate'
+          severity: 'critical'
+        }
+      }
+    ]
+  }
+}
+
+resource queueDepthAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'ma-verdecora-queue-depth-${environment}'
+  location: 'global'
+  tags: tags
+  properties: {
+    description: 'Warning alert when the extraccion-in queue depth remains above 100 messages.'
+    severity: 2
+    enabled: true
+    scopes: [
+      serviceBusNamespaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.ServiceBus/namespaces'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'servicebus-queue-depth'
+          criterionType: 'StaticThresholdCriterion'
+          metricNamespace: 'Microsoft.ServiceBus/namespaces'
+          metricName: 'ActiveMessages'
+          operator: 'GreaterThan'
+          threshold: 100
+          timeAggregation: 'Average'
+          dimensions: [
+            {
+              name: 'EntityName'
+              operator: 'Include'
+              values: [
+                processingQueueName
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: [
+      {
+        actionGroupId: opsActionGroup.id
+        webHookProperties: {
+          alert_key: 'servicebus-queue-depth'
+          severity: 'warning'
+          queue_name: processingQueueName
+        }
+      }
+    ]
+  }
+}
+
+resource hitlBacklogMetricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'ma-verdecora-hitl-backlog-${environment}'
+  location: 'global'
+  tags: tags
+  properties: {
+    description: 'Warning alert when the pending HITL backlog older than 24 hours exceeds 50 reviews.'
+    severity: 2
+    enabled: true
+    scopes: [
+      applicationInsightsId
+    ]
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT30M'
+    targetResourceType: 'microsoft.insights/components'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'hitl-backlog-over-24h'
+          criterionType: 'StaticThresholdCriterion'
+          metricNamespace: 'microsoft.insights/components'
+          metricName: 'hitl_pending_reviews_over_24h'
+          operator: 'GreaterThan'
+          threshold: 50
+          timeAggregation: 'Average'
+          skipMetricValidation: true
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: [
+      {
+        actionGroupId: opsActionGroup.id
+        webHookProperties: {
+          alert_key: 'hitl-backlog-over-24h'
+          severity: 'warning'
+        }
+      }
+    ]
+  }
+}
+
+resource bcMcpConnectionFailuresAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-bc-mcp-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Detect repeated Business Central MCP connection failures.'
+    displayName: 'Verdecora BC MCP connection failures'
+    enabled: true
+    severity: 1
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: bcMcpConnectionFailureQuery
+          metricMeasureColumn: 'FailureCount'
+          timeAggregation: 'Total'
+          operator: 'GreaterThan'
+          threshold: 3
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'bc-mcp-connection-failures'
+        severity: 'critical'
+      }
+    }
+  }
+}
+
+resource docIntelligenceTimeoutAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-docint-timeouts-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Detect Document Intelligence timeout rates above 10% over the last 15 minutes.'
+    displayName: 'Verdecora Document Intelligence timeout rate'
+    enabled: true
+    severity: 2
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: docIntelligenceTimeoutRateQuery
+          metricMeasureColumn: 'TimeoutRatePct'
+          timeAggregation: 'Maximum'
+          operator: 'GreaterThan'
+          threshold: 10
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'document-intelligence-timeout-rate'
+        severity: 'warning'
+      }
+    }
+  }
+}
+
+resource agentProcessingTimeAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-agent-p95-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Detect p95 agent processing times above 60 seconds across A1-A6.'
+    displayName: 'Verdecora agent processing p95'
+    enabled: true
+    severity: 1
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: agentProcessingP95Query
+          metricMeasureColumn: 'P95DurationSeconds'
+          timeAggregation: 'Maximum'
+          operator: 'GreaterThan'
+          threshold: 60
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'agent-processing-p95'
+        severity: 'critical'
+      }
+    }
+  }
+}
+
+@description('Action group resource id.')
+output actionGroupId string = opsActionGroup.id

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -6,6 +6,9 @@ param environment string
 @description('Azure region for all resources.')
 param location string = 'swedencentral'
 
+@description('Ops team email notified by Azure Monitor action groups.')
+param opsEmailAddress string = 'ops@verdecora.example.com'
+
 var resourceGroupName = 'rg-verdecoratest-${environment}'
 
 module rg './resource-group.bicep' = {
@@ -183,6 +186,20 @@ module identity './identity.bicep' = {
   ]
 }
 
+module alerts './alerts.bicep' = {
+  name: 'alerts'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+    applicationInsightsId: monitoring.outputs.applicationInsightsId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
+    serviceBusNamespaceId: serviceBus.outputs.serviceBusNamespaceId
+    processingQueueName: serviceBus.outputs.extraccionQueueName
+    opsEmailAddress: opsEmailAddress
+  }
+}
+
 @description('Resource group id.')
 output resourceGroupId string = rg.outputs.resourceGroupId
 
@@ -251,6 +268,9 @@ output docIntellId string = docIntell.outputs.docIntellId
 
 @description('Document Intelligence endpoint.')
 output docIntellEndpoint string = docIntell.outputs.docIntellEndpoint
+
+@description('Azure Monitor action group id.')
+output opsActionGroupId string = alerts.outputs.actionGroupId
 
 @description('Container Apps environment id.')
 output containerAppsEnvironmentId string = containerApps.outputs.managedEnvironmentId


### PR DESCRIPTION
## Summary
- add an Azure Workbook ARM template for operational observability dashboards
- document deployment steps and practical KQL investigation queries
- add Azure Monitor action group, metric alerts, and log alerts wired into the main Bicep deployment

## Validation
- python -m json.tool .\\infra\\dashboards\\overview-workbook.json
- az bicep build --file .\\infra\\modules\\alerts.bicep
- az bicep build --file .\\infra\\modules\\main.bicep

## Notes
- metric alerts for error rate and HITL backlog use custom Application Insights metrics with skipMetricValidation enabled so telemetry can be emitted by the workloads after deployment