### PR TITLE
chore: Upgrade MAF to v1.2.2 and adapt breaking changes

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -15,3 +15,9 @@
 - Recommended GPT-5 family as the new production baseline, with `gpt-5-mini` for Agent 1 and Agent 3, and `gpt-5.5` for Agent 2.
 - Recommended keeping Azure AI Document Intelligence as the OCR foundation, but changing the design from unconditional double-pass to selective hybrid escalation.
 - Wrote full findings to `prerequisites/analysis/bishop-llm-evaluation.md` and decision summary to `.squad/decisions/inbox/bishop-llm-models.md`.
+
+### 2026-05-05 — MAF v1.2.2 migration behavior
+- Upgrading to MAF v1.2.2 requires using `agent_framework.Agent` directly; `ChatAgent` is no longer exported from the top-level package.
+- Structured outputs now belong in `default_options={"response_format": Model}` instead of passing `response_format=` to the agent constructor.
+- Sequential workflow output handlers must normalize `AgentResponse` values by reading `.text` first and falling back to `.messages[-1].content` when needed.
+- `SequentialBuilder` should be imported from `agent_framework.orchestrations` for v1.2.2-compatible code paths.

--- a/.squad/decisions/inbox/bishop-maf-upgrade.md
+++ b/.squad/decisions/inbox/bishop-maf-upgrade.md
@@ -1,0 +1,6 @@
+# Bishop — MAF v1.2.2 upgrade compatibility
+
+- **Date:** 2026-05-05
+- **Decision:** Standardize new MAF SDK usage on `agent_framework.Agent` + `default_options={"response_format": Model}` and import orchestration builders from `agent_framework.orchestrations`.
+- **Why:** After upgrading to MAF v1.2.2, `ChatAgent` is no longer exported from the top-level package and structured output configuration is expected in `default_options`, not `response_format=`. The workflow event stream also returns `AgentResponse`, so terminal output handling must normalize `.text` / `.messages` consistently.
+- **Impact:** New agent code and future upgrades should follow this constructor/import pattern to stay compatible with MAF v1.2.2+ and avoid test collection failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "agent-framework",
+    "agent-framework>=1.2.2,<2.0",
+    "agent-framework-azure-cosmos>=1.2.2,<2.0",
     "aiohttp>=3.11.0",
     "azure-ai-documentintelligence>=1.0.2",
     "azure-communication-email>=1.0.0",
@@ -30,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-    "agent-framework",
+    "agent-framework>=1.2.2,<2.0",
     "azure-ai-documentintelligence>=1.0.2",
     "azure-communication-email>=1.0.0",
     "azure-cosmos>=4.9.0",

--- a/src/agents/factory.py
+++ b/src/agents/factory.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from agent_framework import ChatAgent as Agent
+from agent_framework import Agent
 
 from src.models.albaran import AlbaranExtraction, CoherenceCheckResult, TriageResult
 from src.models.inventory import PostingResult
@@ -67,44 +67,44 @@ def create_agents(
 
     return {
         "triage": Agent(
-            chat_client=gpt5_mini,
+            gpt5_mini,
             name="Triage",
             instructions=build_triage_instructions(),
-            response_format=TriageResult,
+            default_options={"response_format": TriageResult},
         ),
         "extractor": Agent(
-            chat_client=gpt5,
+            gpt5,
             name="Extractor",
             instructions=build_extractor_instructions(_resolve_tool_names(extractor_tools)),
-            response_format=AlbaranExtraction,
+            default_options={"response_format": AlbaranExtraction},
             tools=extractor_tools,
         ),
         "coherence": Agent(
-            chat_client=gpt5_mini,
+            gpt5_mini,
             name="Coherence",
             instructions=build_coherence_instructions(_resolve_tool_names(coherence_tools)),
-            response_format=CoherenceCheckResult,
+            default_options={"response_format": CoherenceCheckResult},
             tools=coherence_tools,
         ),
         "validator": Agent(
-            chat_client=gpt5_mini,
+            gpt5_mini,
             name="Validator",
             instructions=build_validator_instructions(_resolve_tool_names(validator_tools)),
-            response_format=ValidationResult,
+            default_options={"response_format": ValidationResult},
             tools=validator_tools,
         ),
         "inventory": Agent(
-            chat_client=gpt5_mini,
+            gpt5_mini,
             name="Inventory",
             instructions=build_inventory_instructions(_resolve_tool_names(inventory_tools)),
-            response_format=PostingResult,
+            default_options={"response_format": PostingResult},
             tools=inventory_tools,
         ),
         "communication": Agent(
-            chat_client=gpt5_mini,
+            gpt5_mini,
             name="Communication",
             instructions=build_communication_instructions(),
-            response_format=CommunicationSummary,
+            default_options={"response_format": CommunicationSummary},
             tools=communication_tools,
         ),
     }

--- a/src/agents/pipeline.py
+++ b/src/agents/pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from agent_framework import SequentialBuilder
+from agent_framework.orchestrations import SequentialBuilder
 from azure.identity.aio import DefaultAzureCredential
 from pydantic import BaseModel, Field, ValidationError
 
@@ -95,7 +95,14 @@ class AlbaranPipeline:
         if hasattr(resolved, "__aiter__"):
             latest_payload: Any = None
             async for event in resolved:
-                latest_payload = getattr(event, "data", event)
+                data = getattr(event, "data", event)
+                text = getattr(data, "text", None)
+                if text is not None:
+                    latest_payload = text
+                elif hasattr(data, "messages"):
+                    latest_payload = data.messages[-1].content if data.messages else str(data)
+                else:
+                    latest_payload = data
             return latest_payload
         return getattr(resolved, "text", resolved)
 

--- a/src/poc/maf_poc/orchestrator.py
+++ b/src/poc/maf_poc/orchestrator.py
@@ -20,6 +20,16 @@ from opentelemetry.sdk.trace.export import (
 
 from .stub_agents import create_extractor, create_inventory, create_validator
 
+
+def _resolve_workflow_output(data) -> str:
+    text = getattr(data, "text", None)
+    if text is not None:
+        return str(text)
+    if hasattr(data, "messages"):
+        return str(data.messages[-1].content) if data.messages else str(data)
+    return str(data)
+
+
 # ---------------------------------------------------------------------------
 # Telemetry setup (console exporter for local dev)
 # ---------------------------------------------------------------------------
@@ -53,13 +63,14 @@ async def run_extraction_pipeline(client, input_text: str, tracer: trace.Tracer)
     with tracer.start_as_current_span("extraction_pipeline") as span:
         span.set_attribute("input.text", input_text)
 
-        result = None
+        result = ""
         async for event in workflow.run(input_text, stream=True):
             if event.type == "output":
-                result = event.data
-                span.set_attribute("extraction.result_length", len(str(result)))
+                data = getattr(event, "data", event)
+                result = _resolve_workflow_output(data)
+                span.set_attribute("extraction.result_length", len(result))
 
-    return str(result) if result else ""
+    return result
 
 
 async def run_validation_handoff(client, extracted_json: str, tracer: trace.Tracer) -> dict:
@@ -92,11 +103,15 @@ async def run_validation_handoff(client, extracted_json: str, tracer: trace.Trac
             stream=True,
         ):
             if event.type == "output":
-                messages.append(event.data)
-                span.add_event("agent_output", {"agent": getattr(event.data, "author_name", "unknown")})
+                data = getattr(event, "data", event)
+                messages.append(_resolve_workflow_output(data))
+                author = getattr(data, "author_name", "unknown")
+                if author == "unknown" and hasattr(data, "messages") and data.messages:
+                    author = getattr(data.messages[-1], "author_name", "unknown")
+                span.add_event("agent_output", {"agent": author})
 
         # Determine outcome
-        output_text = " ".join(str(m) for m in messages)
+        output_text = " ".join(messages)
         if "REC-" in output_text or "posted" in output_text.lower():
             outcome = "posted"
         elif "discrepancia" in output_text.lower() or "discrepancy" in output_text.lower():
@@ -108,7 +123,7 @@ async def run_validation_handoff(client, extracted_json: str, tracer: trace.Trac
 
     return {
         "outcome": outcome,
-        "messages": [str(m) for m in messages],
+        "messages": messages,
     }
 
 

--- a/src/poc/maf_poc/requirements-poc.txt
+++ b/src/poc/maf_poc/requirements-poc.txt
@@ -2,7 +2,7 @@
 # Install: pip install -r src/poc/maf_poc/requirements-poc.txt
 
 # Core framework
-agent-framework>=1.0.0
+agent-framework>=1.2.2,<2.0
 
 # Chat client (pick one or both)
 # agent-framework[foundry]    # For FoundryChatClient (Azure AI Foundry)

--- a/tests/unit/agent_test_helpers.py
+++ b/tests/unit/agent_test_helpers.py
@@ -55,5 +55,14 @@ class FakeWorkflow:
         return self.response
 
 
-def build_structured_agent_stub(**kwargs: Any) -> StructuredAgentStub:
-    return StructuredAgentStub(response_format=kwargs["response_format"], kwargs=dict(kwargs))
+def build_structured_agent_stub(*args: Any, **kwargs: Any) -> StructuredAgentStub:
+    response_format = kwargs.get("response_format")
+    if response_format is None:
+        response_format = kwargs.get("default_options", {}).get("response_format")
+    if response_format is None:
+        raise KeyError("response_format")
+
+    captured_kwargs = dict(kwargs)
+    if args:
+        captured_kwargs["client"] = args[0]
+    return StructuredAgentStub(response_format=response_format, kwargs=captured_kwargs)

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -63,22 +63,22 @@ def test_create_agents_returns_expected_keys_and_models(mock_agent: Any) -> None
     communication = agents["communication"]
 
     assert isinstance(triage, StructuredAgentStub)
-    assert triage.kwargs["chat_client"] == "gpt5-mini-client"
-    assert triage.kwargs["response_format"] is TriageResult
+    assert triage.kwargs["client"] == "gpt5-mini-client"
+    assert triage.kwargs["default_options"]["response_format"] is TriageResult
     assert "document triage specialist" in triage.kwargs["instructions"]
 
-    assert extractor.kwargs["chat_client"] == "gpt5-client"
-    assert extractor.kwargs["response_format"] is AlbaranExtraction
+    assert extractor.kwargs["client"] == "gpt5-client"
+    assert extractor.kwargs["default_options"]["response_format"] is AlbaranExtraction
     assert extractor.kwargs["tools"] == tool_registry["extractor"]
 
-    assert coherence.kwargs["chat_client"] == "gpt5-mini-client"
-    assert coherence.kwargs["response_format"] is CoherenceCheckResult
+    assert coherence.kwargs["client"] == "gpt5-mini-client"
+    assert coherence.kwargs["default_options"]["response_format"] is CoherenceCheckResult
     assert "bc.search_purchase_orders" in coherence.kwargs["instructions"]
 
-    assert validator.kwargs["response_format"] is ValidationResult
+    assert validator.kwargs["default_options"]["response_format"] is ValidationResult
     assert validator.kwargs["tools"] == tool_registry["validator"]
 
-    assert inventory.kwargs["response_format"] is PostingResult
+    assert inventory.kwargs["default_options"]["response_format"] is PostingResult
     assert inventory.kwargs["tools"] == tool_registry["inventory"]
 
     assert communication.kwargs["tools"] == tool_registry["communication"]
@@ -88,7 +88,9 @@ def test_create_agents_returns_expected_keys_and_models(mock_agent: Any) -> None
 def test_create_agents_omits_optional_tool_lists_when_not_provided() -> None:
     captured_calls: list[dict[str, Any]] = []
 
-    def fake_agent(**kwargs: Any) -> dict[str, Any]:
+    def fake_agent(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        if args:
+            kwargs["client"] = args[0]
         captured_calls.append(kwargs)
         return kwargs
 

--- a/tests/unit/test_agent_pipeline.py
+++ b/tests/unit/test_agent_pipeline.py
@@ -18,6 +18,18 @@ from tests.fixtures.sample_albarans import (
 )
 from tests.unit.agent_test_helpers import FakeAsyncStream, FakeEvent, FakeWorkflow, WorkflowResult
 
+
+class _AgentMessage:
+    def __init__(self, content: str, author_name: str = "agent") -> None:
+        self.content = content
+        self.author_name = author_name
+
+
+class _AgentResponse:
+    def __init__(self, *, text: str | None = None, messages: list[_AgentMessage] | None = None) -> None:
+        self.text = text
+        self.messages = messages or []
+
 pytestmark = pytest.mark.unit
 
 
@@ -44,6 +56,28 @@ def test_pipeline_creation_with_all_agents() -> None:
     pipeline = AlbaranPipeline(agents=_named_agents())
 
     assert set(pipeline.agents) == {"triage", "extractor", "coherence", "validator", "inventory", "communication"}
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_uses_agent_response_text_from_stream() -> None:
+    pipeline = AlbaranPipeline(agents=_named_agents())
+    workflow = FakeWorkflow(
+        FakeAsyncStream([FakeEvent(_AgentResponse(text='{"status":"ok"}', messages=[_AgentMessage('ignored')]))])
+    )
+
+    result = await pipeline._run_workflow(workflow, {"payload": True})
+
+    assert result == '{"status":"ok"}'
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_falls_back_to_agent_response_messages() -> None:
+    pipeline = AlbaranPipeline(agents=_named_agents())
+    workflow = FakeWorkflow(FakeAsyncStream([FakeEvent(_AgentResponse(messages=[_AgentMessage('{"status":"ok"}')]))]))
+
+    result = await pipeline._run_workflow(workflow, {"payload": True})
+
+    assert result == '{"status":"ok"}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #85

## Summary
- upgrade MAF dependency declarations to v1.2.2 and add the Azure Cosmos package needed for checkpoint storage
- adapt workflow consumers to read v1.2.2 `AgentResponse` outputs via `.text` / `.messages`
- update agent construction for the current MAF v1.2.2 API and extend unit coverage for the new response shape

## Validation
- python -m ruff check src\\agents\\factory.py src\\agents\\pipeline.py src\\poc\\maf_poc\\orchestrator.py tests\\unit\\agent_test_helpers.py tests\\unit\\test_agent_factory.py tests\\unit\\test_agent_pipeline.py
- python -m pytest tests/ -v --tb=short