### PR TITLE
feat(infra): add Application Gateway v2 and Easy Auth for upload-web (#90, #94)

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -22,3 +22,9 @@
 - Added `infra/modules/runners.bicep` with an internal ACA managed environment on `snet-runners`, a user-assigned managed identity, Key Vault-backed PAT secret wiring, and an ACA Job that uses the `github-runner` KEDA scaler.
 - Added `infra/bootstrap/bootstrap.bicep` and `infra/bootstrap/bootstrap.ps1` for the Phase 0 bootstrap path, including manual runner execution plus GitHub API verification.
 - Documented the operational flow in `docs/operations/bootstrap-guide.md`, including the explicit requirement that all later deployments move onto the self-hosted runner after bootstrap and that temporary public access is removed after private cutover.
+
+### 2026-05-05 — App Gateway + Easy Auth landing zone for upload-web
+- Added a dedicated `appgw-snet` (/24) and locked-down NSG shape for Azure Application Gateway v2 so the ACA environment can stay private while upload-web gets a controlled public ingress path.
+- Added `infra/modules/appgw.bicep` wiring for Standard_v2 autoscale, HTTP→HTTPS redirect, `/healthz` probing, backend HTTPS to the ACA internal FQDN, and Key Vault-backed TLS certificate access via managed identity.
+- Added `infra/modules/upload-web-auth.bicep` so Easy Auth can be switched on for `verdecora-upload-web-${environment}` with Entra audiences plus optional `verdecora-store-uploaders` group enforcement once the app exists.
+- Documented that the Entra group itself must still be created manually in the Azure portal before rollout.

--- a/.squad/decisions/inbox/brett-appgw-easyauth.md
+++ b/.squad/decisions/inbox/brett-appgw-easyauth.md
@@ -1,0 +1,14 @@
+# Brett — App Gateway + Easy Auth
+
+## What changed
+- Added a dedicated `appgw-snet` (`10.10.6.0/24`) and locked NSG rules so Application Gateway v2 has its own subnet and only accepts Internet 80/443 plus GatewayManager maintenance traffic.
+- Added `infra/modules/appgw.bicep` for the upload-web edge: Standard_v2 autoscale, HTTP→HTTPS redirect, `/healthz` probe, HTTPS backend to the ACA internal FQDN, and Key Vault-backed frontend TLS via managed identity.
+- Added `infra/modules/upload-web-auth.bicep` plus `uploadWebEntraClientId`/group audience parameters in `infra/modules/main.bicep` so Easy Auth can be enabled once `verdecora-upload-web-${environment}` exists.
+
+## Decision
+- Keep the ACA environment private and front upload-web with Application Gateway on a dedicated subnet.
+- Gate Easy Auth rollout behind an explicit flag until the upload-web container app exists, while documenting the required manual Entra group creation (`verdecora-store-uploaders`) in `infra/README.md`.
+
+## Why
+- This preserves the private-network-first architecture from the approved proposal while letting Sprint 0 land the edge and auth IaC safely ahead of the app workload.
+- The manual Entra group step remains outside Bicep, so the deployment notes must carry that operational dependency.

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,3 +6,9 @@ Bicep templates for Azure deployment.
 - *.bicep - Top-level deployment templates
 
 Deploy with: `az deployment group create -t main.bicep`
+
+## Upload web notes
+
+- Create the Microsoft Entra group `verdecora-store-uploaders` manually in the Azure portal, then pass its object ID(s) through `uploadWebAllowedGroupObjectIds` when enabling Easy Auth.
+- Set `enableUploadWebAuth=true` only after `verdecora-upload-web-${environment}` exists in the Container Apps environment.
+- Set `enableUploadWebAppGateway=true` and configure `appGwFrontendCertificateSecretId` with a Key Vault PFX secret URI before deploying the Application Gateway HTTPS listener.

--- a/infra/modules/appgw.bicep
+++ b/infra/modules/appgw.bicep
@@ -1,0 +1,294 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for networking resources.')
+param location string
+
+@description('Dedicated subnet resource ID for Application Gateway.')
+param subnetId string
+
+@description('Internal ACA FQDN used as the backend target for upload-web.')
+param backendFqdn string
+
+@description('Existing Key Vault name that stores the Application Gateway TLS certificate secret.')
+param keyVaultName string
+
+@secure()
+@description('Key Vault secret identifier for the frontend TLS certificate (PFX secret, versionless URI recommended).')
+param frontendSslCertificateSecretId string
+
+@description('Public DNS label assigned to the Application Gateway public IP.')
+param publicIpDnsLabel string = 'verdecora-upload-${environment}'
+
+@description('Application Gateway resource name.')
+param appGatewayName string = 'agw-verdecora-upload-${environment}'
+
+@description('Public IP resource name for the Application Gateway frontend.')
+param publicIpName string = 'pip-verdecora-upload-${environment}'
+
+@description('User-assigned managed identity name used by Application Gateway to read TLS material from Key Vault.')
+param appGatewayIdentityName string = 'id-appgw-verdecora-upload-${environment}'
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  service: 'upload-web-edge'
+  'managed-by': 'bicep'
+}
+var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+var frontendPortHttpId = resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayName, 'port-http')
+var frontendPortHttpsId = resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayName, 'port-https')
+var frontendIpConfigurationId = resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayName, 'frontend-public')
+var backendAddressPoolId = resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGatewayName, 'upload-web-backend')
+var backendHttpSettingsId = resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, 'upload-web-https-settings')
+var httpsProbeId = resourceId('Microsoft.Network/applicationGateways/probes', appGatewayName, 'upload-web-healthz')
+var httpListenerId = resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, 'listener-http')
+var httpsListenerId = resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, 'listener-https')
+var sslCertificateId = resourceId('Microsoft.Network/applicationGateways/sslCertificates', appGatewayName, 'frontend-cert')
+var httpRedirectId = resourceId('Microsoft.Network/applicationGateways/redirectConfigurations', appGatewayName, 'http-to-https')
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource appGatewayIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: appGatewayIdentityName
+  location: location
+  tags: tags
+}
+
+resource keyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, appGatewayIdentity.name, keyVaultSecretsUserRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    principalId: appGatewayIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: keyVaultSecretsUserRoleDefinitionId
+  }
+}
+
+resource publicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = {
+  name: publicIpName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  properties: {
+    publicIPAddressVersion: 'IPv4'
+    publicIPAllocationMethod: 'Static'
+    dnsSettings: {
+      domainNameLabel: toLower(publicIpDnsLabel)
+    }
+  }
+}
+
+resource appGateway 'Microsoft.Network/applicationGateways@2024-07-01' = {
+  name: appGatewayName
+  location: location
+  tags: tags
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${appGatewayIdentity.id}': {}
+    }
+  }
+  properties: {
+    sku: {
+      name: 'Standard_v2'
+      tier: 'Standard_v2'
+    }
+    autoscaleConfiguration: {
+      minCapacity: 0
+      maxCapacity: 10
+    }
+    enableHttp2: true
+    sslPolicy: {
+      policyType: 'Predefined'
+      policyName: 'AppGwSslPolicy20220101'
+    }
+    gatewayIPConfigurations: [
+      {
+        name: 'gateway-ip-config'
+        properties: {
+          subnet: {
+            id: subnetId
+          }
+        }
+      }
+    ]
+    frontendIPConfigurations: [
+      {
+        name: 'frontend-public'
+        properties: {
+          publicIPAddress: {
+            id: publicIp.id
+          }
+        }
+      }
+    ]
+    frontendPorts: [
+      {
+        name: 'port-http'
+        properties: {
+          port: 80
+        }
+      }
+      {
+        name: 'port-https'
+        properties: {
+          port: 443
+        }
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: 'upload-web-backend'
+        properties: {
+          backendAddresses: [
+            {
+              fqdn: backendFqdn
+            }
+          ]
+        }
+      }
+    ]
+    backendHttpSettingsCollection: [
+      {
+        name: 'upload-web-https-settings'
+        properties: {
+          cookieBasedAffinity: 'Disabled'
+          pickHostNameFromBackendAddress: true
+          port: 443
+          protocol: 'Https'
+          probe: {
+            id: httpsProbeId
+          }
+          probeEnabled: true
+          requestTimeout: 30
+        }
+      }
+    ]
+    probes: [
+      {
+        name: 'upload-web-healthz'
+        properties: {
+          protocol: 'Https'
+          path: '/healthz'
+          interval: 30
+          timeout: 10
+          unhealthyThreshold: 3
+          pickHostNameFromBackendHttpSettings: true
+          match: {
+            statusCodes: [
+              '200'
+            ]
+          }
+        }
+      }
+    ]
+    sslCertificates: [
+      {
+        name: 'frontend-cert'
+        properties: {
+          keyVaultSecretId: frontendSslCertificateSecretId
+        }
+      }
+    ]
+    httpListeners: [
+      {
+        name: 'listener-http'
+        properties: {
+          frontendIPConfiguration: {
+            id: frontendIpConfigurationId
+          }
+          frontendPort: {
+            id: frontendPortHttpId
+          }
+          protocol: 'Http'
+        }
+      }
+      {
+        name: 'listener-https'
+        properties: {
+          frontendIPConfiguration: {
+            id: frontendIpConfigurationId
+          }
+          frontendPort: {
+            id: frontendPortHttpsId
+          }
+          protocol: 'Https'
+          sslCertificate: {
+            id: sslCertificateId
+          }
+        }
+      }
+    ]
+    redirectConfigurations: [
+      {
+        name: 'http-to-https'
+        properties: {
+          includePath: true
+          includeQueryString: true
+          redirectType: 'Permanent'
+          targetListener: {
+            id: httpsListenerId
+          }
+        }
+      }
+    ]
+    requestRoutingRules: [
+      {
+        name: 'http-redirect'
+        properties: {
+          httpListener: {
+            id: httpListenerId
+          }
+          redirectConfiguration: {
+            id: httpRedirectId
+          }
+          priority: 100
+          ruleType: 'Basic'
+        }
+      }
+      {
+        name: 'https-backend'
+        properties: {
+          backendAddressPool: {
+            id: backendAddressPoolId
+          }
+          backendHttpSettings: {
+            id: backendHttpSettingsId
+          }
+          httpListener: {
+            id: httpsListenerId
+          }
+          priority: 110
+          ruleType: 'Basic'
+        }
+      }
+    ]
+  }
+  dependsOn: [
+    keyVaultSecretsUser
+  ]
+}
+
+@description('Application Gateway public FQDN.')
+output appGwPublicFqdn string = publicIp.properties.dnsSettings.fqdn
+
+@description('Application Gateway public IP resource id.')
+output appGwPublicIpId string = publicIp.id

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -446,6 +446,9 @@ output managedEnvironmentId string = managedEnvironment.id
 @description('Container Apps managed environment name.')
 output managedEnvironmentName string = managedEnvironment.name
 
+@description('Container Apps managed environment default domain.')
+output managedEnvironmentDefaultDomain string = managedEnvironment.properties.defaultDomain
+
 @description('Main orchestrator container app id.')
 output orchestratorAppId string = orchestratorApp.id
 

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -21,6 +21,25 @@ param hitlWebformImage string = ''
 @description('Optional override for the escalation timer job image during infrastructure deployments.')
 param escalationTimerJobImage string = ''
 
+@secure()
+@description('Key Vault secret identifier for the Application Gateway TLS certificate (PFX secret, versionless URI recommended).')
+param appGwFrontendCertificateSecretId string = ''
+
+@description('Enable Application Gateway deployment for upload-web once the TLS certificate secret is ready.')
+param enableUploadWebAppGateway bool = false
+
+@description('Microsoft Entra application client id used by upload-web Easy Auth.')
+param uploadWebEntraClientId string = ''
+
+@description('Enable Easy Auth deployment for upload-web once the container app exists.')
+param enableUploadWebAuth bool = false
+
+@description('Optional audiences accepted by upload-web Easy Auth. Defaults to api://{uploadWebEntraClientId}.')
+param uploadWebAllowedAudiences array = []
+
+@description('Optional Microsoft Entra group object ids allowed to access upload-web.')
+param uploadWebAllowedGroupObjectIds array = []
+
 var resourceGroupName = 'rg-verdecoratest-${environment}'
 var storageAccountUrl = 'https://${storage.outputs.storageAccountName}.blob.${az.environment().suffixes.storage}/'
 
@@ -249,6 +268,40 @@ module containerApps './container-apps.bicep' = {
   ]
 }
 
+var uploadWebAppName = 'verdecora-upload-web-${environment}'
+var uploadWebBackendFqdn = '${uploadWebAppName}.internal.${containerApps.outputs.managedEnvironmentDefaultDomain}'
+
+module appGateway './appgw.bicep' = if (enableUploadWebAppGateway) {
+  name: 'appGateway'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+    subnetId: network.outputs.subnetAppGatewayId
+    backendFqdn: uploadWebBackendFqdn
+    keyVaultName: keyVault.outputs.keyVaultName
+    frontendSslCertificateSecretId: appGwFrontendCertificateSecretId
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
+module uploadWebAuth './upload-web-auth.bicep' = if (enableUploadWebAuth && !empty(uploadWebEntraClientId)) {
+  name: 'uploadWebAuth'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    containerAppName: uploadWebAppName
+    tenantId: subscription().tenantId
+    clientId: uploadWebEntraClientId
+    allowedAudiences: uploadWebAllowedAudiences
+    allowedGroupObjectIds: uploadWebAllowedGroupObjectIds
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
 module eventGrid './eventgrid.bicep' = {
   name: 'eventGrid'
   scope: az.resourceGroup(resourceGroupName)
@@ -399,6 +452,9 @@ output opsActionGroupId string = alerts.outputs.actionGroupId
 @description('Container Apps environment id.')
 output containerAppsEnvironmentId string = containerApps.outputs.managedEnvironmentId
 
+@description('Container Apps environment default domain.')
+output containerAppsEnvironmentDefaultDomain string = containerApps.outputs.managedEnvironmentDefaultDomain
+
 @description('GitHub runner ACA environment name.')
 output runnersEnvironmentName string = runners.outputs.runnerEnvironmentName
 
@@ -416,6 +472,12 @@ output hitlWebformAppId string = containerApps.outputs.hitlWebformAppId
 
 @description('Escalation timer ACA Job id.')
 output escalationTimerJobId string = containerApps.outputs.escalationTimerJobId
+
+@description('Application Gateway public FQDN for upload-web.')
+output appGwPublicFqdn string = enableUploadWebAppGateway ? appGateway!.outputs.appGwPublicFqdn : ''
+
+@description('Application Gateway public IP resource id for upload-web.')
+output appGwPublicIpId string = enableUploadWebAppGateway ? appGateway!.outputs.appGwPublicIpId : ''
 
 @description('Whether production-only network hardening is enabled.')
 output networkHardeningEnabled bool = enableNetworkHardening

--- a/infra/modules/main.json
+++ b/infra/modules/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "4335735284261144565"
+      "templateHash": "6784977157700746004"
     }
   },
   "parameters": {
@@ -56,11 +56,54 @@
       "metadata": {
         "description": "Optional override for the escalation timer job image during infrastructure deployments."
       }
+    },
+    "appGwFrontendCertificateSecretId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Key Vault secret identifier for the Application Gateway TLS certificate (PFX secret, versionless URI recommended)."
+      }
+    },
+    "enableUploadWebAppGateway": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable Application Gateway deployment for upload-web once the TLS certificate secret is ready."
+      }
+    },
+    "uploadWebEntraClientId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Microsoft Entra application client id used by upload-web Easy Auth."
+      }
+    },
+    "enableUploadWebAuth": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable Easy Auth deployment for upload-web once the container app exists."
+      }
+    },
+    "uploadWebAllowedAudiences": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional audiences accepted by upload-web Easy Auth. Defaults to api://{uploadWebEntraClientId}."
+      }
+    },
+    "uploadWebAllowedGroupObjectIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional Microsoft Entra group object ids allowed to access upload-web."
+      }
     }
   },
   "variables": {
     "resourceGroupName": "[format('rg-verdecoratest-{0}', parameters('environment'))]",
-    "enableNetworkHardening": true
+    "enableNetworkHardening": true,
+    "uploadWebAppName": "[format('verdecora-upload-web-{0}', parameters('environment'))]"
   },
   "resources": [
     {
@@ -175,7 +218,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "14441465333506807893"
+              "templateHash": "13938833016720167310"
             }
           },
           "parameters": {
@@ -242,6 +285,69 @@
               "name": "[format('nsg-egress-albaranes-{0}', parameters('environment'))]",
               "location": "[parameters('location')]",
               "tags": "[variables('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2023-04-01",
+              "name": "[format('nsg-appgw-albaranes-{0}', parameters('environment'))]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "allow-http-inbound",
+                    "properties": {
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "priority": 100,
+                      "protocol": "Tcp",
+                      "sourceAddressPrefix": "Internet",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "80"
+                    }
+                  },
+                  {
+                    "name": "allow-https-inbound",
+                    "properties": {
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "priority": 110,
+                      "protocol": "Tcp",
+                      "sourceAddressPrefix": "Internet",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "443"
+                    }
+                  },
+                  {
+                    "name": "allow-gatewaymanager",
+                    "properties": {
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "priority": 120,
+                      "protocol": "Tcp",
+                      "sourceAddressPrefix": "GatewayManager",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "65200-65535"
+                    }
+                  },
+                  {
+                    "name": "deny-rest-inbound",
+                    "properties": {
+                      "access": "Deny",
+                      "direction": "Inbound",
+                      "priority": 4096,
+                      "protocol": "*",
+                      "sourceAddressPrefix": "*",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "*"
+                    }
+                  }
+                ]
+              }
             },
             {
               "type": "Microsoft.Network/virtualNetworks",
@@ -317,11 +423,21 @@
                         "id": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]"
                       }
                     }
+                  },
+                  {
+                    "name": "appgw-snet",
+                    "properties": {
+                      "addressPrefix": "10.10.6.0/24",
+                      "networkSecurityGroup": {
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-appgw-albaranes-{0}', parameters('environment')))]"
+                      }
+                    }
                   }
                 ]
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-aca-env-albaranes-{0}', parameters('environment')))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-appgw-albaranes-{0}', parameters('environment')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-functions-albaranes-{0}', parameters('environment')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-pe-albaranes-{0}', parameters('environment')))]",
@@ -372,6 +488,13 @@
               },
               "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2023-04-01').subnets[4].id]"
             },
+            "subnetAppGatewayId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Gateway subnet id."
+              },
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2023-04-01').subnets[5].id]"
+            },
             "nsgAcaId": {
               "type": "string",
               "metadata": {
@@ -406,6 +529,13 @@
                 "description": "Egress NSG id."
               },
               "value": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]"
+            },
+            "nsgAppGatewayId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Gateway NSG id."
+              },
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-appgw-albaranes-{0}', parameters('environment')))]"
             }
           }
         }
@@ -3199,7 +3329,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "1508615338088884100"
+              "templateHash": "9811920103377580210"
             }
           },
           "parameters": {
@@ -3737,6 +3867,13 @@
               },
               "value": "[variables('managedEnvironmentName')]"
             },
+            "managedEnvironmentDefaultDomain": {
+              "type": "string",
+              "metadata": {
+                "description": "Container Apps managed environment default domain."
+              },
+              "value": "[reference(resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName')), '2025-01-01').defaultDomain]"
+            },
             "orchestratorAppId": {
               "type": "string",
               "metadata": {
@@ -3810,6 +3947,532 @@
         "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'serviceBus')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]"
+      ]
+    },
+    {
+      "condition": "[parameters('enableUploadWebAppGateway')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "appGateway",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "environment": {
+            "value": "[parameters('environment')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "subnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.subnetAppGatewayId.value]"
+          },
+          "backendFqdn": {
+            "value": "[format('{0}.internal.{1}', variables('uploadWebAppName'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentDefaultDomain.value)]"
+          },
+          "keyVaultName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'keyVault'), '2025-04-01').outputs.keyVaultName.value]"
+          },
+          "frontendSslCertificateSecretId": {
+            "value": "[parameters('appGwFrontendCertificateSecretId')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "17053705018400402108"
+            }
+          },
+          "parameters": {
+            "environment": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment name (dev/test/prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for networking resources."
+              }
+            },
+            "subnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "Dedicated subnet resource ID for Application Gateway."
+              }
+            },
+            "backendFqdn": {
+              "type": "string",
+              "metadata": {
+                "description": "Internal ACA FQDN used as the backend target for upload-web."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Existing Key Vault name that stores the Application Gateway TLS certificate secret."
+              }
+            },
+            "frontendSslCertificateSecretId": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Key Vault secret identifier for the frontend TLS certificate (PFX secret, versionless URI recommended)."
+              }
+            },
+            "publicIpDnsLabel": {
+              "type": "string",
+              "defaultValue": "[format('verdecora-upload-{0}', parameters('environment'))]",
+              "metadata": {
+                "description": "Public DNS label assigned to the Application Gateway public IP."
+              }
+            },
+            "appGatewayName": {
+              "type": "string",
+              "defaultValue": "[format('agw-verdecora-upload-{0}', parameters('environment'))]",
+              "metadata": {
+                "description": "Application Gateway resource name."
+              }
+            },
+            "publicIpName": {
+              "type": "string",
+              "defaultValue": "[format('pip-verdecora-upload-{0}', parameters('environment'))]",
+              "metadata": {
+                "description": "Public IP resource name for the Application Gateway frontend."
+              }
+            },
+            "appGatewayIdentityName": {
+              "type": "string",
+              "defaultValue": "[format('id-appgw-verdecora-upload-{0}', parameters('environment'))]",
+              "metadata": {
+                "description": "User-assigned managed identity name used by Application Gateway to read TLS material from Key Vault."
+              }
+            }
+          },
+          "variables": {
+            "tags": {
+              "project": "verdecora-albaranes",
+              "env": "[parameters('environment')]",
+              "service": "upload-web-edge",
+              "managed-by": "bicep"
+            },
+            "keyVaultSecretsUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+            "frontendPortHttpId": "[resourceId('Microsoft.Network/applicationGateways/frontendPorts', parameters('appGatewayName'), 'port-http')]",
+            "frontendPortHttpsId": "[resourceId('Microsoft.Network/applicationGateways/frontendPorts', parameters('appGatewayName'), 'port-https')]",
+            "frontendIpConfigurationId": "[resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', parameters('appGatewayName'), 'frontend-public')]",
+            "backendAddressPoolId": "[resourceId('Microsoft.Network/applicationGateways/backendAddressPools', parameters('appGatewayName'), 'upload-web-backend')]",
+            "backendHttpSettingsId": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', parameters('appGatewayName'), 'upload-web-https-settings')]",
+            "httpsProbeId": "[resourceId('Microsoft.Network/applicationGateways/probes', parameters('appGatewayName'), 'upload-web-healthz')]",
+            "httpListenerId": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', parameters('appGatewayName'), 'listener-http')]",
+            "httpsListenerId": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', parameters('appGatewayName'), 'listener-https')]",
+            "sslCertificateId": "[resourceId('Microsoft.Network/applicationGateways/sslCertificates', parameters('appGatewayName'), 'frontend-cert')]",
+            "httpRedirectId": "[resourceId('Microsoft.Network/applicationGateways/redirectConfigurations', parameters('appGatewayName'), 'http-to-https')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2023-01-31",
+              "name": "[parameters('appGatewayIdentityName')]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]"
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+              "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('appGatewayIdentityName'), variables('keyVaultSecretsUserRoleDefinitionId'))]",
+              "properties": {
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('appGatewayIdentityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('appGatewayIdentityName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/publicIPAddresses",
+              "apiVersion": "2024-07-01",
+              "name": "[parameters('publicIpName')]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]",
+              "sku": {
+                "name": "Standard",
+                "tier": "Regional"
+              },
+              "zones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "properties": {
+                "publicIPAddressVersion": "IPv4",
+                "publicIPAllocationMethod": "Static",
+                "dnsSettings": {
+                  "domainNameLabel": "[toLower(parameters('publicIpDnsLabel'))]"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Network/applicationGateways",
+              "apiVersion": "2024-07-01",
+              "name": "[parameters('appGatewayName')]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]",
+              "zones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('appGatewayIdentityName')))]": {}
+                }
+              },
+              "properties": {
+                "sku": {
+                  "name": "Standard_v2",
+                  "tier": "Standard_v2"
+                },
+                "autoscaleConfiguration": {
+                  "minCapacity": 0,
+                  "maxCapacity": 10
+                },
+                "enableHttp2": true,
+                "sslPolicy": {
+                  "policyType": "Predefined",
+                  "policyName": "AppGwSslPolicy20220101"
+                },
+                "gatewayIPConfigurations": [
+                  {
+                    "name": "gateway-ip-config",
+                    "properties": {
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      }
+                    }
+                  }
+                ],
+                "frontendIPConfigurations": [
+                  {
+                    "name": "frontend-public",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
+                      }
+                    }
+                  }
+                ],
+                "frontendPorts": [
+                  {
+                    "name": "port-http",
+                    "properties": {
+                      "port": 80
+                    }
+                  },
+                  {
+                    "name": "port-https",
+                    "properties": {
+                      "port": 443
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "upload-web-backend",
+                    "properties": {
+                      "backendAddresses": [
+                        {
+                          "fqdn": "[parameters('backendFqdn')]"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "backendHttpSettingsCollection": [
+                  {
+                    "name": "upload-web-https-settings",
+                    "properties": {
+                      "cookieBasedAffinity": "Disabled",
+                      "pickHostNameFromBackendAddress": true,
+                      "port": 443,
+                      "protocol": "Https",
+                      "probe": {
+                        "id": "[variables('httpsProbeId')]"
+                      },
+                      "probeEnabled": true,
+                      "requestTimeout": 30
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "upload-web-healthz",
+                    "properties": {
+                      "protocol": "Https",
+                      "path": "/healthz",
+                      "interval": 30,
+                      "timeout": 10,
+                      "unhealthyThreshold": 3,
+                      "pickHostNameFromBackendHttpSettings": true,
+                      "match": {
+                        "statusCodes": [
+                          "200"
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "sslCertificates": [
+                  {
+                    "name": "frontend-cert",
+                    "properties": {
+                      "keyVaultSecretId": "[parameters('frontendSslCertificateSecretId')]"
+                    }
+                  }
+                ],
+                "httpListeners": [
+                  {
+                    "name": "listener-http",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontendIpConfigurationId')]"
+                      },
+                      "frontendPort": {
+                        "id": "[variables('frontendPortHttpId')]"
+                      },
+                      "protocol": "Http"
+                    }
+                  },
+                  {
+                    "name": "listener-https",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontendIpConfigurationId')]"
+                      },
+                      "frontendPort": {
+                        "id": "[variables('frontendPortHttpsId')]"
+                      },
+                      "protocol": "Https",
+                      "sslCertificate": {
+                        "id": "[variables('sslCertificateId')]"
+                      }
+                    }
+                  }
+                ],
+                "redirectConfigurations": [
+                  {
+                    "name": "http-to-https",
+                    "properties": {
+                      "includePath": true,
+                      "includeQueryString": true,
+                      "redirectType": "Permanent",
+                      "targetListener": {
+                        "id": "[variables('httpsListenerId')]"
+                      }
+                    }
+                  }
+                ],
+                "requestRoutingRules": [
+                  {
+                    "name": "http-redirect",
+                    "properties": {
+                      "httpListener": {
+                        "id": "[variables('httpListenerId')]"
+                      },
+                      "redirectConfiguration": {
+                        "id": "[variables('httpRedirectId')]"
+                      },
+                      "priority": 100,
+                      "ruleType": "Basic"
+                    }
+                  },
+                  {
+                    "name": "https-backend",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "[variables('backendAddressPoolId')]"
+                      },
+                      "backendHttpSettings": {
+                        "id": "[variables('backendHttpSettingsId')]"
+                      },
+                      "httpListener": {
+                        "id": "[variables('httpsListenerId')]"
+                      },
+                      "priority": 110,
+                      "ruleType": "Basic"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('appGatewayIdentityName'))]",
+                "[extensionResourceId(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('appGatewayIdentityName'), variables('keyVaultSecretsUserRoleDefinitionId')))]",
+                "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "appGwPublicFqdn": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Gateway public FQDN."
+              },
+              "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName')), '2024-07-01').dnsSettings.fqdn]"
+            },
+            "appGwPublicIpId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Gateway public IP resource id."
+              },
+              "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'keyVault')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network')]",
+        "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]"
+      ]
+    },
+    {
+      "condition": "[and(parameters('enableUploadWebAuth'), not(empty(parameters('uploadWebEntraClientId'))))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "uploadWebAuth",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "containerAppName": {
+            "value": "[variables('uploadWebAppName')]"
+          },
+          "tenantId": {
+            "value": "[subscription().tenantId]"
+          },
+          "clientId": {
+            "value": "[parameters('uploadWebEntraClientId')]"
+          },
+          "allowedAudiences": {
+            "value": "[parameters('uploadWebAllowedAudiences')]"
+          },
+          "allowedGroupObjectIds": {
+            "value": "[parameters('uploadWebAllowedGroupObjectIds')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "8894751000453714026"
+            }
+          },
+          "parameters": {
+            "containerAppName": {
+              "type": "string",
+              "metadata": {
+                "description": "Container App name for upload-web."
+              }
+            },
+            "tenantId": {
+              "type": "string",
+              "metadata": {
+                "description": "Microsoft Entra tenant id used by Easy Auth."
+              }
+            },
+            "clientId": {
+              "type": "string",
+              "metadata": {
+                "description": "Microsoft Entra application client id used by upload-web Easy Auth."
+              }
+            },
+            "allowedAudiences": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional audiences accepted by upload-web Easy Auth. Defaults to api://{clientId}."
+              }
+            },
+            "allowedGroupObjectIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional Microsoft Entra group object ids allowed to access upload-web."
+              }
+            }
+          },
+          "variables": {
+            "resolvedAllowedAudiences": "[if(empty(parameters('allowedAudiences')), createArray(format('api://{0}', parameters('clientId'))), parameters('allowedAudiences'))]",
+            "aadValidation": "[if(empty(parameters('allowedGroupObjectIds')), createObject('allowedAudiences', variables('resolvedAllowedAudiences')), createObject('allowedAudiences', variables('resolvedAllowedAudiences'), 'defaultAuthorizationPolicy', createObject('allowedPrincipals', createObject('groups', parameters('allowedGroupObjectIds'))), 'jwtClaimChecks', createObject('allowedGroups', parameters('allowedGroupObjectIds'))))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.App/containerApps/authConfigs",
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('containerAppName'), 'current')]",
+              "properties": {
+                "platform": {
+                  "enabled": true
+                },
+                "globalValidation": {
+                  "redirectToProvider": "azureActiveDirectory",
+                  "unauthenticatedClientAction": "RedirectToLoginPage"
+                },
+                "httpSettings": {
+                  "requireHttps": true
+                },
+                "identityProviders": {
+                  "azureActiveDirectory": {
+                    "enabled": true,
+                    "login": {
+                      "loginParameters": [
+                        "scope=openid profile email"
+                      ]
+                    },
+                    "registration": {
+                      "clientId": "[parameters('clientId')]",
+                      "openIdIssuer": "[format('{0}{1}/v2.0', environment().authentication.loginEndpoint, parameters('tenantId'))]"
+                    },
+                    "validation": "[variables('aadValidation')]"
+                  }
+                },
+                "login": {
+                  "tokenStore": {
+                    "enabled": true
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "authConfigId": {
+              "type": "string",
+              "metadata": {
+                "description": "Easy Auth config resource id for upload-web."
+              },
+              "value": "[resourceId('Microsoft.App/containerApps/authConfigs', parameters('containerAppName'), 'current')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]"
       ]
     },
     {
@@ -5119,6 +5782,13 @@
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentId.value]"
     },
+    "containerAppsEnvironmentDefaultDomain": {
+      "type": "string",
+      "metadata": {
+        "description": "Container Apps environment default domain."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentDefaultDomain.value]"
+    },
     "runnersEnvironmentName": {
       "type": "string",
       "metadata": {
@@ -5160,6 +5830,20 @@
         "description": "Escalation timer ACA Job id."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.escalationTimerJobId.value]"
+    },
+    "appGwPublicFqdn": {
+      "type": "string",
+      "metadata": {
+        "description": "Application Gateway public FQDN for upload-web."
+      },
+      "value": "[if(parameters('enableUploadWebAppGateway'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appGateway'), '2025-04-01').outputs.appGwPublicFqdn.value, '')]"
+    },
+    "appGwPublicIpId": {
+      "type": "string",
+      "metadata": {
+        "description": "Application Gateway public IP resource id for upload-web."
+      },
+      "value": "[if(parameters('enableUploadWebAppGateway'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'appGateway'), '2025-04-01').outputs.appGwPublicIpId.value, '')]"
     },
     "networkHardeningEnabled": {
       "type": "bool",

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -47,6 +47,68 @@ resource nsgEgress 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
   tags: tags
 }
 
+resource nsgAppGateway 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+  name: 'nsg-appgw-albaranes-${environment}'
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'allow-http-inbound'
+        properties: {
+          access: 'Allow'
+          direction: 'Inbound'
+          priority: 100
+          protocol: 'Tcp'
+          sourceAddressPrefix: 'Internet'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '80'
+        }
+      }
+      {
+        name: 'allow-https-inbound'
+        properties: {
+          access: 'Allow'
+          direction: 'Inbound'
+          priority: 110
+          protocol: 'Tcp'
+          sourceAddressPrefix: 'Internet'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '443'
+        }
+      }
+      {
+        name: 'allow-gatewaymanager'
+        properties: {
+          access: 'Allow'
+          direction: 'Inbound'
+          priority: 120
+          protocol: 'Tcp'
+          sourceAddressPrefix: 'GatewayManager'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '65200-65535'
+        }
+      }
+      {
+        name: 'deny-rest-inbound'
+        properties: {
+          access: 'Deny'
+          direction: 'Inbound'
+          priority: 4096
+          protocol: '*'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '*'
+        }
+      }
+    ]
+  }
+}
+
 resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   name: vnetName
   location: location
@@ -120,6 +182,15 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
           }
         }
       }
+      {
+        name: 'appgw-snet'
+        properties: {
+          addressPrefix: '10.10.6.0/24'
+          networkSecurityGroup: {
+            id: nsgAppGateway.id
+          }
+        }
+      }
     ]
   }
 }
@@ -142,6 +213,9 @@ output subnetRunnersId string = vnet.properties.subnets[3].id
 @description('Egress subnet id.')
 output subnetEgressId string = vnet.properties.subnets[4].id
 
+@description('Application Gateway subnet id.')
+output subnetAppGatewayId string = vnet.properties.subnets[5].id
+
 @description('ACA NSG id.')
 output nsgAcaId string = nsgAca.id
 
@@ -156,3 +230,6 @@ output nsgRunnersId string = nsgRunners.id
 
 @description('Egress NSG id.')
 output nsgEgressId string = nsgEgress.id
+
+@description('Application Gateway NSG id.')
+output nsgAppGatewayId string = nsgAppGateway.id

--- a/infra/modules/upload-web-auth.bicep
+++ b/infra/modules/upload-web-auth.bicep
@@ -1,0 +1,79 @@
+targetScope = 'resourceGroup'
+
+@description('Container App name for upload-web.')
+param containerAppName string
+
+@description('Microsoft Entra tenant id used by Easy Auth.')
+param tenantId string
+
+@description('Microsoft Entra application client id used by upload-web Easy Auth.')
+param clientId string
+
+@description('Optional audiences accepted by upload-web Easy Auth. Defaults to api://{clientId}.')
+param allowedAudiences array = []
+
+@description('Optional Microsoft Entra group object ids allowed to access upload-web.')
+param allowedGroupObjectIds array = []
+
+var resolvedAllowedAudiences = empty(allowedAudiences) ? [
+  'api://${clientId}'
+] : allowedAudiences
+var aadValidation = empty(allowedGroupObjectIds)
+  ? {
+      allowedAudiences: resolvedAllowedAudiences
+    }
+  : {
+      allowedAudiences: resolvedAllowedAudiences
+      defaultAuthorizationPolicy: {
+        allowedPrincipals: {
+          groups: allowedGroupObjectIds
+        }
+      }
+      jwtClaimChecks: {
+        allowedGroups: allowedGroupObjectIds
+      }
+    }
+
+resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' existing = {
+  name: containerAppName
+}
+
+resource uploadWebAuth 'Microsoft.App/containerApps/authConfigs@2025-01-01' = {
+  parent: uploadWebApp
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      redirectToProvider: 'azureActiveDirectory'
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+    }
+    httpSettings: {
+      requireHttps: true
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        login: {
+          loginParameters: [
+            'scope=openid profile email'
+          ]
+        }
+        registration: {
+          clientId: clientId
+          openIdIssuer: '${environment().authentication.loginEndpoint}${tenantId}/v2.0'
+        }
+        validation: aadValidation
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: true
+      }
+    }
+  }
+}
+
+@description('Easy Auth config resource id for upload-web.')
+output authConfigId string = uploadWebAuth.id


### PR DESCRIPTION
## Summary
- add Application Gateway v2 IaC with dedicated subnet, NSG, HTTPS backend routing, and public ingress outputs
- add upload-web Easy Auth module and main parameters for Entra audiences and group-based access
- document the manual Entra group prerequisite and capture Brett's decision/history notes

Closes #90
Closes #94