### PR TITLE
feat(devops): Dockerfile + CI pipeline for upload-web (#98)

### DIFF
--- a/.github/workflows/upload-web-ci.yml
+++ b/.github/workflows/upload-web-ci.yml
@@ -1,0 +1,70 @@
+name: Upload Web CI
+
+on:
+  push:
+    branches:
+      - squad/*
+    paths:
+      - src/upload_web/**
+      - src/shared/**
+      - docker/upload-web/**
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            docker/upload-web/requirements.txt
+
+      - name: Install lint dependencies
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Ruff check
+        run: ruff check src/upload_web src/shared
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            docker/upload-web/requirements.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r docker/upload-web/requirements.txt pytest pytest-asyncio pytest-cov httpx PyJWT
+
+      - name: Run targeted tests
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(tests/unit/test_upload_web* tests/unit/test_store* tests/unit/test_jinja*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No targeted tests found"
+            exit 1
+          fi
+          pytest "${files[@]}"
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build upload-web image
+        run: docker build --file docker/upload-web/Dockerfile --tag verdecora-upload-web:ci .

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -43,3 +43,9 @@ gh label create "squad" --color "0078d4" --description "Untriaged squad work" --
 - Squad workflow benefits from a deterministic `key -> issue#` map persisted to disk so dependent agents can reference issues without re-querying GitHub.
 - Reworks for rejected stacked PRs are safest in an isolated worktree from `origin/master` so unrelated local changes and lockout branches stay untouched.
 - The Upload Web store detector should consume the canonical JSON catalog via `src.shared.stores.loader.load_stores()` and keep the heuristic logic free of hardcoded store lists.
+
+### 2026-05-05: Upload Web Dockerfile + CI pipeline (UW-16 / #98)
+- Created `docker/upload-web/Dockerfile` as a multi-stage Python 3.12 image for the Upload Web service with a dedicated runtime dependency list, non-root `appuser`, `HEALTHCHECK`, and `uvicorn` entrypoint on port 8000.
+- Added `docker/upload-web/requirements.txt` with the Upload Web runtime dependency subset extracted from `pyproject.toml`.
+- Added `.github/workflows/upload-web-ci.yml` to lint `src/upload_web` + `src/shared`, run the targeted Upload Web/store pytest suite, and verify the Docker image builds on `ubuntu-latest` for `squad/*` pushes touching the Upload Web paths.
+- Verified local Ruff and targeted pytest checks in an isolated worktree from `origin/master`; local Docker image build was blocked because the Docker daemon was unavailable in the environment.

--- a/docker/upload-web/Dockerfile
+++ b/docker/upload-web/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY docker/upload-web/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser
+
+COPY --from=builder /opt/venv /opt/venv
+COPY src/upload_web ./src/upload_web
+COPY src/shared ./src/shared
+COPY src/models ./src/models
+COPY data/stores ./data/stores
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8000
+
+HEALTHCHECK CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]
+
+CMD ["uvicorn", "src.upload_web.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/upload-web/requirements.txt
+++ b/docker/upload-web/requirements.txt
@@ -1,0 +1,10 @@
+fastapi>=0.115.0
+uvicorn>=0.34.0
+jinja2>=3.1.0
+python-multipart>=0.0.20
+azure-storage-blob>=12.24.0
+azure-identity>=1.20.0
+azure-cosmos>=4.9.0
+pydantic>=2.11.0
+pydantic-settings>=2.10.1
+aiohttp>=3.11.0


### PR DESCRIPTION
## Summary
- add a dedicated multi-stage Dockerfile and runtime requirements for upload-web
- add upload-web specific GitHub Actions lint, test, and docker build jobs for squad branches
- append Hicks history with the DevOps work log for UW-16

Closes #98