### PR TITLE
feat(infra): upload-web Container App + Cosmos sessions + EventGrid filter (#96, #97, #101)

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -28,3 +28,9 @@
 - Added `infra/modules/appgw.bicep` wiring for Standard_v2 autoscale, HTTP→HTTPS redirect, `/healthz` probing, backend HTTPS to the ACA internal FQDN, and Key Vault-backed TLS certificate access via managed identity.
 - Added `infra/modules/upload-web-auth.bicep` so Easy Auth can be switched on for `verdecora-upload-web-${environment}` with Entra audiences plus optional `verdecora-store-uploaders` group enforcement once the app exists.
 - Documented that the Entra group itself must still be created manually in the Azure portal before rollout.
+
+### 2026-05-05 — Upload-web ACA app + session store wiring
+- Added `infra/modules/upload-web-app.bicep` and a new `enableUploadWeb` feature flag in `infra/modules/main.bicep` so the private `verdecora-upload-web-${environment}` Container App can be deployed into the shared ACA environment without exposing public ingress.
+- Provisioned the Cosmos `upload-sessions` container in `albaranes-db` with `/user_oid` partitioning, 24-hour TTL, and baseline throughput for short-lived upload UI session state.
+- Extended managed-identity RBAC so upload-web can pull from ACR and use Blob/Cosmos data-plane access without secrets.
+- Tightened the Event Grid subject prefix documentation/filter to the `albaranes-raw/blobs/` root so nested upload-web blob paths still trigger Flow 0 ingestion.

--- a/docs/security/identity-matrix.md
+++ b/docs/security/identity-matrix.md
@@ -29,6 +29,10 @@
 | HITL web form | `hitl-webform` | Blob Storage account | Storage Blob Data Contributor | Generate User Delegation Keys and serve read-only SAS URLs for original PDFs without storage account keys. |
 | HITL web form | `hitl-webform` | Service Bus namespace | Azure Service Bus Data Sender | Resume workflows after human approval, rejection, or modification. |
 | HITL web form | `hitl-webform` | Key Vault | Key Vault Secrets User | Read approved secret-backed configuration without embedding credentials in code. |
+| Upload web app | `upload-web` | Cosmos DB NoSQL account | Cosmos DB Built-in Data Contributor | Persist upload session state in `upload-sessions` and query upload status without account keys. |
+| Upload web app | `upload-web` | Blob Storage account | Storage Blob Data Contributor | Create upload payloads in `albaranes-raw` using managed identity instead of storage account keys. |
+| Upload web app | `upload-web` | Blob Storage account | Storage Blob Delegator | Issue user delegation SAS tokens for browser/mobile uploads without exposing storage keys. |
+| Upload web app | `upload-web` | Azure Container Registry | AcrPull | Pull the private `verdecora-upload-web` image into the ACA environment. |
 | Flow 0 worker | `flow0-worker` | Cosmos DB NoSQL account | Cosmos DB Built-in Data Contributor | Write deduplication records and initial ingestion state. |
 | Flow 0 worker | `flow0-worker` | Service Bus namespace | Azure Service Bus Data Sender | Publish `albaran.recibido` events after deduplication. |
 | Flow 0 worker | `flow0-worker` | Blob Storage account | Storage Blob Data Reader | Read source PDFs and blob metadata during ingestion. |

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,6 +9,8 @@ Deploy with: `az deployment group create -t main.bicep`
 
 ## Upload web notes
 
+- Set `enableUploadWeb=true` to deploy the private `verdecora-upload-web-${environment}` Container App into the shared ACA environment.
 - Create the Microsoft Entra group `verdecora-store-uploaders` manually in the Azure portal, then pass its object ID(s) through `uploadWebAllowedGroupObjectIds` when enabling Easy Auth.
 - Set `enableUploadWebAuth=true` only after `verdecora-upload-web-${environment}` exists in the Container Apps environment.
 - Set `enableUploadWebAppGateway=true` and configure `appGwFrontendCertificateSecretId` with a Key Vault PFX secret URI before deploying the Application Gateway HTTPS listener.
+- The upload UI session metadata now lives in the Cosmos `upload-sessions` container (TTL 24h, partition key `/user_oid`).

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -98,6 +98,25 @@ resource dlqContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contai
   }
 }
 
+resource uploadSessionsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = {
+  name: '${cosmosAccount.name}/albaranes-db/upload-sessions'
+  properties: {
+    resource: {
+      id: 'upload-sessions'
+      partitionKey: {
+        paths: [
+          '/user_oid'
+        ]
+        kind: 'Hash'
+      }
+      defaultTtl: 86400
+    }
+    options: {
+      throughput: 400
+    }
+  }
+}
+
 @description('Cosmos DB account id.')
 output cosmosAccountId string = cosmosAccount.id
 
@@ -118,3 +137,6 @@ output tiendasContainerId string = tiendasContainer.id
 
 @description('DLQ container id.')
 output dlqContainerId string = dlqContainer.id
+
+@description('Upload sessions container id.')
+output uploadSessionsContainerId string = uploadSessionsContainer.id

--- a/infra/modules/eventgrid.bicep
+++ b/infra/modules/eventgrid.bicep
@@ -79,7 +79,9 @@ resource blobCreatedSubscription 'Microsoft.EventGrid/systemTopics/eventSubscrip
       includedEventTypes: [
         'Microsoft.Storage.BlobCreated'
       ]
-      subjectBeginsWith: '/blobServices/default/containers/albaranes-raw'
+      // upload-web writes blobs under albaranes-raw/{session_id}/... (and deeper nested prefixes),
+      // so filtering at the container blob root keeps Event Grid -> Flow 0 working for every new upload path.
+      subjectBeginsWith: '/blobServices/default/containers/albaranes-raw/blobs/'
       isSubjectCaseSensitive: false
     }
     retryPolicy: {

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -36,6 +36,9 @@ param flow0WorkerPrincipalId string = ''
 @description('Optional system-assigned principal id for the escalation timer ACA Job.')
 param escalationTimerPrincipalId string = ''
 
+@description('Optional system-assigned principal id for the upload-web ACA app.')
+param uploadWebPrincipalId string = ''
+
 var cosmosBuiltInDataContributorRoleDefinitionId = '00000000-0000-0000-0000-000000000002'
 var serviceBusDataSenderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
 var serviceBusDataReceiverRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
@@ -331,9 +334,50 @@ resource escalationTimerSystemAssignedAcrPullRoleAssignment 'Microsoft.Authoriza
   }
 }
 
+resource uploadWebSystemAssignedBlobContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId)) {
+  name: guid(storageAccount.id, uploadWebPrincipalId, storageBlobDataContributorRoleDefinitionId, 'system')
+  scope: storageAccount
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleDefinitionId
+  }
+}
+
+resource uploadWebSystemAssignedBlobDelegatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId)) {
+  name: guid(storageAccount.id, uploadWebPrincipalId, storageBlobDelegatorRoleDefinitionId, 'system')
+  scope: storageAccount
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDelegatorRoleDefinitionId
+  }
+}
+
+resource uploadWebSystemAssignedCosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = if (!empty(uploadWebPrincipalId)) {
+  parent: cosmosAccount
+  name: guid(cosmosAccount.id, uploadWebPrincipalId, cosmosBuiltInDataContributorRoleDefinitionId, 'system')
+  properties: {
+    principalId: uploadWebPrincipalId
+    roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosBuiltInDataContributorRoleDefinitionId}'
+    scope: cosmosAccount.id
+  }
+}
+
+resource uploadWebSystemAssignedAcrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId) && !empty(acrName)) {
+  name: guid(acr.id, uploadWebPrincipalId, acrPullRoleDefinitionId, 'system')
+  scope: acr
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: acrPullRoleDefinitionId
+  }
+}
+
 output identities object = {
   orchestratorSystemAssignedPrincipalId: orchestratorPrincipalId
   hitlWebformSystemAssignedPrincipalId: hitlWebformPrincipalId
   flow0WorkerSystemAssignedPrincipalId: flow0WorkerPrincipalId
   escalationTimerSystemAssignedPrincipalId: escalationTimerPrincipalId
+  uploadWebSystemAssignedPrincipalId: uploadWebPrincipalId
 }

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -21,9 +21,15 @@ param hitlWebformImage string = ''
 @description('Optional override for the escalation timer job image during infrastructure deployments.')
 param escalationTimerJobImage string = ''
 
+@description('Optional override for the upload-web image during infrastructure deployments.')
+param uploadWebImage string = ''
+
 @secure()
 @description('Key Vault secret identifier for the Application Gateway TLS certificate (PFX secret, versionless URI recommended).')
 param appGwFrontendCertificateSecretId string = ''
+
+@description('Enable upload-web Container App deployment.')
+param enableUploadWeb bool = false
 
 @description('Enable Application Gateway deployment for upload-web once the TLS certificate secret is ready.')
 param enableUploadWebAppGateway bool = false
@@ -268,6 +274,21 @@ module containerApps './container-apps.bicep' = {
   ]
 }
 
+module uploadWebApp './upload-web-app.bicep' = if (enableUploadWeb) {
+  name: 'uploadWebApp'
+  scope: az.resourceGroup(resourceGroupName)
+  params: {
+    environment: environment
+    location: location
+    managedEnvironmentId: containerApps.outputs.managedEnvironmentId
+    acrLoginServer: acr.outputs.acrLoginServer
+    storageAccountUrl: storageAccountUrl
+    cosmosEndpoint: cosmos.outputs.cosmosEndpoint
+    applicationInsightsConnectionString: monitoring.outputs.applicationInsightsConnectionString
+    uploadWebImage: uploadWebImage
+  }
+}
+
 var uploadWebAppName = 'verdecora-upload-web-${environment}'
 var uploadWebBackendFqdn = '${uploadWebAppName}.internal.${containerApps.outputs.managedEnvironmentDefaultDomain}'
 
@@ -333,6 +354,7 @@ module identity './identity.bicep' = {
     hitlWebformPrincipalId: containerApps.outputs.hitlWebformPrincipalId
     flow0WorkerPrincipalId: containerApps.outputs.flow0DedupPrincipalId
     escalationTimerPrincipalId: containerApps.outputs.escalationTimerPrincipalId
+    uploadWebPrincipalId: enableUploadWeb ? uploadWebApp.outputs.uploadWebPrincipalId : ''
   }
   dependsOn: [
     rg
@@ -382,6 +404,9 @@ output cosmosAccountId string = cosmos.outputs.cosmosAccountId
 
 @description('Cosmos DB endpoint.')
 output cosmosEndpoint string = cosmos.outputs.cosmosEndpoint
+
+@description('Upload sessions container id.')
+output uploadSessionsContainerId string = cosmos.outputs.uploadSessionsContainerId
 
 @description('Storage account id.')
 output storageAccountId string = storage.outputs.storageAccountId
@@ -472,6 +497,9 @@ output hitlWebformAppId string = containerApps.outputs.hitlWebformAppId
 
 @description('Escalation timer ACA Job id.')
 output escalationTimerJobId string = containerApps.outputs.escalationTimerJobId
+
+@description('Upload-web container app id.')
+output uploadWebAppId string = enableUploadWeb ? uploadWebApp.outputs.uploadWebAppId : ''
 
 @description('Application Gateway public FQDN for upload-web.')
 output appGwPublicFqdn string = enableUploadWebAppGateway ? appGateway!.outputs.appGwPublicFqdn : ''

--- a/infra/modules/main.json
+++ b/infra/modules/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "6784977157700746004"
+      "templateHash": "13582473259998606215"
     }
   },
   "parameters": {
@@ -57,11 +57,25 @@
         "description": "Optional override for the escalation timer job image during infrastructure deployments."
       }
     },
+    "uploadWebImage": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional override for the upload-web image during infrastructure deployments."
+      }
+    },
     "appGwFrontendCertificateSecretId": {
       "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Key Vault secret identifier for the Application Gateway TLS certificate (PFX secret, versionless URI recommended)."
+      }
+    },
+    "enableUploadWeb": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable upload-web Container App deployment."
       }
     },
     "enableUploadWebAppGateway": {
@@ -791,7 +805,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "7924333133771176499"
+              "templateHash": "14336631258523432210"
             }
           },
           "parameters": {
@@ -917,6 +931,29 @@
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('accountName'))]"
               ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2023-04-15",
+              "name": "[format('{0}/albaranes-db/upload-sessions', variables('accountName'))]",
+              "properties": {
+                "resource": {
+                  "id": "upload-sessions",
+                  "partitionKey": {
+                    "paths": [
+                      "/user_oid"
+                    ],
+                    "kind": "Hash"
+                  },
+                  "defaultTtl": 86400
+                },
+                "options": {
+                  "throughput": 400
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('accountName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -968,6 +1005,13 @@
                 "description": "DLQ container id."
               },
               "value": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', split(format('{0}/albaranes-db/dlq', variables('accountName')), '/')[0], split(format('{0}/albaranes-db/dlq', variables('accountName')), '/')[1], split(format('{0}/albaranes-db/dlq', variables('accountName')), '/')[2])]"
+            },
+            "uploadSessionsContainerId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload sessions container id."
+              },
+              "value": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', split(format('{0}/albaranes-db/upload-sessions', variables('accountName')), '/')[0], split(format('{0}/albaranes-db/upload-sessions', variables('accountName')), '/')[1], split(format('{0}/albaranes-db/upload-sessions', variables('accountName')), '/')[2])]"
             }
           }
         }
@@ -3329,7 +3373,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "9811920103377580210"
+              "templateHash": "1526511513243205740"
             }
           },
           "parameters": {
@@ -3466,6 +3510,20 @@
               "metadata": {
                 "description": "Optional override for the escalation timer ACA Job image."
               }
+            },
+            "reconciliationJobImage": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional override for the reconciliation ACA Job image."
+              }
+            },
+            "learningJobImage": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional override for the learning ACA Job image."
+              }
             }
           },
           "variables": {
@@ -3479,7 +3537,9 @@
             "resolvedOrchestratorImage": "[if(empty(parameters('orchestratorImage')), format('{0}/verdecora-orchestrator:latest', parameters('acrLoginServer')), parameters('orchestratorImage'))]",
             "resolvedDedupJobImage": "[if(empty(parameters('dedupJobImage')), format('{0}/verdecora-flow0-dedup:latest', parameters('acrLoginServer')), parameters('dedupJobImage'))]",
             "resolvedHitlWebformImage": "[if(empty(parameters('hitlWebformImage')), format('{0}/verdecora-hitl-webform:latest', parameters('acrLoginServer')), parameters('hitlWebformImage'))]",
-            "resolvedEscalationTimerJobImage": "[if(empty(parameters('escalationTimerJobImage')), format('{0}/verdecora-escalation-timer:latest', parameters('acrLoginServer')), parameters('escalationTimerJobImage'))]"
+            "resolvedEscalationTimerJobImage": "[if(empty(parameters('escalationTimerJobImage')), format('{0}/verdecora-escalation-timer:latest', parameters('acrLoginServer')), parameters('escalationTimerJobImage'))]",
+            "resolvedReconciliationJobImage": "[if(empty(parameters('reconciliationJobImage')), 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest', parameters('reconciliationJobImage'))]",
+            "resolvedLearningJobImage": "[if(empty(parameters('learningJobImage')), 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest', parameters('learningJobImage'))]"
           },
           "resources": [
             {
@@ -3850,6 +3910,122 @@
               "dependsOn": [
                 "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]"
               ]
+            },
+            {
+              "type": "Microsoft.App/jobs",
+              "apiVersion": "2025-01-01",
+              "name": "[format('verdecora-reconciliation-{0}', parameters('environment'))]",
+              "location": "[parameters('location')]",
+              "tags": "[union(variables('tags'), createObject('service', 'reconciliation'))]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "environmentId": "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]",
+                "configuration": {
+                  "registries": [
+                    {
+                      "server": "[parameters('acrLoginServer')]",
+                      "identity": "system"
+                    }
+                  ],
+                  "triggerType": "Schedule",
+                  "replicaTimeout": 1800,
+                  "replicaRetryLimit": 1,
+                  "scheduleTriggerConfig": {
+                    "cronExpression": "0 6 * * *",
+                    "parallelism": 1,
+                    "replicaCompletionCount": 1
+                  }
+                },
+                "template": {
+                  "containers": [
+                    {
+                      "name": "reconciliation",
+                      "image": "[variables('resolvedReconciliationJobImage')]",
+                      "env": [
+                        {
+                          "name": "COSMOS_ENDPOINT",
+                          "value": "[parameters('cosmosEndpoint')]"
+                        },
+                        {
+                          "name": "SERVICE_BUS_NAMESPACE",
+                          "value": "[parameters('serviceBusNamespaceName')]"
+                        },
+                        {
+                          "name": "ACS_ENDPOINT",
+                          "value": "[parameters('acsEndpoint')]"
+                        },
+                        {
+                          "name": "AZURE_AI_PROJECT_ENDPOINT",
+                          "value": "[parameters('aiServicesEndpoint')]"
+                        }
+                      ],
+                      "resources": {
+                        "cpu": "[json('0.25')]",
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.App/jobs",
+              "apiVersion": "2025-01-01",
+              "name": "[format('verdecora-learning-{0}', parameters('environment'))]",
+              "location": "[parameters('location')]",
+              "tags": "[union(variables('tags'), createObject('service', 'learning'))]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "environmentId": "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]",
+                "configuration": {
+                  "registries": [
+                    {
+                      "server": "[parameters('acrLoginServer')]",
+                      "identity": "system"
+                    }
+                  ],
+                  "triggerType": "Schedule",
+                  "replicaTimeout": 1800,
+                  "replicaRetryLimit": 1,
+                  "scheduleTriggerConfig": {
+                    "cronExpression": "0 4 * * 0",
+                    "parallelism": 1,
+                    "replicaCompletionCount": 1
+                  }
+                },
+                "template": {
+                  "containers": [
+                    {
+                      "name": "learning",
+                      "image": "[variables('resolvedLearningJobImage')]",
+                      "env": [
+                        {
+                          "name": "COSMOS_ENDPOINT",
+                          "value": "[parameters('cosmosEndpoint')]"
+                        },
+                        {
+                          "name": "AZURE_AI_PROJECT_ENDPOINT",
+                          "value": "[parameters('aiServicesEndpoint')]"
+                        }
+                      ],
+                      "resources": {
+                        "cpu": "[json('0.25')]",
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -3929,6 +4105,34 @@
                 "description": "Escalation timer ACA Job managed identity principal id."
               },
               "value": "[reference(resourceId('Microsoft.App/jobs', format('verdecora-escalation-timer-{0}', parameters('environment'))), '2025-01-01', 'full').identity.principalId]"
+            },
+            "reconciliationJobId": {
+              "type": "string",
+              "metadata": {
+                "description": "Reconciliation ACA Job id."
+              },
+              "value": "[resourceId('Microsoft.App/jobs', format('verdecora-reconciliation-{0}', parameters('environment')))]"
+            },
+            "reconciliationPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Reconciliation ACA Job managed identity principal id."
+              },
+              "value": "[reference(resourceId('Microsoft.App/jobs', format('verdecora-reconciliation-{0}', parameters('environment'))), '2025-01-01', 'full').identity.principalId]"
+            },
+            "learningJobId": {
+              "type": "string",
+              "metadata": {
+                "description": "Learning ACA Job id."
+              },
+              "value": "[resourceId('Microsoft.App/jobs', format('verdecora-learning-{0}', parameters('environment')))]"
+            },
+            "learningPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Learning ACA Job managed identity principal id."
+              },
+              "value": "[reference(resourceId('Microsoft.App/jobs', format('verdecora-learning-{0}', parameters('environment'))), '2025-01-01', 'full').identity.principalId]"
             }
           }
         }
@@ -3946,6 +4150,217 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'privateEndpoints')]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'serviceBus')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]"
+      ]
+    },
+    {
+      "condition": "[parameters('enableUploadWeb')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "uploadWebApp",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "environment": {
+            "value": "[parameters('environment')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "managedEnvironmentId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentId.value]"
+          },
+          "acrLoginServer": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr'), '2025-04-01').outputs.acrLoginServer.value]"
+          },
+          "storageAccountUrl": {
+            "value": "[format('https://{0}.blob.{1}/', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage'), '2025-04-01').outputs.storageAccountName.value, environment().suffixes.storage)]"
+          },
+          "cosmosEndpoint": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos'), '2025-04-01').outputs.cosmosEndpoint.value]"
+          },
+          "applicationInsightsConnectionString": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'monitoring'), '2025-04-01').outputs.applicationInsightsConnectionString.value]"
+          },
+          "uploadWebImage": {
+            "value": "[parameters('uploadWebImage')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "5620655351156105687"
+            }
+          },
+          "parameters": {
+            "environment": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment name (dev/test/prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for Container Apps resources."
+              }
+            },
+            "managedEnvironmentId": {
+              "type": "string",
+              "metadata": {
+                "description": "Existing Container Apps managed environment resource id used by upload-web."
+              }
+            },
+            "acrLoginServer": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure Container Registry login server used for the upload-web image."
+              }
+            },
+            "storageAccountUrl": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage account blob endpoint exposed to upload-web."
+              }
+            },
+            "cosmosEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Cosmos DB endpoint exposed to upload-web."
+              }
+            },
+            "applicationInsightsConnectionString": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Insights connection string injected into upload-web."
+              }
+            },
+            "uploadWebImage": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional override for the upload-web image."
+              }
+            }
+          },
+          "variables": {
+            "tags": {
+              "project": "verdecora-albaranes",
+              "env": "[parameters('environment')]",
+              "service": "upload-web",
+              "managed-by": "bicep"
+            },
+            "resolvedUploadWebImage": "[if(empty(parameters('uploadWebImage')), format('{0}/verdecora-upload-web:latest', parameters('acrLoginServer')), parameters('uploadWebImage'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.App/containerApps",
+              "apiVersion": "2025-01-01",
+              "name": "[format('verdecora-upload-web-{0}', parameters('environment'))]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "environmentId": "[parameters('managedEnvironmentId')]",
+                "configuration": {
+                  "activeRevisionsMode": "Single",
+                  "registries": [
+                    {
+                      "server": "[parameters('acrLoginServer')]",
+                      "identity": "system"
+                    }
+                  ],
+                  "ingress": {
+                    "external": false,
+                    "allowInsecure": false,
+                    "targetPort": 8000,
+                    "transport": "Auto"
+                  }
+                },
+                "template": {
+                  "containers": [
+                    {
+                      "name": "upload-web",
+                      "image": "[variables('resolvedUploadWebImage')]",
+                      "env": [
+                        {
+                          "name": "STORAGE_ACCOUNT_URL",
+                          "value": "[parameters('storageAccountUrl')]"
+                        },
+                        {
+                          "name": "COSMOS_ENDPOINT",
+                          "value": "[parameters('cosmosEndpoint')]"
+                        },
+                        {
+                          "name": "APPINSIGHTS_CONNECTION_STRING",
+                          "value": "[parameters('applicationInsightsConnectionString')]"
+                        }
+                      ],
+                      "resources": {
+                        "cpu": "[json('0.5')]",
+                        "memory": "1Gi"
+                      },
+                      "probes": [
+                        {
+                          "type": "Liveness",
+                          "httpGet": {
+                            "path": "/healthz",
+                            "port": 8000
+                          },
+                          "initialDelaySeconds": 5,
+                          "periodSeconds": 30
+                        }
+                      ]
+                    }
+                  ],
+                  "scale": {
+                    "minReplicas": 1,
+                    "maxReplicas": 5
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "uploadWebAppId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web container app id."
+              },
+              "value": "[resourceId('Microsoft.App/containerApps', format('verdecora-upload-web-{0}', parameters('environment')))]"
+            },
+            "uploadWebAppName": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web container app name."
+              },
+              "value": "[format('verdecora-upload-web-{0}', parameters('environment'))]"
+            },
+            "uploadWebPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web managed identity principal id."
+              },
+              "value": "[reference(resourceId('Microsoft.App/containerApps', format('verdecora-upload-web-{0}', parameters('environment'))), '2025-01-01', 'full').identity.principalId]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'monitoring')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]"
       ]
     },
@@ -4509,7 +4924,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "6832764745457073911"
+              "templateHash": "4496258555352146639"
             }
           },
           "parameters": {
@@ -4603,7 +5018,7 @@
                   "includedEventTypes": [
                     "Microsoft.Storage.BlobCreated"
                   ],
-                  "subjectBeginsWith": "/blobServices/default/containers/albaranes-raw",
+                  "subjectBeginsWith": "/blobServices/default/containers/albaranes-raw/blobs/",
                   "isSubjectCaseSensitive": false
                 },
                 "retryPolicy": {
@@ -4687,7 +5102,8 @@
           },
           "escalationTimerPrincipalId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.escalationTimerPrincipalId.value]"
-          }
+          },
+          "uploadWebPrincipalId": "[if(parameters('enableUploadWeb'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'uploadWebApp'), '2025-04-01').outputs.uploadWebPrincipalId.value), createObject('value', ''))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -4696,7 +5112,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "144572381153987395"
+              "templateHash": "2956969929273550838"
             }
           },
           "parameters": {
@@ -4779,6 +5195,13 @@
               "defaultValue": "",
               "metadata": {
                 "description": "Optional system-assigned principal id for the escalation timer ACA Job."
+              }
+            },
+            "uploadWebPrincipalId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional system-assigned principal id for the upload-web ACA app."
               }
             }
           },
@@ -5091,6 +5514,53 @@
                 "principalType": "ServicePrincipal",
                 "roleDefinitionId": "[variables('acrPullRoleDefinitionId')]"
               }
+            },
+            {
+              "condition": "[not(empty(parameters('uploadWebPrincipalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('uploadWebPrincipalId'), variables('storageBlobDataContributorRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('storageBlobDataContributorRoleDefinitionId')]"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('uploadWebPrincipalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('uploadWebPrincipalId'), variables('storageBlobDelegatorRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('storageBlobDelegatorRoleDefinitionId')]"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('uploadWebPrincipalId')))]",
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+              "apiVersion": "2024-05-15",
+              "name": "[format('{0}/{1}', parameters('cosmosAccountName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosAccountName')), parameters('uploadWebPrincipalId'), variables('cosmosBuiltInDataContributorRoleDefinitionId'), 'system'))]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosAccountName')), variables('cosmosBuiltInDataContributorRoleDefinitionId'))]",
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosAccountName'))]"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('uploadWebPrincipalId'))), not(empty(parameters('acrName'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+              "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), parameters('uploadWebPrincipalId'), variables('acrPullRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('acrPullRoleDefinitionId')]"
+              }
             }
           ],
           "outputs": {
@@ -5100,7 +5570,8 @@
                 "orchestratorSystemAssignedPrincipalId": "[parameters('orchestratorPrincipalId')]",
                 "hitlWebformSystemAssignedPrincipalId": "[parameters('hitlWebformPrincipalId')]",
                 "flow0WorkerSystemAssignedPrincipalId": "[parameters('flow0WorkerPrincipalId')]",
-                "escalationTimerSystemAssignedPrincipalId": "[parameters('escalationTimerPrincipalId')]"
+                "escalationTimerSystemAssignedPrincipalId": "[parameters('escalationTimerPrincipalId')]",
+                "uploadWebSystemAssignedPrincipalId": "[parameters('uploadWebPrincipalId')]"
               }
             }
           }
@@ -5116,7 +5587,8 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'keyVault')]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'serviceBus')]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'uploadWebApp')]"
       ]
     },
     {
@@ -5621,6 +6093,13 @@
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos'), '2025-04-01').outputs.cosmosEndpoint.value]"
     },
+    "uploadSessionsContainerId": {
+      "type": "string",
+      "metadata": {
+        "description": "Upload sessions container id."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos'), '2025-04-01').outputs.uploadSessionsContainerId.value]"
+    },
     "storageAccountId": {
       "type": "string",
       "metadata": {
@@ -5830,6 +6309,13 @@
         "description": "Escalation timer ACA Job id."
       },
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.escalationTimerJobId.value]"
+    },
+    "uploadWebAppId": {
+      "type": "string",
+      "metadata": {
+        "description": "Upload-web container app id."
+      },
+      "value": "[if(parameters('enableUploadWeb'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'uploadWebApp'), '2025-04-01').outputs.uploadWebAppId.value, '')]"
     },
     "appGwPublicFqdn": {
       "type": "string",

--- a/infra/modules/upload-web-app.bicep
+++ b/infra/modules/upload-web-app.bicep
@@ -1,0 +1,110 @@
+targetScope = 'resourceGroup'
+
+@description('Deployment environment name (dev/test/prod).')
+param environment string
+
+@description('Azure region for Container Apps resources.')
+param location string
+
+@description('Existing Container Apps managed environment resource id used by upload-web.')
+param managedEnvironmentId string
+
+@description('Azure Container Registry login server used for the upload-web image.')
+param acrLoginServer string
+
+@description('Storage account blob endpoint exposed to upload-web.')
+param storageAccountUrl string
+
+@description('Cosmos DB endpoint exposed to upload-web.')
+param cosmosEndpoint string
+
+@description('Application Insights connection string injected into upload-web.')
+param applicationInsightsConnectionString string
+
+@description('Optional override for the upload-web image.')
+param uploadWebImage string = ''
+
+var tags = {
+  project: 'verdecora-albaranes'
+  env: environment
+  service: 'upload-web'
+  'managed-by': 'bicep'
+}
+var resolvedUploadWebImage = empty(uploadWebImage) ? '${acrLoginServer}/verdecora-upload-web:latest' : uploadWebImage
+
+resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
+  name: 'verdecora-upload-web-${environment}'
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    environmentId: managedEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: acrLoginServer
+          identity: 'system'
+        }
+      ]
+      ingress: {
+        external: false
+        allowInsecure: false
+        targetPort: 8000
+        transport: 'Auto'
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'upload-web'
+          image: resolvedUploadWebImage
+          env: [
+            {
+              name: 'STORAGE_ACCOUNT_URL'
+              value: storageAccountUrl
+            }
+            {
+              name: 'COSMOS_ENDPOINT'
+              value: cosmosEndpoint
+            }
+            {
+              name: 'APPINSIGHTS_CONNECTION_STRING'
+              value: applicationInsightsConnectionString
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/healthz'
+                port: 8000
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 30
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 5
+      }
+    }
+  }
+}
+
+@description('Upload-web container app id.')
+output uploadWebAppId string = uploadWebApp.id
+
+@description('Upload-web container app name.')
+output uploadWebAppName string = uploadWebApp.name
+
+@description('Upload-web managed identity principal id.')
+output uploadWebPrincipalId string = uploadWebApp.identity.principalId

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "agent-framework>=1.2.2,<2.0",
-    "agent-framework-azure-cosmos>=1.2.2,<2.0",
     "aiohttp>=3.11.0",
     "azure-ai-documentintelligence>=1.0.2",
     "azure-communication-email>=1.0.0",


### PR DESCRIPTION
## Summary
- add the private upload-web Container App module and wire it into main.bicep behind `enableUploadWeb`
- provision the Cosmos `upload-sessions` container and upload-web managed identity RBAC for Blob/Cosmos/ACR
- tighten/document the Event Grid subject filter so nested `albaranes-raw` upload paths still reach Flow 0

Closes #96
Closes #97
Closes #101