### PR TITLE
feat(upload-web): HTMX frontend — file capture, preflight UI, summary (#103)

### DIFF
--- a/src/upload_web/static/css/upload.css
+++ b/src/upload_web/static/css/upload.css
@@ -1,0 +1,509 @@
+/* ───────────────────────────────────────────────
+   Upload page styles — Verdecora Upload Web
+   ─────────────────────────────────────────────── */
+
+/* Dropzone */
+.dropzone {
+  position: relative;
+  border: 2px dashed var(--vc-primary, #01928F);
+  border-radius: 1.5rem;
+  background: rgba(1, 146, 143, 0.04);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.dropzone:hover,
+.dropzone.dragover {
+  background: rgba(1, 146, 143, 0.10);
+  border-color: var(--vc-nav-dark, #005E62);
+  box-shadow: 0 0 0 4px rgba(1, 146, 143, 0.12);
+}
+
+.dropzone input[type="file"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.dropzone-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  background: white;
+  font-size: 1.75rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.dropzone-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--vc-text);
+  margin: 0 0 0.25rem;
+}
+
+.dropzone-hint {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin: 0;
+}
+
+/* File list */
+.file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  transition: box-shadow 0.15s;
+}
+
+.file-item:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.file-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: rgba(1, 146, 143, 0.08);
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.file-thumb {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.file-name {
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--vc-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-size {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+
+.file-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.file-remove:hover {
+  background: #fef2f2;
+  color: #ef4444;
+}
+
+/* Upload progress bar */
+.file-progress {
+  flex: 1;
+  height: 0.375rem;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.file-progress-bar {
+  height: 100%;
+  background: var(--vc-primary);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.file-progress-bar.complete {
+  background: #22c55e;
+}
+
+.file-progress-bar.error {
+  background: #ef4444;
+}
+
+/* Confidence indicators */
+.confidence-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.confidence-high {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.confidence-medium {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.confidence-low {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+/* Result card */
+.result-card {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  margin-top: 1rem;
+}
+
+.result-card.success {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.result-card.warning {
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.result-card.error {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.result-card p {
+  margin: 0.375rem 0;
+  font-size: 0.875rem;
+  color: var(--vc-text);
+}
+
+.result-card p:first-child {
+  margin-top: 0;
+}
+
+/* Grouping UI */
+.albaran-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.albaran-group {
+  padding: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  background: #f8fafc;
+  min-height: 4rem;
+}
+
+.albaran-group.drag-over {
+  border-color: var(--vc-primary);
+  background: rgba(1, 146, 143, 0.06);
+}
+
+.albaran-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.albaran-group-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--vc-text);
+}
+
+.albaran-group-count {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+/* Summary table */
+.summary-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.875rem;
+}
+
+.summary-table th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  color: #64748b;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.summary-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.summary-table tr:last-child td {
+  border-bottom: none;
+}
+
+.summary-table .editable-field {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: white;
+  transition: border-color 0.15s;
+}
+
+.summary-table .editable-field:focus {
+  outline: none;
+  border-color: var(--vc-primary);
+  box-shadow: 0 0 0 3px rgba(1, 146, 143, 0.1);
+}
+
+.warning-row {
+  background: #fffbeb;
+}
+
+.warning-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+/* Store selector */
+.store-selector {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: white;
+  min-width: 16rem;
+}
+
+.store-selector:focus {
+  outline: none;
+  border-color: var(--vc-primary);
+  box-shadow: 0 0 0 3px rgba(1, 146, 143, 0.1);
+}
+
+/* Step indicator */
+.step-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #94a3b8;
+}
+
+.step.active {
+  color: var(--vc-primary);
+  font-weight: 600;
+}
+
+.step.completed {
+  color: #22c55e;
+}
+
+.step-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: #e2e8f0;
+  color: #64748b;
+}
+
+.step.active .step-number {
+  background: var(--vc-primary);
+  color: white;
+}
+
+.step.completed .step-number {
+  background: #22c55e;
+  color: white;
+}
+
+.step-divider {
+  width: 2rem;
+  height: 2px;
+  background: #e2e8f0;
+}
+
+/* Buttons */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.75rem 2rem;
+  border: none;
+  border-radius: 999px;
+  background: var(--vc-primary);
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: brightness 0.15s, box-shadow 0.15s;
+  box-shadow: 0 4px 14px rgba(0, 94, 98, 0.15);
+}
+
+.btn-primary:hover {
+  filter: brightness(1.05);
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.625rem 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  background: white;
+  color: var(--vc-text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-secondary:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+/* HTMX loading indicator */
+.htmx-indicator {
+  display: none;
+}
+
+.htmx-request .htmx-indicator {
+  display: inline-flex;
+}
+
+.htmx-request .htmx-hide-on-request {
+  display: none;
+}
+
+.spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive — tablet-first */
+@media (max-width: 768px) {
+  .dropzone {
+    padding: 2rem 1rem;
+  }
+
+  .summary-table {
+    font-size: 0.8125rem;
+  }
+
+  .summary-table th,
+  .summary-table td {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .step-indicator {
+    flex-wrap: wrap;
+  }
+
+  .btn-primary {
+    width: 100%;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1024px) {
+  .dropzone {
+    padding: 3rem 2rem;
+  }
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #94a3b8;
+  font-size: 0.875rem;
+}

--- a/src/upload_web/static/js/upload.js
+++ b/src/upload_web/static/js/upload.js
@@ -1,0 +1,325 @@
+/**
+ * Verdecora Upload Web — Client-side upload via SAS tokens
+ *
+ * Flow:
+ *  1. User drops/selects files in the dropzone
+ *  2. For each file: POST /api/sessions/{id}/sas → get SAS URL
+ *  3. PUT file to SAS URL directly (browser → Azure Blob Storage)
+ *  4. On success: POST /api/sessions/{id}/files → register metadata
+ *  5. Update file list via HTMX swap
+ */
+
+(function () {
+  "use strict";
+
+  const ACCEPTED_TYPES = [
+    "application/pdf",
+    "image/jpeg",
+    "image/png",
+    "image/tiff",
+  ];
+  const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+  /**
+   * Return CSRF token from <meta> tag.
+   */
+  function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.content : "";
+  }
+
+  /**
+   * Format bytes to a human-readable string.
+   */
+  function formatSize(bytes) {
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+    return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+  }
+
+  /**
+   * Validate a file before upload.
+   */
+  function validateFile(file) {
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      return "Tipo de archivo no permitido. Usa PDF, JPG, PNG o TIFF.";
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return "El archivo supera el límite de 50 MB.";
+    }
+    return null;
+  }
+
+  /**
+   * Create a file item element for the upload list.
+   */
+  function createFileItemEl(file, tempId) {
+    const div = document.createElement("div");
+    div.className = "file-item";
+    div.dataset.tempId = tempId;
+
+    const isImage = file.type.startsWith("image/");
+    let iconHtml;
+    if (isImage) {
+      iconHtml =
+        '<img class="file-thumb" src="' +
+        URL.createObjectURL(file) +
+        '" alt="">';
+    } else {
+      iconHtml = '<span class="file-icon">📄</span>';
+    }
+
+    div.innerHTML =
+      iconHtml +
+      '<span class="file-name">' +
+      file.name +
+      "</span>" +
+      '<span class="file-size">' +
+      formatSize(file.size) +
+      "</span>" +
+      '<div class="file-progress"><div class="file-progress-bar" style="width:0%"></div></div>' +
+      '<button type="button" class="file-remove" title="Quitar archivo">✕</button>';
+
+    div.querySelector(".file-remove").addEventListener("click", function () {
+      div.remove();
+      updateFileCount();
+    });
+
+    return div;
+  }
+
+  /**
+   * Update the visible file count badge.
+   */
+  function updateFileCount() {
+    const list = document.getElementById("file-list");
+    const counter = document.getElementById("file-count");
+    const nextBtn = document.getElementById("btn-next-preflight");
+    if (!list) return;
+
+    const count = list.querySelectorAll(".file-item").length;
+    if (counter) {
+      counter.textContent = count > 0 ? count + " archivo(s)" : "";
+    }
+    if (nextBtn) {
+      nextBtn.disabled = count === 0;
+    }
+  }
+
+  /**
+   * Request a SAS token for one file.
+   */
+  async function requestSas(sessionId, filename, contentType) {
+    const resp = await fetch("/api/sessions/" + sessionId + "/sas", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": getCsrfToken(),
+      },
+      body: JSON.stringify({ filename: filename, content_type: contentType }),
+    });
+    if (!resp.ok) {
+      throw new Error("No se pudo obtener la URL de subida (SAS).");
+    }
+    return resp.json();
+  }
+
+  /**
+   * Upload a file directly to Azure Blob Storage via SAS URL.
+   */
+  async function uploadToBlob(sasUrl, file, progressBar) {
+    return new Promise(function (resolve, reject) {
+      const xhr = new XMLHttpRequest();
+      xhr.open("PUT", sasUrl, true);
+      xhr.setRequestHeader("x-ms-blob-type", "BlockBlob");
+      xhr.setRequestHeader("Content-Type", file.type);
+
+      xhr.upload.addEventListener("progress", function (e) {
+        if (e.lengthComputable && progressBar) {
+          const pct = Math.round((e.loaded / e.total) * 100);
+          progressBar.style.width = pct + "%";
+        }
+      });
+
+      xhr.addEventListener("load", function () {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          if (progressBar) {
+            progressBar.style.width = "100%";
+            progressBar.classList.add("complete");
+          }
+          resolve();
+        } else {
+          reject(new Error("Error al subir a almacenamiento: " + xhr.status));
+        }
+      });
+
+      xhr.addEventListener("error", function () {
+        reject(new Error("Error de red al subir el archivo."));
+      });
+
+      xhr.send(file);
+    });
+  }
+
+  /**
+   * Register uploaded file metadata with the backend.
+   */
+  async function registerFile(sessionId, filename, blobPath, contentType, size) {
+    const resp = await fetch("/api/sessions/" + sessionId + "/files", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": getCsrfToken(),
+      },
+      body: JSON.stringify({
+        filename: filename,
+        blob_path: blobPath,
+        content_type: contentType,
+        size_bytes: size,
+      }),
+    });
+    if (!resp.ok) {
+      throw new Error("No se pudo registrar el archivo.");
+    }
+    return resp.json();
+  }
+
+  /**
+   * Process a single file: SAS → Blob upload → register.
+   */
+  async function processFile(sessionId, file, fileItemEl) {
+    const progressBar = fileItemEl.querySelector(".file-progress-bar");
+    try {
+      const sas = await requestSas(sessionId, file.name, file.type);
+      await uploadToBlob(sas.sas_url, file, progressBar);
+      await registerFile(
+        sessionId,
+        file.name,
+        sas.blob_path,
+        file.type,
+        file.size
+      );
+    } catch (err) {
+      if (progressBar) {
+        progressBar.classList.add("error");
+      }
+      console.error("Upload failed for " + file.name + ":", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Handle file selection (from input or drop).
+   */
+  function handleFiles(files, sessionId) {
+    const list = document.getElementById("file-list");
+    if (!list) return;
+
+    Array.from(files).forEach(function (file, idx) {
+      const error = validateFile(file);
+      if (error) {
+        alert(file.name + ": " + error);
+        return;
+      }
+
+      const tempId = "temp-" + Date.now() + "-" + idx;
+      const el = createFileItemEl(file, tempId);
+      list.appendChild(el);
+
+      if (sessionId) {
+        processFile(sessionId, file, el).catch(function () {
+          // error already logged; keep UI item to show error state
+        });
+      }
+    });
+
+    updateFileCount();
+  }
+
+  /**
+   * Initialize dropzone interactions.
+   */
+  function initDropzone() {
+    const dropzone = document.getElementById("dropzone");
+    if (!dropzone) return;
+
+    const fileInput = dropzone.querySelector('input[type="file"]');
+    const sessionId = dropzone.dataset.sessionId || "";
+
+    dropzone.addEventListener("dragover", function (e) {
+      e.preventDefault();
+      dropzone.classList.add("dragover");
+    });
+
+    dropzone.addEventListener("dragleave", function () {
+      dropzone.classList.remove("dragover");
+    });
+
+    dropzone.addEventListener("drop", function (e) {
+      e.preventDefault();
+      dropzone.classList.remove("dragover");
+      if (e.dataTransfer && e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files, sessionId);
+      }
+    });
+
+    if (fileInput) {
+      fileInput.addEventListener("change", function () {
+        handleFiles(fileInput.files, sessionId);
+        fileInput.value = "";
+      });
+    }
+
+    // "Add more files" button
+    var addBtn = document.getElementById("btn-add-files");
+    if (addBtn && fileInput) {
+      addBtn.addEventListener("click", function () {
+        fileInput.click();
+      });
+    }
+  }
+
+  /**
+   * Initialize page grouping drag-and-drop.
+   */
+  function initGrouping() {
+    document.querySelectorAll(".albaran-group").forEach(function (group) {
+      group.addEventListener("dragover", function (e) {
+        e.preventDefault();
+        group.classList.add("drag-over");
+      });
+
+      group.addEventListener("dragleave", function () {
+        group.classList.remove("drag-over");
+      });
+
+      group.addEventListener("drop", function (e) {
+        e.preventDefault();
+        group.classList.remove("drag-over");
+        var fileId = e.dataTransfer.getData("text/plain");
+        var item = document.querySelector('[data-file-id="' + fileId + '"]');
+        if (item) {
+          group.querySelector(".albaran-group-files").appendChild(item);
+        }
+      });
+    });
+
+    document.querySelectorAll(".file-item[draggable]").forEach(function (item) {
+      item.addEventListener("dragstart", function (e) {
+        e.dataTransfer.setData("text/plain", item.dataset.fileId);
+      });
+    });
+  }
+
+  // Boot
+  document.addEventListener("DOMContentLoaded", function () {
+    initDropzone();
+    initGrouping();
+  });
+
+  // Re-init after HTMX swaps
+  document.addEventListener("htmx:afterSwap", function () {
+    initGrouping();
+    updateFileCount();
+  });
+})();

--- a/src/upload_web/templates/components/file_dropzone.html
+++ b/src/upload_web/templates/components/file_dropzone.html
@@ -1,0 +1,7 @@
+{# Reusable drag-and-drop file upload zone #}
+<div id="dropzone" class="dropzone" data-session-id="{{ session_id | default('') }}">
+  <div class="dropzone-icon">📤</div>
+  <p class="dropzone-title">Arrastra archivos aquí o haz clic para seleccionar</p>
+  <p class="dropzone-hint">PDF, JPG, PNG o TIFF · Máximo 50 MB por archivo</p>
+  <input type="file" multiple accept=".pdf,.jpg,.jpeg,.png,.tiff" aria-label="Seleccionar archivos">
+</div>

--- a/src/upload_web/templates/components/file_list.html
+++ b/src/upload_web/templates/components/file_list.html
@@ -1,0 +1,28 @@
+{# File list component — HTMX partial #}
+<div id="file-list" class="file-list">
+  {% for file in files | default([]) %}
+  <div class="file-item" data-file-id="{{ file.file_id }}" draggable="true">
+    {% if file.content_type and file.content_type.startswith('image/') %}
+    <img class="file-thumb" src="/api/sessions/{{ session_id }}/files/{{ file.file_id }}/thumb" alt="">
+    {% else %}
+    <span class="file-icon">📄</span>
+    {% endif %}
+    <span class="file-name">{{ file.filename }}</span>
+    <span class="file-size">
+      {% if file.size_bytes < 1024 %}{{ file.size_bytes }} B
+      {% elif file.size_bytes < 1048576 %}{{ (file.size_bytes / 1024) | round(1) }} KB
+      {% else %}{{ (file.size_bytes / 1048576) | round(1) }} MB
+      {% endif %}
+    </span>
+    <button type="button" class="file-remove"
+            hx-delete="/api/sessions/{{ session_id }}/files/{{ file.file_id }}"
+            hx-target="closest .file-item"
+            hx-swap="outerHTML"
+            hx-confirm="¿Quitar este archivo?"
+            title="Quitar archivo">✕</button>
+  </div>
+  {% endfor %}
+  {% if not files %}
+  <div class="empty-state">Aún no se han añadido archivos.</div>
+  {% endif %}
+</div>

--- a/src/upload_web/templates/components/preflight_results.html
+++ b/src/upload_web/templates/components/preflight_results.html
@@ -1,0 +1,23 @@
+{# Preflight results partial — swapped in via HTMX #}
+<div id="preflight-results">
+  <h3 class="text-lg font-semibold text-slate-900">Resultados del análisis</h3>
+  {% set conf = confidence | default(0) %}
+  <div class="result-card {% if conf > 0.8 %}success{% elif conf > 0.5 %}warning{% else %}error{% endif %}">
+    <p><strong>Proveedor:</strong> {{ detected_supplier or 'No detectado' }}</p>
+    <p><strong>Nº Albarán:</strong> {{ detected_albaran_number or 'No detectado' }}</p>
+    <p><strong>Fecha:</strong> {{ detected_date or 'No detectada' }}</p>
+    <p>
+      <strong>Confianza:</strong>
+      <span class="confidence-badge {% if conf > 0.8 %}confidence-high{% elif conf > 0.5 %}confidence-medium{% else %}confidence-low{% endif %}">
+        {{ (conf * 100) | round }}%
+      </span>
+    </p>
+    {% if warnings %}
+    <div class="mt-3">
+      {% for w in warnings %}
+      <span class="warning-badge">⚠ {{ w }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</div>

--- a/src/upload_web/templates/pages/confirm_store.html
+++ b/src/upload_web/templates/pages/confirm_store.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+
+{% block content %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/upload.css') }}">
+
+{# Step indicator #}
+<div class="step-indicator">
+  <div class="step completed">
+    <span class="step-number">✓</span>
+    <span>Archivos</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step active">
+    <span class="step-number">2</span>
+    <span>Análisis</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step">
+    <span class="step-number">3</span>
+    <span>Confirmar</span>
+  </div>
+</div>
+
+<section class="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]">
+  <article class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    <h1 class="text-3xl font-bold tracking-tight text-slate-900">Confirmar tienda</h1>
+    <p class="mt-3 text-base leading-7 text-slate-600">Revisa los resultados del análisis y confirma la tienda de destino.</p>
+
+    {# Detected store #}
+    <div class="mt-6">
+      <label for="store-select" class="block text-sm font-semibold text-slate-700 mb-2">Tienda detectada</label>
+      <select id="store-select" name="store" class="store-selector"
+              hx-post="/api/sessions/{{ session.session_id }}/store"
+              hx-trigger="change"
+              hx-vals='js:{"store": document.getElementById("store-select").value}'
+              hx-swap="none">
+        {% for store in stores | default([]) %}
+        <option value="{{ store.id }}" {% if store.id == detected_store %}selected{% endif %}>
+          {{ store.name }}
+        </option>
+        {% endfor %}
+        {% if not stores %}
+        <option value="" selected>{{ preflight.detected_store if preflight else 'Sin detectar' }}</option>
+        {% endif %}
+      </select>
+    </div>
+
+    {# Preflight results #}
+    {% if preflight %}
+    {% set conf = preflight.confidence | default(0) %}
+    <div class="mt-6">
+      <h3 class="text-lg font-semibold text-slate-900">Resultados del análisis</h3>
+      <div class="result-card {% if conf > 0.8 %}success{% elif conf > 0.5 %}warning{% else %}error{% endif %}">
+        <p><strong>Proveedor:</strong> {{ preflight.detected_supplier or 'No detectado' }}</p>
+        <p><strong>Nº Albarán:</strong> {{ preflight.detected_albaran_number or 'No detectado' }}</p>
+        <p><strong>Fecha:</strong> {{ preflight.detected_date or 'No detectada' }}</p>
+        <p>
+          <strong>Confianza:</strong>
+          <span class="confidence-badge {% if conf > 0.8 %}confidence-high{% elif conf > 0.5 %}confidence-medium{% else %}confidence-low{% endif %}">
+            {{ (conf * 100) | round }}%
+          </span>
+        </p>
+        {% if preflight.warnings %}
+        <div class="mt-3">
+          {% for w in preflight.warnings %}
+          <span class="warning-badge">⚠ {{ w }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# File summary #}
+    <div class="mt-6">
+      <h3 class="text-sm font-semibold uppercase tracking-wider text-slate-500 mb-3">
+        Archivos subidos ({{ session.files | length }})
+      </h3>
+      {% set files = session.files %}
+      {% set session_id = session.session_id %}
+      {% include 'components/file_list.html' %}
+    </div>
+
+    {# Actions #}
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <a href="{{ url_for('upload_page') }}" class="btn-secondary">← Volver a archivos</a>
+      <a href="{{ url_for('upload_summary', session_id=session.session_id) }}" class="btn-primary">
+        Confirmar y continuar →
+      </a>
+    </div>
+  </article>
+
+  <aside class="rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    <h2 class="text-lg font-semibold text-slate-900">¿Datos incorrectos?</h2>
+    <ul class="mt-4 space-y-3 text-sm leading-6 text-slate-600">
+      <li>• Si la tienda no es correcta, cámbiala en el desplegable.</li>
+      <li>• Podrás editar el proveedor, fecha y número de albarán en el siguiente paso.</li>
+      <li>• Si la confianza es baja, revisa que las fotos sean legibles.</li>
+    </ul>
+  </aside>
+</section>
+{% endblock %}

--- a/src/upload_web/templates/pages/summary.html
+++ b/src/upload_web/templates/pages/summary.html
@@ -1,0 +1,189 @@
+{% extends "base.html" %}
+
+{% block content %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/upload.css') }}">
+
+{# Step indicator #}
+<div class="step-indicator">
+  <div class="step completed">
+    <span class="step-number">✓</span>
+    <span>Archivos</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step completed">
+    <span class="step-number">✓</span>
+    <span>Análisis</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step active">
+    <span class="step-number">3</span>
+    <span>Confirmar</span>
+  </div>
+</div>
+
+<section class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+  <div class="flex items-center justify-between flex-wrap gap-3">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight text-slate-900">Resumen del envío</h1>
+      <p class="mt-2 text-base leading-7 text-slate-600">Revisa los datos extraídos y edita lo que sea necesario antes de confirmar.</p>
+    </div>
+    <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold
+      {% if session.status == 'confirmed' %}bg-emerald-100 text-emerald-800
+      {% elif session.status == 'failed' %}bg-rose-100 text-rose-800
+      {% else %}bg-cyan-100 text-cyan-800{% endif %}">
+      {{ session.status }}
+    </span>
+  </div>
+
+  {# Summary table with inline editing #}
+  <div class="mt-6 overflow-x-auto rounded-xl border border-slate-200">
+    <table class="summary-table">
+      <thead>
+        <tr>
+          <th>Archivo</th>
+          <th>Proveedor</th>
+          <th>Nº Albarán</th>
+          <th>Fecha</th>
+          <th>Grupo</th>
+          <th>Estado</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for file in session.files %}
+        <tr>
+          <td>
+            <div class="flex items-center gap-2">
+              <span class="file-icon">📄</span>
+              <span class="file-name">{{ file.filename }}</span>
+            </div>
+          </td>
+          <td>
+            <input type="text" class="editable-field"
+                   name="supplier_{{ file.file_id }}"
+                   value="{{ session.preflight.detected_supplier if session.preflight else '' }}"
+                   placeholder="Proveedor"
+                   hx-post="/api/sessions/{{ session.session_id }}/files/{{ file.file_id }}/metadata"
+                   hx-trigger="change"
+                   hx-vals='js:{"field":"supplier","value":event.target.value}'
+                   hx-swap="none">
+          </td>
+          <td>
+            <input type="text" class="editable-field"
+                   name="albaran_{{ file.file_id }}"
+                   value="{{ session.preflight.detected_albaran_number if session.preflight else '' }}"
+                   placeholder="Nº albarán"
+                   hx-post="/api/sessions/{{ session.session_id }}/files/{{ file.file_id }}/metadata"
+                   hx-trigger="change"
+                   hx-vals='js:{"field":"albaran_number","value":event.target.value}'
+                   hx-swap="none">
+          </td>
+          <td>
+            <input type="date" class="editable-field"
+                   name="date_{{ file.file_id }}"
+                   value="{{ session.preflight.detected_date if session.preflight else '' }}"
+                   hx-post="/api/sessions/{{ session.session_id }}/files/{{ file.file_id }}/metadata"
+                   hx-trigger="change"
+                   hx-vals='js:{"field":"date","value":event.target.value}'
+                   hx-swap="none">
+          </td>
+          <td>
+            <span class="text-sm text-slate-500">{{ file.albaran_group or 'Albarán 1' }}</span>
+          </td>
+          <td>
+            <span class="confidence-badge confidence-high">✓ OK</span>
+          </td>
+        </tr>
+        {% endfor %}
+        {% if not session.files %}
+        <tr>
+          <td colspan="6" class="empty-state">No hay archivos en esta sesión.</td>
+        </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+
+  {# Preflight metadata card #}
+  {% if session.preflight %}
+  <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">Proveedor</p>
+      <p class="mt-1 text-sm font-semibold text-slate-900">{{ session.preflight.detected_supplier or '—' }}</p>
+    </div>
+    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">Fecha</p>
+      <p class="mt-1 text-sm font-semibold text-slate-900">{{ session.preflight.detected_date or '—' }}</p>
+    </div>
+    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">Nº Albarán</p>
+      <p class="mt-1 text-sm font-semibold text-slate-900">{{ session.preflight.detected_albaran_number or '—' }}</p>
+    </div>
+    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">Tienda</p>
+      <p class="mt-1 text-sm font-semibold text-slate-900">{{ session.preflight.detected_store or '—' }}</p>
+    </div>
+  </div>
+  {% endif %}
+
+  {# Page grouping visualization #}
+  {% if groups | default([]) %}
+  <div class="mt-6">
+    <h3 class="text-sm font-semibold uppercase tracking-wider text-slate-500 mb-3">Agrupación de páginas</h3>
+    <div class="albaran-groups">
+      {% for group in groups %}
+      <div class="albaran-group">
+        <div class="albaran-group-header">
+          <span class="albaran-group-title">{{ group.name | default('Albarán ' ~ loop.index) }}</span>
+          <span class="albaran-group-count">{{ group.files | length }} página(s)</span>
+        </div>
+        <div class="albaran-group-files">
+          {% for f in group.files %}
+          <div class="file-item">
+            <span class="file-icon">📄</span>
+            <span class="file-name">{{ f.filename }}</span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  {# Warnings #}
+  {% if session.preflight and session.preflight.warnings %}
+  <div class="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-4">
+    <p class="text-sm font-semibold text-amber-800 mb-2">⚠ Advertencias detectadas</p>
+    <ul class="list-disc pl-5 space-y-1 text-sm text-amber-700">
+      {% for w in session.preflight.warnings %}
+      <li>{{ w }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  {# Actions #}
+  {% if session.status != 'confirmed' %}
+  <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <a href="{{ url_for('confirm_store', session_id=session.session_id) }}" class="btn-secondary">← Volver al análisis</a>
+    <button type="button"
+            class="btn-primary"
+            hx-post="/api/sessions/{{ session.session_id }}/confirm"
+            hx-swap="innerHTML"
+            hx-target="#confirm-result"
+            hx-confirm="¿Enviar para procesamiento? No podrás modificar los datos después."
+            hx-indicator="#submit-loading">
+      <span class="htmx-hide-on-request">Enviar para procesamiento ✓</span>
+      <span class="htmx-indicator" id="submit-loading"><span class="spinner"></span>&nbsp;Enviando…</span>
+    </button>
+  </div>
+  <div id="confirm-result"></div>
+  {% else %}
+  <div class="mt-8 rounded-2xl border border-emerald-200 bg-emerald-50 p-5 text-center">
+    <p class="text-lg font-semibold text-emerald-800">✓ Sesión confirmada</p>
+    <p class="mt-1 text-sm text-emerald-600">Los documentos están siendo procesados.</p>
+    <a href="{{ url_for('index') }}" class="mt-4 inline-flex btn-primary">Volver al inicio</a>
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/src/upload_web/templates/pages/upload.html
+++ b/src/upload_web/templates/pages/upload.html
@@ -1,26 +1,86 @@
 {% extends 'base.html' %}
 
 {% block content %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/upload.css') }}">
+
+{# Step indicator #}
+<div class="step-indicator">
+  <div class="step active">
+    <span class="step-number">1</span>
+    <span>Archivos</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step">
+    <span class="step-number">2</span>
+    <span>Análisis</span>
+  </div>
+  <div class="step-divider"></div>
+  <div class="step">
+    <span class="step-number">3</span>
+    <span>Confirmar</span>
+  </div>
+</div>
+
 <section class="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]">
   <article class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
     <h1 class="text-3xl font-bold tracking-tight text-slate-900">Subir albarán</h1>
-    <p class="mt-3 text-base leading-7 text-slate-600">En el siguiente sprint conectaremos esta pantalla con la subida real. Hoy dejamos listo el espacio para que la experiencia sea clara desde el primer momento.</p>
-    <div class="mt-8 rounded-[2rem] border-2 border-dashed border-[var(--vc-primary)] bg-[color:rgba(1,146,143,0.06)] p-8 text-center sm:p-12">
-      <div class="mx-auto flex max-w-md flex-col items-center gap-4">
-        <div class="flex h-16 w-16 items-center justify-center rounded-full bg-white text-3xl shadow-sm">↑</div>
-        <p class="text-lg font-semibold text-slate-900">Zona de arrastre de archivos</p>
-        <p class="text-sm leading-6 text-slate-600">Aquí podrás arrastrar uno o varios documentos para iniciar la subida.</p>
-        <button type="button" class="inline-flex min-h-12 items-center justify-center rounded-full bg-[var(--vc-primary)] px-6 text-base font-semibold text-white shadow-lg shadow-teal-900/10">Seleccionar archivos</button>
+    <p class="mt-3 text-base leading-7 text-slate-600">Arrastra o selecciona los archivos del albarán. Puedes añadir varias páginas y agruparlas.</p>
+
+    {# Dropzone component #}
+    {% include 'components/file_dropzone.html' %}
+
+    {# File list #}
+    <div class="mt-4 flex items-center justify-between">
+      <span id="file-count" class="text-sm text-slate-500"></span>
+      <button type="button" id="btn-add-files" class="btn-secondary">+ Añadir más archivos</button>
+    </div>
+
+    {% include 'components/file_list.html' %}
+
+    {# Grouping UI #}
+    <div class="albaran-groups" id="albaran-groups">
+      <div class="albaran-group" data-group="default">
+        <div class="albaran-group-header">
+          <span class="albaran-group-title">Albarán 1</span>
+          <span class="albaran-group-count"></span>
+        </div>
+        <div class="albaran-group-files">
+          {# Dragged file items land here #}
+        </div>
       </div>
     </div>
+
+    {# Next: Preflight #}
+    <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <a href="{{ url_for('index') }}" class="btn-secondary">← Volver</a>
+      <button id="btn-next-preflight"
+              type="button"
+              class="btn-primary"
+              disabled
+              hx-post="/api/sessions/{{ session_id | default('') }}/preflight"
+              hx-target="#preflight-results"
+              hx-swap="outerHTML"
+              hx-indicator="#preflight-loading">
+        <span class="htmx-hide-on-request">Siguiente: Analizar →</span>
+        <span class="htmx-indicator"><span class="spinner"></span>&nbsp;Analizando…</span>
+      </button>
+    </div>
+
+    {# Preflight results placeholder #}
+    <div id="preflight-results"></div>
+
   </article>
+
   <aside class="rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
     <h2 class="text-lg font-semibold text-slate-900">Instrucciones</h2>
     <ul class="mt-4 space-y-3 text-sm leading-6 text-slate-600">
       <li>• Puedes subir PDF y fotos hechas con el móvil.</li>
       <li>• Si el albarán tiene varias páginas, podrás enviarlas juntas.</li>
+      <li>• Arrastra archivos entre grupos para organizar las páginas.</li>
       <li>• Procura que el documento se vea completo y con buena luz.</li>
     </ul>
   </aside>
 </section>
+
+<script src="{{ url_for('static', path='js/upload.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Implements the full HTMX frontend for the Upload Web application (Issue #103).

### New files
- **\static/css/upload.css\** — Dropzone, file list, progress bars, confidence badges, summary table, responsive tablet-first layout
- **\static/js/upload.js\** — Client-side SAS upload flow (dropzone → SAS token → blob PUT → register metadata)
- **\	emplates/components/file_dropzone.html\** — Reusable drag-and-drop zone for PDF/image files
- **\	emplates/components/file_list.html\** — HTMX partial for file listing with thumbnails and delete
- **\	emplates/components/preflight_results.html\** — HTMX partial swapped in after preflight analysis

### Updated files
- **\	emplates/pages/upload.html\** — Full upload page with dropzone, file list, grouping UI, step indicator, HTMX preflight trigger
- **\	emplates/pages/confirm_store.html\** — Store confirmation with detected store dropdown, preflight results, confidence indicators
- **\	emplates/pages/summary.html\** — Summary table with inline-editable metadata (supplier, albaran number, date), page grouping visualization, warnings, HTMX confirm submission

### Key decisions
- HTMX for all dynamic interactions (no React/Vue)
- Spanish UI text for Verdecora store staff
- Responsive/tablet-first (tablets are primary device)
- Progressive enhancement — basic views work without JS
- 3-step wizard: Archivos → Análisis → Confirmar

Closes #103