### PR TITLE
feat(upload-web): Flow 0 grouping + status tracking + tests + Mis Albaranes (#107, #112-#116)

### DIFF
--- a/src/services/flow0_dedup/dedup_handler.py
+++ b/src/services/flow0_dedup/dedup_handler.py
@@ -81,7 +81,13 @@ class Flow0DedupHandler:
         )
         return dict(items[0]) if items else None
 
-    def build_processing_record(self, event: EventGridEnvelope) -> ProcessingRecord:
+    def build_processing_record(
+        self,
+        event: EventGridEnvelope,
+        *,
+        upload_session_id: str | None = None,
+        uploader_oid: str | None = None,
+    ) -> ProcessingRecord:
         """Build the Cosmos processing record for a newly ingested blob."""
 
         store_id = extract_store_id(event.blob_path)
@@ -108,6 +114,8 @@ class Flow0DedupHandler:
                 "storage_diagnostics": event.data.storageDiagnostics,
                 "blob_metadata": event.data.metadata,
             },
+            upload_session_id=upload_session_id,
+            uploader_oid=uploader_oid,
         )
 
     def build_forward_message(self, record: ProcessingRecord) -> ForwardedExtractionMessage:
@@ -124,6 +132,8 @@ class Flow0DedupHandler:
             event_id=record.event_id,
             event_time=record.event_time,
             metadata=record.source_metadata,
+            upload_session_id=record.upload_session_id,
+            uploader_oid=record.uploader_oid,
         )
 
     def forward_to_extraction_queue(self, record: ProcessingRecord) -> None:
@@ -136,6 +146,91 @@ class Flow0DedupHandler:
             json.dumps(outbound.model_dump(mode="json")),
             application_properties={"eventType": "albaran.recibido"},
             subject="albaran.recibido",
+        )
+        self._sender.send_messages(message)
+
+    def handle_session_message(self, session_payload: dict[str, Any]) -> list[ProcessingRecord]:
+        """Process a confirmed upload session, grouping files by albaran_group.
+
+        Returns a list of ProcessingRecord instances created for each group.
+        """
+        from collections import defaultdict
+        from datetime import UTC, datetime
+
+        session_id = session_payload.get("session_id", "")
+        user_oid = session_payload.get("user_oid", "")
+        files = session_payload.get("files", [])
+        confirmed_at = session_payload.get("confirmed_at")
+
+        groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for file_entry in files:
+            group_key = file_entry.get("albaran_group") or "default"
+            groups[group_key].append(file_entry)
+
+        records: list[ProcessingRecord] = []
+        now = datetime.now(tz=UTC)
+
+        for group_key, group_files in groups.items():
+            first_file = group_files[0]
+            blob_paths = [f.get("blob_path", "") for f in group_files]
+            blob_names = [f.get("filename", "") for f in group_files]
+            primary_blob_path = blob_paths[0]
+            primary_blob_name = blob_names[0]
+
+            store_id = extract_store_id(primary_blob_path) if "/" in primary_blob_path else "upload-web"
+            dedup_key = f"session:{session_id}:group:{group_key}"
+            record_id = f"albaran-{hashlib.sha256(dedup_key.encode('utf-8')).hexdigest()[:24]}"
+            pk = build_partition_key(store_id, now)
+
+            record = ProcessingRecord(
+                id=record_id,
+                pk=pk,
+                store_id=store_id,
+                event_id=f"session-{session_id}",
+                event_type="upload.session.confirmed",
+                event_time=now,
+                event_date=now.date().isoformat(),
+                dedup_key=dedup_key,
+                blob_url=first_file.get("blob_path", ""),
+                blob_path=primary_blob_path,
+                blob_name=primary_blob_name,
+                source_metadata={
+                    "session_id": session_id,
+                    "confirmed_at": confirmed_at,
+                    "albaran_group": group_key,
+                    "blob_paths": blob_paths,
+                    "blob_names": blob_names,
+                    "page_count": len(group_files),
+                },
+                upload_session_id=session_id,
+                uploader_oid=user_oid,
+            )
+
+            self._container_client.upsert_item(body=record.model_dump(mode="json"))
+            self._forward_session_group(record, group_key)
+            records.append(record)
+            self._logger.info(
+                "Session group record created and forwarded",
+                extra={
+                    "albaran_id": record.id,
+                    "session_id": session_id,
+                    "albaran_group": group_key,
+                    "file_count": len(group_files),
+                },
+            )
+
+        return records
+
+    def _forward_session_group(self, record: ProcessingRecord, albaran_group: str) -> None:
+        """Forward a session-based group to the extraction queue."""
+        from azure.servicebus import ServiceBusMessage
+
+        outbound = self.build_forward_message(record)
+        outbound.albaran_group = albaran_group
+        message = ServiceBusMessage(
+            json.dumps(outbound.model_dump(mode="json")),
+            application_properties={"eventType": "albaran.session.confirmed"},
+            subject="albaran.session.confirmed",
         )
         self._sender.send_messages(message)
 

--- a/src/services/flow0_dedup/models.py
+++ b/src/services/flow0_dedup/models.py
@@ -91,6 +91,8 @@ class ProcessingRecord(BaseModel):
     blob_name: str
     blob_etag: str | None = None
     source_metadata: dict[str, Any] = Field(default_factory=dict)
+    upload_session_id: str | None = None
+    uploader_oid: str | None = None
 
 
 class ForwardedExtractionMessage(BaseModel):
@@ -109,3 +111,6 @@ class ForwardedExtractionMessage(BaseModel):
     event_id: str
     event_time: datetime
     metadata: dict[str, Any] = Field(default_factory=dict)
+    upload_session_id: str | None = None
+    uploader_oid: str | None = None
+    albaran_group: str | None = None

--- a/src/services/orchestrator/orchestration.py
+++ b/src/services/orchestrator/orchestration.py
@@ -199,6 +199,10 @@ class OrchestratorService:
         container = await self.dependencies.get_processing_container()
         record = result.model_dump(mode="json")
         record["id"] = result.processing_id
+        if result.metadata.get("upload_session_id"):
+            record["upload_session_id"] = result.metadata["upload_session_id"]
+        if result.metadata.get("uploader_oid"):
+            record["uploader_oid"] = result.metadata["uploader_oid"]
         await container.upsert_item(record)
 
     async def _write_processing_status(

--- a/src/upload_web/routes/api.py
+++ b/src/upload_web/routes/api.py
@@ -182,6 +182,42 @@ def confirm_session(session_id: str, current_user: CurrentUser) -> dict[str, Any
     return {"status": "confirmed", "processing_started": processing_started}
 
 
+@router.get("/{session_id}/status")
+def session_status(session_id: str, current_user: CurrentUser) -> dict[str, Any]:
+    """Return current session state, per-file status, and overall progress."""
+    session = _get_session_or_404(session_id)
+    _enforce_ownership(session, current_user)
+
+    files_status = []
+    completed_count = 0
+    for f in session.files:
+        file_state = getattr(f, "processing_status", None) or "pending"
+        if file_state == "completed":
+            completed_count += 1
+        files_status.append(
+            {
+                "file_id": f.file_id,
+                "filename": f.filename,
+                "status": file_state,
+                "blob_path": f.blob_path,
+                "albaran_group": f.albaran_group,
+            }
+        )
+
+    total = len(session.files)
+    progress = (completed_count / total * 100) if total > 0 else 0
+
+    return {
+        "session_id": session.session_id,
+        "status": session.status,
+        "total_files": total,
+        "completed_files": completed_count,
+        "progress_percent": round(progress, 1),
+        "files": files_status,
+        "confirmed_at": session.confirmed_at.isoformat() if session.confirmed_at else None,
+    }
+
+
 def _publish_to_service_bus(session: UploadSession) -> bool:
     """Best-effort publish to Service Bus. Returns True on success."""
     from src.upload_web.config import get_settings

--- a/src/upload_web/routes/upload.py
+++ b/src/upload_web/routes/upload.py
@@ -56,14 +56,69 @@ async def upload_page(request: Request, current_user: CurrentUser) -> HTMLRespon
 
 @router.get("/mis-albaranes", response_class=HTMLResponse, name="my_uploads_page")
 async def my_uploads_page(request: Request, current_user: CurrentUser) -> HTMLResponse:
+    from src.upload_web.services.upload_session import get_all_user_sessions
+
+    sessions = get_all_user_sessions(current_user.oid)
+    uploads: list[dict[str, Any]] = []
+    for s in sessions:
+        for f in s.files:
+            uploads.append(
+                {
+                    "session_id": s.session_id,
+                    "filename": f.filename,
+                    "status": s.status,
+                    "albaran_group": f.albaran_group,
+                    "uploaded_at": f.uploaded_at.strftime("%d/%m/%Y %H:%M"),
+                    "content_type": f.content_type,
+                }
+            )
+
     return request.app.state.templates.TemplateResponse(
         request,
-        "pages/home.html",
+        "pages/my_albaranes.html",
         _build_template_context(
             request,
             current_user,
             page_title="Mis albaranes · Verdecora Upload Web",
-            my_uploads_message="Tus albaranes enviados aparecerán aquí en el siguiente sprint. Mientras tanto, puedes seguir subiendo documentos desde el botón principal.",
+            uploads=uploads,
+        ),
+    )
+
+
+@router.get("/mis-albaranes/filter", response_class=HTMLResponse, name="my_uploads_filter")
+async def my_uploads_filter(
+    request: Request,
+    current_user: CurrentUser,
+    status_filter: str = "",
+) -> HTMLResponse:
+    from src.upload_web.services.upload_session import get_all_user_sessions
+
+    sessions = get_all_user_sessions(current_user.oid)
+    uploads: list[dict[str, Any]] = []
+    for s in sessions:
+        if status_filter and s.status != status_filter:
+            continue
+        for f in s.files:
+            uploads.append(
+                {
+                    "session_id": s.session_id,
+                    "filename": f.filename,
+                    "status": s.status,
+                    "albaran_group": f.albaran_group,
+                    "uploaded_at": f.uploaded_at.strftime("%d/%m/%Y %H:%M"),
+                    "content_type": f.content_type,
+                }
+            )
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "pages/my_albaranes.html",
+        _build_template_context(
+            request,
+            current_user,
+            page_title="Mis albaranes · Verdecora Upload Web",
+            uploads=uploads,
+            status_filter=status_filter,
         ),
     )
 
@@ -82,6 +137,36 @@ async def my_uploads_partial(current_user: CurrentUser) -> dict[str, object]:
 @router.get("/logout", include_in_schema=False, name="logout_placeholder")
 async def logout_placeholder() -> RedirectResponse:
     return RedirectResponse(url="/", status_code=307)
+
+
+@router.get("/upload/{session_id}/status", response_class=HTMLResponse, name="upload_status")
+async def upload_status(request: Request, session_id: str, current_user: CurrentUser) -> HTMLResponse:
+    """Show processing status with HTMX auto-refresh."""
+    from src.upload_web.services.upload_session import get_upload_session
+
+    session = get_upload_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
+    if session.user_oid != current_user.oid:
+        raise HTTPException(status_code=403, detail="Access denied.")
+
+    total = len(session.files)
+    completed = sum(1 for f in session.files if getattr(f, "processing_status", None) == "completed")
+    progress = (completed / total * 100) if total > 0 else 0
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "pages/status.html",
+        _build_template_context(
+            request,
+            current_user,
+            page_title="Estado de procesamiento · Verdecora Upload Web",
+            session=session,
+            total=total,
+            completed=completed,
+            progress=round(progress, 1),
+        ),
+    )
 
 
 @router.get("/upload/{session_id}/confirm-store", response_class=HTMLResponse, name="confirm_store")

--- a/src/upload_web/services/upload_session.py
+++ b/src/upload_web/services/upload_session.py
@@ -42,6 +42,11 @@ def get_upload_session(session_id: str) -> UploadSession | None:
     return _UPLOAD_SESSIONS.get(session_id)
 
 
+def get_all_user_sessions(user_oid: str) -> list[UploadSession]:
+    """Return all sessions belonging to the given user."""
+    return [s for s in _UPLOAD_SESSIONS.values() if s.user_oid == user_oid]
+
+
 def clear_upload_sessions() -> None:
     _UPLOAD_SESSIONS.clear()
 
@@ -77,4 +82,4 @@ def _build_mock_sas_token(session_id: str, expiry: datetime) -> str:
     return f"mock-sas-session={session_id}&prefix={_build_upload_prefix(session_id)}&exp={safe_expiry}"
 
 
-__all__ = ["clear_upload_sessions", "create_upload_session", "get_upload_session"]
+__all__ = ["clear_upload_sessions", "create_upload_session", "get_all_user_sessions", "get_upload_session"]

--- a/src/upload_web/templates/pages/my_albaranes.html
+++ b/src/upload_web/templates/pages/my_albaranes.html
@@ -1,0 +1,75 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="space-y-6">
+  <div class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    <p class="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--vc-accent)]">Historial</p>
+    <h1 class="mt-3 text-2xl font-bold tracking-tight text-slate-900">Mis albaranes</h1>
+    <p class="mt-2 text-base text-slate-600">Consulta el estado de tus albaranes enviados.</p>
+
+    <!-- Filter buttons -->
+    <div class="mt-6 flex flex-wrap gap-2">
+      <a href="{{ url_for('my_uploads_page') }}"
+         class="rounded-full px-4 py-1.5 text-sm font-medium transition
+                {% if not status_filter %}bg-[var(--vc-primary)] text-white{% else %}bg-slate-100 text-slate-700 hover:bg-slate-200{% endif %}">
+        Todos
+      </a>
+      {% for st in ['created', 'uploading', 'confirmed', 'processing', 'completed', 'failed'] %}
+      <a hx-get="{{ url_for('my_uploads_filter') }}?status_filter={{ st }}"
+         hx-target="#uploads-table"
+         hx-swap="innerHTML"
+         class="cursor-pointer rounded-full px-4 py-1.5 text-sm font-medium transition
+                {% if status_filter == st %}bg-[var(--vc-primary)] text-white{% else %}bg-slate-100 text-slate-700 hover:bg-slate-200{% endif %}">
+        {{ st | capitalize }}
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div id="uploads-table" class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    {% if uploads %}
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="border-b border-slate-200 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+            <th class="pb-3 pr-4">Fecha</th>
+            <th class="pb-3 pr-4">Archivo</th>
+            <th class="pb-3 pr-4">Grupo albarán</th>
+            <th class="pb-3">Estado</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {% for u in uploads %}
+          <tr class="cursor-pointer hover:bg-slate-50 transition"
+              onclick="window.location='{{ url_for('upload_status', session_id=u.session_id) }}'">
+            <td class="py-3 pr-4 text-slate-600">{{ u.uploaded_at }}</td>
+            <td class="py-3 pr-4 font-medium text-slate-900">{{ u.filename }}</td>
+            <td class="py-3 pr-4 text-slate-600">{{ u.albaran_group or '—' }}</td>
+            <td class="py-3">
+              {% if u.status == 'completed' %}
+                <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">Completado</span>
+              {% elif u.status == 'confirmed' or u.status == 'processing' %}
+                <span class="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-700">En proceso</span>
+              {% elif u.status == 'failed' %}
+                <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700">Error</span>
+              {% else %}
+                <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">{{ u.status | capitalize }}</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+      <p class="text-base text-slate-500">No tienes albaranes enviados todavía.</p>
+      <a href="{{ url_for('upload_page') }}"
+         class="mt-4 inline-flex items-center rounded-full bg-[var(--vc-primary)] px-6 py-2 text-sm font-semibold text-white shadow transition hover:brightness-105">
+        Subir albarán
+      </a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/src/upload_web/templates/pages/status.html
+++ b/src/upload_web/templates/pages/status.html
@@ -1,0 +1,86 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="mx-auto max-w-3xl space-y-6"
+         hx-get="{{ url_for('upload_status', session_id=session.session_id) }}"
+         hx-trigger="every 5s"
+         hx-select="section"
+         hx-swap="outerHTML">
+  <div class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    <p class="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--vc-accent)]">Estado</p>
+    <h1 class="mt-3 text-2xl font-bold tracking-tight text-slate-900">Procesamiento de albaranes</h1>
+    <p class="mt-2 text-sm text-slate-500">Sesión: {{ session.session_id }}</p>
+
+    <!-- Progress bar -->
+    <div class="mt-6">
+      <div class="flex items-center justify-between text-sm text-slate-600">
+        <span>{{ completed }} de {{ total }} archivos procesados</span>
+        <span class="font-semibold">{{ progress }}%</span>
+      </div>
+      <div class="mt-2 h-3 w-full rounded-full bg-slate-200">
+        <div class="h-3 rounded-full bg-[var(--vc-primary)] transition-all duration-500"
+             style="width: {{ progress }}%"></div>
+      </div>
+    </div>
+
+    <!-- Status badge -->
+    <div class="mt-4">
+      {% if session.status == 'completed' %}
+        <span class="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-sm font-medium text-green-700">Completado</span>
+      {% elif session.status == 'failed' %}
+        <span class="inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-sm font-medium text-red-700">Error</span>
+      {% elif session.status == 'confirmed' or session.status == 'processing' %}
+        <span class="inline-flex items-center rounded-full bg-yellow-100 px-3 py-1 text-sm font-medium text-yellow-700">En proceso</span>
+      {% else %}
+        <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700">{{ session.status | capitalize }}</span>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Per-file status table -->
+  <div class="rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+    <h2 class="text-lg font-semibold text-slate-900">Detalle por archivo</h2>
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="border-b border-slate-200 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+            <th class="pb-3 pr-4">Archivo</th>
+            <th class="pb-3 pr-4">Grupo</th>
+            <th class="pb-3">Estado</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {% for f in session.files %}
+          <tr>
+            <td class="py-3 pr-4 font-medium text-slate-900">{{ f.filename }}</td>
+            <td class="py-3 pr-4 text-slate-600">{{ f.albaran_group or '—' }}</td>
+            <td class="py-3">
+              {% set fstatus = f.processing_status if f.processing_status is defined else 'pending' %}
+              {% if fstatus == 'completed' %}
+                <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">Completado</span>
+              {% elif fstatus == 'processing' %}
+                <span class="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-700">Procesando</span>
+              {% elif fstatus == 'failed' %}
+                <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700">Error</span>
+              {% else %}
+                <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">Pendiente</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Final state link -->
+  {% if session.status == 'completed' %}
+  <div class="text-center">
+    <a href="{{ url_for('my_uploads_page') }}"
+       class="inline-flex items-center rounded-full bg-[var(--vc-primary)] px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:brightness-105">
+      Ver mis albaranes
+    </a>
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/e2e/test_upload_e2e.py
+++ b/tests/e2e/test_upload_e2e.py
@@ -1,0 +1,159 @@
+"""E2E test: full upload flow from session creation to status check (all mocked)."""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from itsdangerous import URLSafeSerializer
+
+from src.upload_web.app import create_app
+from src.upload_web.config import get_settings
+from src.upload_web.services import upload_session
+
+TEST_SECRET = "test-secret-with-at-least-thirty-two-bytes"
+SIGNING_KEY = "dev-only-upload-web-session-signing-key-change-me"
+
+pytestmark = pytest.mark.e2e
+
+
+def _jwt_token(oid: str = "oid-e2e-flow", name: str = "E2E Flow User") -> str:
+    return jwt.encode(
+        {"oid": oid, "name": name, "groups": ["verdecora-store-uploaders"], "exp": 9999999999},
+        TEST_SECRET,
+        algorithm="HS256",
+    )
+
+
+def _auth_headers(oid: str = "oid-e2e-flow", name: str = "E2E Flow User") -> dict[str, str]:
+    return {"X-MS-TOKEN-AAD-ID-TOKEN": _jwt_token(oid, name)}
+
+
+def _establish_session(client: TestClient, oid: str = "oid-e2e-flow", name: str = "E2E Flow User") -> dict[str, str]:
+    headers = _auth_headers(oid, name)
+    client.get("/", headers=headers)
+    cookie_value = client.cookies.get("upload_web_session", "")
+    if cookie_value:
+        serializer = URLSafeSerializer(SIGNING_KEY, salt="upload-web-session")
+        payload = serializer.loads(cookie_value)
+        headers["X-CSRF-Token"] = payload.get("csrf_token", "")
+    return headers
+
+
+def _api_client() -> TestClient:
+    return TestClient(create_app(), base_url="https://testserver")
+
+
+@pytest.fixture(autouse=True)
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("STORAGE_ACCOUNT_URL", raising=False)
+    monkeypatch.delenv("BLOB_ACCOUNT", raising=False)
+    upload_session.clear_upload_sessions()
+    yield
+    upload_session.clear_upload_sessions()
+    get_settings.cache_clear()
+
+
+def test_full_upload_flow_e2e() -> None:
+    """Full E2E flow: create session → generate SAS → register file → preflight → confirm → check status."""
+    with _api_client() as client:
+        headers = _establish_session(client)
+
+        # 1. Create session
+        create_resp = client.post("/api/sessions", headers=headers)
+        assert create_resp.status_code == 201
+        session_data = create_resp.json()
+        session_id = session_data["session_id"]
+        assert session_data["status"] == "created"
+
+        # 2. Generate SAS URL
+        sas_resp = client.post(f"/api/sessions/{session_id}/sas?filename=albaran_001.pdf", headers=headers)
+        assert sas_resp.status_code == 200
+        sas_body = sas_resp.json()
+        assert "upload_url" in sas_body
+        assert "mock" in sas_body["upload_url"]
+        assert sas_body["blob_path"] == f"{session_id}/albaran_001.pdf"
+
+        # 3. Register file (simulate successful blob upload)
+        reg_resp = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "albaran_001.pdf",
+                "blob_path": f"{session_id}/albaran_001.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 4096,
+                "albaran_group": "group-A",
+                "page_number": 1,
+            },
+        )
+        assert reg_resp.status_code == 201
+        assert reg_resp.json()["status"] == "registered"
+
+        # Register a second file in the same group
+        reg_resp2 = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "albaran_002.pdf",
+                "blob_path": f"{session_id}/albaran_002.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 3072,
+                "albaran_group": "group-A",
+                "page_number": 2,
+            },
+        )
+        assert reg_resp2.status_code == 201
+
+        # 4. Preflight
+        pf_resp = client.post(f"/api/sessions/{session_id}/preflight", headers=headers)
+        assert pf_resp.status_code == 200
+        pf_body = pf_resp.json()
+        assert "confidence" in pf_body
+        assert pf_body["session_id"] == session_id
+
+        # 5. Confirm
+        confirm_resp = client.post(f"/api/sessions/{session_id}/confirm", headers=headers)
+        assert confirm_resp.status_code == 200
+        assert confirm_resp.json()["status"] == "confirmed"
+
+        # 6. Check status
+        status_resp = client.get(f"/api/sessions/{session_id}/status", headers=headers)
+        assert status_resp.status_code == 200
+        status_body = status_resp.json()
+        assert status_body["session_id"] == session_id
+        assert status_body["total_files"] == 2
+        assert status_body["status"] == "confirmed"
+        assert len(status_body["files"]) == 2
+        assert status_body["files"][0]["albaran_group"] == "group-A"
+
+
+def test_e2e_reject_bad_mime() -> None:
+    """E2E: file with bad MIME type is rejected at registration."""
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        resp = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "virus.exe",
+                "blob_path": f"{session_id}/virus.exe",
+                "mime_type": "application/x-executable",
+                "size_bytes": 1024,
+            },
+        )
+        assert resp.status_code == 422
+
+
+def test_e2e_confirm_empty_session_fails() -> None:
+    """E2E: cannot confirm a session with no files."""
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        resp = client.post(f"/api/sessions/{session_id}/confirm", headers=headers)
+        assert resp.status_code == 400

--- a/tests/integration/test_flow0_multipage.py
+++ b/tests/integration/test_flow0_multipage.py
@@ -1,0 +1,169 @@
+"""Integration tests for Flow0 multipage/session-based grouping."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from src.services.flow0_dedup.dedup_handler import Flow0DedupHandler
+
+pytestmark = pytest.mark.integration
+
+
+class FakeCosmosContainer:
+    """In-memory Cosmos container for testing."""
+
+    def __init__(self) -> None:
+        self.items: dict[str, dict[str, Any]] = {}
+
+    def upsert_item(self, *, body: dict[str, Any]) -> dict[str, Any]:
+        self.items[str(body["id"])] = dict(body)
+        return dict(body)
+
+    def query_items(self, *, parameters: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
+        param_map = {p["name"]: p["value"] for p in parameters}
+        dedup_key = param_map.get("@dedup_key")
+        matches = [item for item in self.items.values() if item.get("dedup_key") == dedup_key]
+        return matches[:1]
+
+
+class FakeSender:
+    """Collects Service Bus messages in-memory."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_messages(self, message: Any) -> None:
+        body = b"".join(bytes(part) for part in message.body)
+        self.messages.append(json.loads(body.decode("utf-8")))
+
+
+def _build_session_payload(
+    session_id: str = "sess-multi-001",
+    user_oid: str = "oid-user-001",
+    files: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if files is None:
+        files = []
+    return {
+        "session_id": session_id,
+        "user_oid": user_oid,
+        "files": files,
+        "confirmed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+@pytest.mark.integration
+def test_three_files_one_group_single_record() -> None:
+    """3 files in 1 albaran group → processed as single multi-page document."""
+    container = FakeCosmosContainer()
+    sender = FakeSender()
+    handler = Flow0DedupHandler(container, sender)
+
+    payload = _build_session_payload(
+        files=[
+            {"filename": "page1.pdf", "blob_path": "sess-multi-001/page1.pdf", "albaran_group": "alb-A"},
+            {"filename": "page2.pdf", "blob_path": "sess-multi-001/page2.pdf", "albaran_group": "alb-A"},
+            {"filename": "page3.pdf", "blob_path": "sess-multi-001/page3.pdf", "albaran_group": "alb-A"},
+        ]
+    )
+
+    records = handler.handle_session_message(payload)
+
+    assert len(records) == 1
+    assert records[0].upload_session_id == "sess-multi-001"
+    assert records[0].uploader_oid == "oid-user-001"
+    assert records[0].source_metadata["page_count"] == 3
+    assert len(records[0].source_metadata["blob_paths"]) == 3
+    assert len(container.items) == 1
+    assert len(sender.messages) == 1
+    assert sender.messages[0]["albaran_group"] == "alb-A"
+
+
+@pytest.mark.integration
+def test_two_groups_two_records() -> None:
+    """2 albaran groups in 1 session → 2 separate processing jobs."""
+    container = FakeCosmosContainer()
+    sender = FakeSender()
+    handler = Flow0DedupHandler(container, sender)
+
+    payload = _build_session_payload(
+        session_id="sess-multi-002",
+        files=[
+            {"filename": "a1.pdf", "blob_path": "sess-multi-002/a1.pdf", "albaran_group": "group-X"},
+            {"filename": "a2.pdf", "blob_path": "sess-multi-002/a2.pdf", "albaran_group": "group-X"},
+            {"filename": "b1.pdf", "blob_path": "sess-multi-002/b1.pdf", "albaran_group": "group-Y"},
+        ],
+    )
+
+    records = handler.handle_session_message(payload)
+
+    assert len(records) == 2
+    assert len(container.items) == 2
+    assert len(sender.messages) == 2
+
+    groups_seen = {msg["albaran_group"] for msg in sender.messages}
+    assert groups_seen == {"group-X", "group-Y"}
+
+    # Verify group-X has 2 pages and group-Y has 1
+    for record in records:
+        if record.source_metadata["albaran_group"] == "group-X":
+            assert record.source_metadata["page_count"] == 2
+        else:
+            assert record.source_metadata["page_count"] == 1
+
+
+@pytest.mark.integration
+def test_dedup_handles_reupload_within_session() -> None:
+    """Re-uploading the same session produces new records with same dedup keys."""
+    container = FakeCosmosContainer()
+    sender = FakeSender()
+    handler = Flow0DedupHandler(container, sender)
+
+    payload = _build_session_payload(
+        session_id="sess-reupload",
+        files=[
+            {"filename": "doc.pdf", "blob_path": "sess-reupload/doc.pdf", "albaran_group": "g1"},
+        ],
+    )
+
+    # First submission
+    records1 = handler.handle_session_message(payload)
+    assert len(records1) == 1
+    first_id = records1[0].id
+
+    # Second submission (re-upload) - same session_id + group = same dedup_key = same record ID
+    records2 = handler.handle_session_message(payload)
+    assert len(records2) == 1
+    assert records2[0].id == first_id  # Same dedup key → same record ID
+
+    # Cosmos should have 1 item (upsert overwrites)
+    assert len(container.items) == 1
+    # But sender received 2 messages (one per call)
+    assert len(sender.messages) == 2
+
+
+@pytest.mark.integration
+def test_files_without_group_default_group() -> None:
+    """Files with no albaran_group use 'default' as the group key."""
+    container = FakeCosmosContainer()
+    sender = FakeSender()
+    handler = Flow0DedupHandler(container, sender)
+
+    payload = _build_session_payload(
+        session_id="sess-no-group",
+        files=[
+            {"filename": "a.pdf", "blob_path": "sess-no-group/a.pdf"},
+            {"filename": "b.pdf", "blob_path": "sess-no-group/b.pdf"},
+        ],
+    )
+
+    records = handler.handle_session_message(payload)
+
+    assert len(records) == 1
+    assert records[0].source_metadata["albaran_group"] == "default"
+    assert records[0].source_metadata["page_count"] == 2
+    assert sender.messages[0]["albaran_group"] == "default"

--- a/tests/unit/test_upload_flow.py
+++ b/tests/unit/test_upload_flow.py
@@ -1,0 +1,327 @@
+"""Tests for Upload Web Wave 2 flow: SAS, file registration, validation, preflight, session lifecycle, ownership."""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from itsdangerous import URLSafeSerializer
+
+from src.upload_web.app import create_app
+from src.upload_web.config import get_settings
+from src.upload_web.services import upload_session
+from src.upload_web.services.blob_sas import generate_upload_sas_url
+from src.upload_web.services.file_validator import validate_file
+
+TEST_SECRET = "test-secret-with-at-least-thirty-two-bytes"
+SIGNING_KEY = "dev-only-upload-web-session-signing-key-change-me"
+
+
+def _jwt_token(oid: str = "oid-flow-001", name: str = "Flow Test User") -> str:
+    return jwt.encode(
+        {"oid": oid, "name": name, "groups": ["verdecora-store-uploaders"], "exp": 9999999999},
+        TEST_SECRET,
+        algorithm="HS256",
+    )
+
+
+def _auth_headers(oid: str = "oid-flow-001", name: str = "Flow Test User") -> dict[str, str]:
+    return {"X-MS-TOKEN-AAD-ID-TOKEN": _jwt_token(oid, name)}
+
+
+def _establish_session(client: TestClient, oid: str = "oid-flow-001", name: str = "Flow Test User") -> dict[str, str]:
+    headers = _auth_headers(oid, name)
+    client.get("/", headers=headers)
+    cookie_value = client.cookies.get("upload_web_session", "")
+    if cookie_value:
+        serializer = URLSafeSerializer(SIGNING_KEY, salt="upload-web-session")
+        payload = serializer.loads(cookie_value)
+        headers["X-CSRF-Token"] = payload.get("csrf_token", "")
+    return headers
+
+
+def _api_client() -> TestClient:
+    return TestClient(create_app(), base_url="https://testserver")
+
+
+@pytest.fixture(autouse=True)
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("STORAGE_ACCOUNT_URL", raising=False)
+    monkeypatch.delenv("BLOB_ACCOUNT", raising=False)
+    upload_session.clear_upload_sessions()
+    yield
+    upload_session.clear_upload_sessions()
+    get_settings.cache_clear()
+
+
+# ── SAS URL generation (mock mode) ──────────────────────────────────
+
+
+@pytest.mark.unit
+def test_sas_url_mock_contains_session_id() -> None:
+    sas_url, blob_path, expires_in = generate_upload_sas_url("sess-001", "albaran.pdf")
+    assert "mock" in sas_url.lower()
+    assert "sess-001" in sas_url
+    assert blob_path == "sess-001/albaran.pdf"
+    assert expires_in == 900
+
+
+@pytest.mark.unit
+def test_sas_url_mock_different_filenames() -> None:
+    url1, path1, _ = generate_upload_sas_url("s1", "file_a.pdf")
+    url2, path2, _ = generate_upload_sas_url("s1", "file_b.jpg")
+    assert path1 == "s1/file_a.pdf"
+    assert path2 == "s1/file_b.jpg"
+    assert url1 != url2
+
+
+# ── File metadata registration ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_register_file_valid_payload() -> None:
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        resp = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "albaran.pdf",
+                "blob_path": f"{session_id}/albaran.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 2048,
+            },
+        )
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "registered"
+    assert "file_id" in resp.json()
+
+
+@pytest.mark.unit
+def test_register_file_invalid_no_filename() -> None:
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        resp = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "blob_path": f"{session_id}/test.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 100,
+            },
+        )
+    assert resp.status_code == 422
+
+
+# ── MIME validation ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_mime_accept_pdf() -> None:
+    result = validate_file("test.pdf", "application/pdf", 1024)
+    assert result.valid is True
+
+
+@pytest.mark.unit
+def test_mime_accept_jpeg() -> None:
+    result = validate_file("photo.jpg", "image/jpeg", 2048)
+    assert result.valid is True
+
+
+@pytest.mark.unit
+def test_mime_accept_png() -> None:
+    result = validate_file("scan.png", "image/png", 3072)
+    assert result.valid is True
+
+
+@pytest.mark.unit
+def test_mime_accept_tiff() -> None:
+    result = validate_file("scan.tiff", "image/tiff", 4096)
+    assert result.valid is True
+
+
+@pytest.mark.unit
+def test_mime_reject_exe() -> None:
+    result = validate_file("malware.exe", "application/x-executable", 1024)
+    assert result.valid is False
+    assert any("not allowed" in e for e in result.errors)
+
+
+@pytest.mark.unit
+def test_mime_reject_zip() -> None:
+    result = validate_file("archive.zip", "application/zip", 1024)
+    assert result.valid is False
+
+
+# ── Size validation ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_size_under_limit() -> None:
+    result = validate_file("ok.pdf", "application/pdf", 10 * 1024 * 1024)
+    assert result.valid is True
+
+
+@pytest.mark.unit
+def test_size_over_limit() -> None:
+    result = validate_file("huge.pdf", "application/pdf", 60 * 1024 * 1024)
+    assert result.valid is False
+    assert any("50 MB" in e for e in result.errors)
+
+
+# ── Preflight endpoint ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_preflight_returns_result_structure() -> None:
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "test.pdf",
+                "blob_path": f"{session_id}/test.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 1024,
+            },
+        )
+
+        resp = client.post(f"/api/sessions/{session_id}/preflight", headers=headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "confidence" in body
+    assert "session_id" in body
+    assert "is_albaran" in body
+    assert "warnings" in body
+
+
+# ── Session lifecycle ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_session_lifecycle_created_to_confirmed() -> None:
+    with _api_client() as client:
+        headers = _establish_session(client)
+
+        # created
+        create_resp = client.post("/api/sessions", headers=headers)
+        assert create_resp.status_code == 201
+        session_id = create_resp.json()["session_id"]
+        assert create_resp.json()["status"] == "created"
+
+        # uploading (SAS generation transitions)
+        client.post(f"/api/sessions/{session_id}/sas?filename=a.pdf", headers=headers)
+
+        # register file
+        client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "a.pdf",
+                "blob_path": f"{session_id}/a.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 1024,
+            },
+        )
+
+        # preflight
+        pf_resp = client.post(f"/api/sessions/{session_id}/preflight", headers=headers)
+        assert pf_resp.status_code == 200
+
+        # Check session is in preflight state
+        get_resp = client.get(f"/api/sessions/{session_id}", headers=headers)
+        assert get_resp.json()["status"] == "preflight"
+
+        # confirm
+        confirm_resp = client.post(f"/api/sessions/{session_id}/confirm", headers=headers)
+        assert confirm_resp.status_code == 200
+        assert confirm_resp.json()["status"] == "confirmed"
+
+
+# ── Session ownership ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_session_ownership_user_a_cannot_access_user_b() -> None:
+    with _api_client() as client:
+        headers_a = _establish_session(client, oid="user-a")
+        create_resp = client.post("/api/sessions", headers=headers_a)
+        session_id = create_resp.json()["session_id"]
+
+        headers_b = _establish_session(client, oid="user-b")
+
+        # GET session
+        resp = client.get(f"/api/sessions/{session_id}", headers=headers_b)
+        assert resp.status_code == 403
+
+        # SAS
+        resp = client.post(f"/api/sessions/{session_id}/sas?filename=x.pdf", headers=headers_b)
+        assert resp.status_code == 403
+
+        # register file
+        resp = client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers_b,
+            json={
+                "filename": "x.pdf",
+                "blob_path": f"{session_id}/x.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 100,
+            },
+        )
+        assert resp.status_code == 403
+
+        # confirm
+        resp = client.post(f"/api/sessions/{session_id}/confirm", headers=headers_b)
+        assert resp.status_code == 403
+
+
+@pytest.mark.unit
+def test_session_status_endpoint() -> None:
+    with _api_client() as client:
+        headers = _establish_session(client)
+        create_resp = client.post("/api/sessions", headers=headers)
+        session_id = create_resp.json()["session_id"]
+
+        client.post(
+            f"/api/sessions/{session_id}/files",
+            headers=headers,
+            json={
+                "filename": "doc.pdf",
+                "blob_path": f"{session_id}/doc.pdf",
+                "mime_type": "application/pdf",
+                "size_bytes": 512,
+            },
+        )
+
+        resp = client.get(f"/api/sessions/{session_id}/status", headers=headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == session_id
+    assert body["total_files"] == 1
+    assert "progress_percent" in body
+    assert "files" in body
+
+
+@pytest.mark.unit
+def test_session_status_ownership() -> None:
+    with _api_client() as client:
+        headers_a = _establish_session(client, oid="owner-a")
+        create_resp = client.post("/api/sessions", headers=headers_a)
+        session_id = create_resp.json()["session_id"]
+
+        headers_b = _establish_session(client, oid="owner-b")
+        resp = client.get(f"/api/sessions/{session_id}/status", headers=headers_b)
+    assert resp.status_code == 403


### PR DESCRIPTION
## Upload Web Wave 2

### Issues
- **#107** — Upload tests (unit + E2E): 17 unit tests + 3 E2E tests covering SAS generation, MIME validation, size validation, preflight, session lifecycle, and ownership
- **#112** — Flow 0 grouping by session+albaran: `handle_session_message()` groups files by `albaran_group`, creating separate processing jobs per group
- **#113** — Flow 0 multi-page integration tests: 4 tests verifying multi-page grouping, separate jobs, and dedup within sessions
- **#114** — Status endpoint with HTMX polling: `GET /api/sessions/{id}/status` API + `/upload/{id}/status` page with `hx-trigger='every 5s'`
- **#115** — Propagate upload_session_id and uploader_oid: Added to ProcessingRecord, ForwardedExtractionMessage, and Cosmos records via OrchestratorService
- **#116** — Mis Albaranes panel: Real implementation with uploads table, status badges, HTMX filtering, clickable rows

### Changes
- `src/services/flow0_dedup/models.py` — Added `upload_session_id`, `uploader_oid`, `albaran_group` fields
- `src/services/flow0_dedup/dedup_handler.py` — New `handle_session_message()` and `_forward_session_group()`
- `src/services/orchestrator/orchestration.py` — Propagate session metadata to Cosmos
- `src/upload_web/routes/api.py` — New `GET /{session_id}/status` endpoint
- `src/upload_web/routes/upload.py` — New status page, real mis-albaranes, HTMX filter
- `src/upload_web/services/upload_session.py` — New `get_all_user_sessions()`
- `src/upload_web/templates/pages/status.html` — HTMX polling status page
- `src/upload_web/templates/pages/my_albaranes.html` — Uploads history with filtering

### Testing
- **48 unit tests pass** (including all existing)
- **4 integration tests pass**
- **ruff check + format clean**