### PR TITLE
feat(upload-web): observability + security hardening + docs + rollout plan (#117-#124)

### DIFF
--- a/docs/operations/rollout-plan.md
+++ b/docs/operations/rollout-plan.md
@@ -1,0 +1,163 @@
+# Plan de Rollout — Upload Web (25 tiendas)
+
+## Resumen
+
+Despliegue progresivo del portal de subida de albaranes (Upload Web) en
+tres fases, desde 2 tiendas piloto hasta 25 tiendas en producción completa.
+
+---
+
+## Fases de despliegue
+
+### Fase 1 — Piloto (2 tiendas)
+
+| Parámetro | Valor |
+|---|---|
+| **Tiendas** | Tienda A (Madrid) · Tienda B (Valencia) |
+| **Duración** | 2 semanas |
+| **Feature flag** | `upload_web_enabled: pilot` |
+| **Réplicas ACA** | 1 (mínimo) |
+
+**Checklist de monitorización**:
+- [ ] Error rate < 1 % durante 48 h continuas
+- [ ] Tasa de abandono < 15 %
+- [ ] Preflight detecta proveedor en > 80 % de sesiones
+- [ ] Latencia p95 < 2 s para preflight
+- [ ] Cero incidentes Sev1 o Sev2
+- [ ] Feedback UAT ≥ 7/10 en ambas tiendas
+
+**Criterios de rollback**:
+- Error rate > 5 % durante 30 min
+- Bloqueo total del flujo de subida
+- Feedback negativo consistente de ambas tiendas
+
+**Acciones de rollback**:
+```bash
+# Desactivar feature flag
+az containerapp update -n ca-upload-web -g rg-verdecora-prod \
+  --set-env-vars "UPLOAD_WEB_FEATURE_FLAG=disabled"
+
+# Redirigir a página de mantenimiento
+az containerapp ingress update -n ca-upload-web -g rg-verdecora-prod \
+  --target-port 8000
+```
+
+---
+
+### Fase 2 — Rollout controlado (10 tiendas)
+
+| Parámetro | Valor |
+|---|---|
+| **Tiendas** | 8 tiendas adicionales (mix de tamaños y regiones) |
+| **Duración** | 2 semanas |
+| **Feature flag** | `upload_web_enabled: controlled` |
+| **Réplicas ACA** | 2-3 (auto-scaling activado) |
+
+**Pre-requisitos**:
+- ✅ Fase 1 completada con éxito
+- ✅ Todas las incidencias de UAT resueltas
+- ✅ Formación completada para las 8 nuevas tiendas
+
+**Checklist de monitorización**:
+- [ ] Error rate < 2 % durante 72 h continuas
+- [ ] Tasa de abandono < 20 %
+- [ ] RPS < 60 % de capacidad máxima
+- [ ] No hay degradación de latencia vs. Fase 1
+- [ ] Service Bus queue depth < 50 mensajes
+- [ ] Zero incidentes de seguridad
+
+**Criterios de rollback**:
+- Error rate > 5 % durante 15 min
+- Latencia p95 > 5 s durante 30 min
+- Queue depth > 200 mensajes durante 15 min
+
+---
+
+### Fase 3 — Rollout completo (25 tiendas)
+
+| Parámetro | Valor |
+|---|---|
+| **Tiendas** | 15 tiendas adicionales |
+| **Duración** | Indefinida (producción) |
+| **Feature flag** | `upload_web_enabled: all` |
+| **Réplicas ACA** | 2-5 (KEDA auto-scaling) |
+
+**Pre-requisitos**:
+- ✅ Fase 2 completada con éxito (2 semanas sin Sev1/Sev2)
+- ✅ Load test de 30 RPS / 30 min superado
+- ✅ Runbook de operaciones revisado y actualizado
+- ✅ Formación completada para todas las tiendas
+
+**Checklist de monitorización**:
+- [ ] Error rate < 1 % en régimen estable
+- [ ] Auto-scaling funciona correctamente bajo carga pico
+- [ ] Alertas configuradas y probadas
+- [ ] Dashboard operativo revisado diariamente (primera semana)
+- [ ] Sin degradación en el pipeline de procesamiento (orquestador, agentes)
+
+---
+
+## Configuración de Feature Flags
+
+```bash
+# Fase 1: solo tiendas piloto
+az containerapp update -n ca-upload-web -g rg-verdecora-prod \
+  --set-env-vars "UPLOAD_WEB_FEATURE_FLAG=pilot" \
+                 "UPLOAD_WEB_ALLOWED_STORES=STORE-A,STORE-B"
+
+# Fase 2: 10 tiendas
+az containerapp update -n ca-upload-web -g rg-verdecora-prod \
+  --set-env-vars "UPLOAD_WEB_FEATURE_FLAG=controlled" \
+                 "UPLOAD_WEB_ALLOWED_STORES=STORE-A,STORE-B,STORE-C,STORE-D,STORE-E,STORE-F,STORE-G,STORE-H,STORE-I,STORE-J"
+
+# Fase 3: todas las tiendas
+az containerapp update -n ca-upload-web -g rg-verdecora-prod \
+  --set-env-vars "UPLOAD_WEB_FEATURE_FLAG=all" \
+  --remove-env-vars "UPLOAD_WEB_ALLOWED_STORES"
+```
+
+---
+
+## Plan de comunicación
+
+### Antes de cada fase
+
+| Acción | Responsable | Plazo |
+|---|---|---|
+| Enviar email informativo a responsables de tienda | Coordinador de operaciones | 1 semana antes |
+| Compartir manual de usuario (docs/user/upload-web-manual.md) | Coordinador de operaciones | 1 semana antes |
+| Sesión de formación por videollamada (30 min) | Equipo técnico | 3 días antes |
+| Confirmar acceso de usuarios en Entra ID | Administrador IT | 1 día antes |
+
+### Durante cada fase
+
+| Acción | Responsable | Frecuencia |
+|---|---|---|
+| Revisar dashboard de Upload Web | Operaciones | Diario |
+| Recoger feedback de tiendas | Coordinador | Semanal |
+| Revisar alertas y incidencias | DevOps | Diario |
+| Reunión de seguimiento con tiendas piloto | Coordinador | Semanal (Fase 1) |
+
+### Después de cada fase
+
+| Acción | Responsable | Plazo |
+|---|---|---|
+| Compilar informe de métricas | DevOps | 2 días después |
+| Decidir Go/No-Go para siguiente fase | Comité de operaciones | 3 días después |
+| Documentar lecciones aprendidas | Equipo técnico | 1 semana después |
+
+---
+
+## Métricas de éxito global
+
+| Métrica | Objetivo |
+|---|---|
+| Adopción | ≥ 80 % de tiendas usando Upload Web activamente |
+| Error rate | < 1 % en régimen estable |
+| Tiempo medio de subida | < 3 minutos por albarán |
+| Satisfacción de usuario | ≥ 7/10 |
+| Reducción de errores manuales | ≥ 50 % vs. proceso anterior |
+
+---
+
+*Última actualización: 2025*

--- a/docs/operations/upload-web-runbook.md
+++ b/docs/operations/upload-web-runbook.md
@@ -1,0 +1,296 @@
+# Upload Web — Runbook de Operaciones
+
+## Resumen
+
+Este runbook cubre la respuesta a incidentes, diagnóstico y escalado del
+componente **Upload Web** (portal de subida de albaranes desplegado en
+Azure Container Apps).
+
+---
+
+## 1. Respuesta a incidentes
+
+### 1.1 Tasa alta de errores 5xx
+
+**Síntomas**: dashboard muestra error rate > 5 %, alerta `upload-web-5xx-rate` disparada.
+
+```text
+Severidad: Crítica
+Tiempo de respuesta: < 15 min
+```
+
+**Pasos de diagnóstico**:
+
+1. Verificar salud básica:
+   ```bash
+   curl https://upload.verdecora.es/healthz
+   curl https://upload.verdecora.es/readyz
+   ```
+
+2. Consultar logs en App Insights:
+   ```kql
+   AppExceptions
+   | where TimeGenerated >= ago(30m)
+   | where AppRoleName has 'upload-web'
+   | summarize count() by type, outerMessage
+   | order by count_ desc
+   ```
+
+3. Verificar estado de Container Apps:
+   ```bash
+   az containerapp show -n ca-upload-web -g rg-verdecora-prod --query "properties.runningStatus"
+   ```
+
+**Remediación**:
+- Reiniciar Container App:
+  ```bash
+  az containerapp revision restart -n ca-upload-web -g rg-verdecora-prod --revision <revision-name>
+  ```
+- Si el error persiste, verificar dependencias (Storage, Cosmos, Service Bus).
+
+---
+
+### 1.2 Fallo en generación de SAS
+
+**Síntomas**: usuarios no pueden subir archivos, error "No se pudo generar URL de subida".
+
+**Pasos de diagnóstico**:
+
+1. Verificar permisos de Managed Identity en Storage:
+   ```bash
+   az role assignment list \
+     --assignee <managed-identity-object-id> \
+     --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<account> \
+     --output table
+   ```
+   Debe tener `Storage Blob Data Contributor`.
+
+2. Verificar conectividad al Storage Account:
+   ```kql
+   AppDependencies
+   | where TimeGenerated >= ago(30m)
+   | where Target has 'blob.core.windows.net'
+   | where Success == false
+   | summarize count() by ResultCode, DependencyTypeName
+   ```
+
+**Remediación**:
+- Si faltan permisos:
+  ```bash
+  az role assignment create \
+    --assignee <managed-identity-object-id> \
+    --role "Storage Blob Data Contributor" \
+    --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<account>
+  ```
+- Si hay problemas de red, verificar Private Endpoints y NSG.
+
+---
+
+### 1.3 Timeouts en preflight (Document Intelligence)
+
+**Síntomas**: preflight tarda más de 30 s o falla con timeout.
+
+**Pasos de diagnóstico**:
+
+1. Verificar salud del endpoint de Document Intelligence:
+   ```bash
+   az cognitiveservices account show -n <di-account> -g <rg> --query "properties.provisioningState"
+   ```
+
+2. Revisar latencia en logs:
+   ```kql
+   AppDependencies
+   | where TimeGenerated >= ago(1h)
+   | where Target has 'cognitiveservices'
+   | summarize avg(DurationMs), percentile(DurationMs, 95), count() by bin(TimeGenerated, 5m)
+   ```
+
+3. Verificar rate limits de Document Intelligence:
+   ```kql
+   AppDependencies
+   | where TimeGenerated >= ago(1h)
+   | where Target has 'cognitiveservices'
+   | where ResultCode == '429'
+   | summarize count() by bin(TimeGenerated, 5m)
+   ```
+
+**Remediación**:
+- Si hay throttling (429), reducir concurrencia o escalar el tier de DI.
+- Si hay timeout de red, verificar Private Endpoints.
+- El preflight cae a heurístico si DI falla; los usuarios pueden seguir subiendo.
+
+---
+
+### 1.4 Sesión atascada en "processing"
+
+**Síntomas**: albarán confirmado pero nunca pasa a "completado".
+
+**Pasos de diagnóstico**:
+
+1. Verificar que el mensaje se publicó en Service Bus:
+   ```kql
+   AppTraces
+   | where TimeGenerated >= ago(2h)
+   | where Message has 'Published session'
+   | where Message has '<session-id>'
+   ```
+
+2. Verificar profundidad de cola:
+   ```bash
+   az servicebus topic subscription show \
+     --namespace-name <sb-namespace> \
+     --topic-name albaran-processing \
+     --name <subscription> \
+     --query "countDetails"
+   ```
+
+3. Verificar logs del orquestador (Flow 0):
+   ```kql
+   AppTraces
+   | where TimeGenerated >= ago(2h)
+   | where AppRoleName has 'orchestrator'
+   | where Message has '<session-id>'
+   | order by TimeGenerated asc
+   ```
+
+**Remediación**:
+- Si el mensaje no se publicó, reenviar manualmente o confirmar de nuevo la sesión.
+- Si está en la cola pero no se procesa, verificar el orquestador y los agentes.
+
+---
+
+### 1.5 Fallos de autenticación
+
+**Síntomas**: usuarios no pueden iniciar sesión, alerta `upload-web-auth-failures` disparada.
+
+**Pasos de diagnóstico**:
+
+1. Verificar configuración de Easy Auth en Container Apps:
+   ```bash
+   az containerapp auth show -n ca-upload-web -g rg-verdecora-prod
+   ```
+
+2. Verificar App Registration en Entra ID:
+   ```bash
+   az ad app show --id <app-id> --query "{redirectUris:web.redirectUris, status:disabledByMicrosoftStatus}"
+   ```
+
+3. Revisar logs de autenticación:
+   ```kql
+   AppTraces
+   | where TimeGenerated >= ago(1h)
+   | where Message has_any ('auth', 'login', '401', '403')
+   | where AppRoleName has 'upload-web'
+   | summarize count() by Message
+   | order by count_ desc
+   ```
+
+**Remediación**:
+- Verificar que `AZURE_TENANT_ID` y `SESSION_SIGNING_KEY` están correctamente configurados.
+- Si es un posible ataque de fuerza bruta (> 10 intentos en 5 min desde misma IP), considerar bloqueo temporal.
+- Verificar que el grupo `verdecora-store-uploaders` tiene los usuarios correctos.
+
+---
+
+## 2. Escalado
+
+### 2.1 Escalado manual
+
+```bash
+# Escalar a 3 réplicas
+az containerapp update -n ca-upload-web -g rg-verdecora-prod \
+  --min-replicas 2 --max-replicas 5
+
+# Verificar réplicas
+az containerapp revision list -n ca-upload-web -g rg-verdecora-prod \
+  --query "[].{name:name, replicas:properties.replicas, active:properties.active}" -o table
+```
+
+### 2.2 Escalado con KEDA
+
+La app soporta auto-scaling basado en peticiones HTTP concurrentes:
+
+```yaml
+# Configuración KEDA (ya definida en Bicep)
+scale:
+  minReplicas: 1
+  maxReplicas: 10
+  rules:
+    - name: http-scaling
+      http:
+        metadata:
+          concurrentRequests: "50"
+```
+
+- **Regla**: 1 réplica adicional por cada 50 peticiones concurrentes.
+- **Mínimo**: 1 réplica (2 en producción para HA).
+- **Máximo**: 10 réplicas.
+
+---
+
+## 3. Consultas KQL útiles
+
+### Sesiones creadas vs confirmadas (última hora)
+
+```kql
+customMetrics
+| where TimeGenerated >= ago(1h)
+| where name in ('upload_sessions_created', 'upload_session_abandoned')
+| summarize Total = sum(valueCount) by name
+```
+
+### Errores por tipo
+
+```kql
+customMetrics
+| where TimeGenerated >= ago(1h)
+| where name == 'upload_errors'
+| extend error_type = tostring(customDimensions['error_type'])
+| summarize count() by error_type
+| order by count_ desc
+```
+
+### Latencia de preflight (percentiles)
+
+```kql
+customMetrics
+| where TimeGenerated >= ago(1h)
+| where name == 'upload_preflight_duration_seconds'
+| summarize P50 = percentile(value, 50), P95 = percentile(value, 95), P99 = percentile(value, 99)
+```
+
+### Top usuarios por volumen
+
+```kql
+customMetrics
+| where TimeGenerated >= ago(24h)
+| where name == 'upload_files_processed'
+| extend supplier = tostring(customDimensions['supplier'])
+| summarize Files = sum(valueCount) by supplier
+| top 10 by Files desc
+```
+
+### Requests 5xx en la última hora
+
+```kql
+AppRequests
+| where TimeGenerated >= ago(1h)
+| where AppRoleName has 'upload-web'
+| where toint(ResultCode) >= 500
+| summarize count() by ResultCode, Name, bin(TimeGenerated, 5m)
+| order by TimeGenerated desc
+```
+
+---
+
+## 4. Contactos de escalado
+
+| Nivel | Contacto | Tiempo de respuesta |
+|---|---|---|
+| L1 — Operaciones | ops@verdecora.example.com | < 15 min |
+| L2 — Desarrollo | dev-team@verdecora.example.com | < 1 h |
+| L3 — Infraestructura | infra@verdecora.example.com | < 2 h |
+
+---
+
+*Última actualización: 2025*

--- a/docs/user/uat-checklist.md
+++ b/docs/user/uat-checklist.md
@@ -1,0 +1,127 @@
+# Checklist de Pruebas de Aceptación de Usuario (UAT)
+
+## Información general
+
+| Campo | Valor |
+|---|---|
+| **Aplicación** | Upload Web — Portal de subida de albaranes |
+| **Tiendas piloto** | Tienda A (Madrid) · Tienda B (Valencia) |
+| **Periodo de pruebas** | 2 semanas desde el inicio del piloto |
+| **Responsable** | Coordinador de operaciones + responsable de tienda |
+
+---
+
+## Escenarios de prueba
+
+### 1. Subir un albarán PDF de una sola página
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Iniciar sesión con la cuenta de tienda | Página principal cargada correctamente |
+| 2 | Pulsar "Subir albarán" | Se abre la pantalla de subida |
+| 3 | Arrastrar o seleccionar un PDF de 1 página | Barra de progreso visible, carga completa |
+| 4 | Pulsar "Verificar" (preflight) | Se muestra proveedor, fecha y número detectados |
+| 5 | Pulsar "Confirmar y enviar" | Mensaje de confirmación con resumen |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 2. Subir fotografías de albarán (JPEG/PNG)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Seleccionar 2-3 fotos JPEG/PNG del albarán | Cada imagen aparece como miniatura |
+| 2 | Agrupar las imágenes como un único albarán | Indicador de grupo visible |
+| 3 | Verificar (preflight) | Proveedor y datos detectados con confianza media-alta |
+| 4 | Confirmar y enviar | Sesión marcada como "confirmada" |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 3. Subir albarán multipágina (PDF de varias páginas)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Seleccionar un PDF con 3+ páginas | Todas las páginas se cargan |
+| 2 | Verificar qué páginas corresponden al albarán | Preflight muestra datos coherentes |
+| 3 | Confirmar | Sesión enviada sin errores |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 4. Subir un archivo con tipo incorrecto (DOCX, XLS, etc.)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Intentar subir un archivo .docx o .xls | Error claro: "Tipo de archivo no permitido" |
+| 2 | Verificar que la sesión sigue activa | Se puede reintentar con un archivo válido |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 5. Archivo demasiado grande (> 50 MB)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Intentar subir un archivo mayor de 50 MB | Error: "El archivo supera el tamaño máximo" |
+| 2 | La sesión no se rompe | Puede seguir subiendo otros archivos |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 6. Sesión inactiva (timeout)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Iniciar sesión y no interactuar durante 30 min | Redirigido a login con aviso de inactividad |
+| 2 | Volver a iniciar sesión | Los datos anteriores no confirmados no se pierden |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+### 7. Acceso denegado (usuario sin permisos)
+
+| Paso | Acción | Resultado esperado |
+|---|---|---|
+| 1 | Acceder con una cuenta sin grupo "uploaders" | Mensaje: "No tiene permisos para acceder" |
+
+**Resultado**: ☐ Correcto · ☐ Incorrecto  
+**Observaciones**: _______________________________________________
+
+---
+
+## Formulario de feedback
+
+Al finalizar las pruebas, cada tienda piloto debe completar este formulario:
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿El proceso de subida fue intuitivo? (1-5) | ___ |
+| ¿Los mensajes de error fueron claros? (1-5) | ___ |
+| ¿El tiempo de carga fue aceptable? (1-5) | ___ |
+| ¿El preflight detectó correctamente el proveedor? | Sí / No / Parcialmente |
+| ¿Encontró algún error no listado arriba? | ___ |
+| ¿Qué mejoraría del proceso? | ___ |
+| Puntuación general (1-10) | ___ |
+
+---
+
+## Criterios de aceptación
+
+- ✅ Todos los escenarios 1-5 pasan sin errores.
+- ✅ Los mensajes de error son comprensibles para el personal de tienda.
+- ✅ Puntuación media ≥ 7/10 en ambas tiendas piloto.
+- ✅ No se detectan bloqueos críticos.
+- ⚠️ Incidencias menores se documentan y se resuelven antes de la Fase 2.

--- a/docs/user/upload-web-manual.md
+++ b/docs/user/upload-web-manual.md
@@ -1,0 +1,145 @@
+# Manual de Usuario — Upload Web
+
+> Portal de subida de albaranes para tiendas Verdecora
+
+---
+
+## 1. Cómo acceder
+
+1. Abra su navegador (Chrome, Edge o Firefox recomendados).
+2. Vaya a la dirección proporcionada por su coordinador:  
+   **`https://upload.verdecora.es`** (o la URL de pruebas indicada).
+3. Inicie sesión con su **cuenta corporativa de tienda** (la misma que usa para el correo de Verdecora).
+4. Si es la primera vez, se le pedirá que acepte los permisos de la aplicación.
+
+> 💡 Si ve el mensaje *"No tiene permisos para acceder"*, contacte con su coordinador para que le añadan al grupo de usuarios autorizados.
+
+---
+
+## 2. Cómo subir un albarán
+
+### Paso a paso
+
+1. En la pantalla principal, pulse el botón **"Subir albarán"**.
+
+   <!-- [Captura: botón "Subir albarán" en la pantalla principal] -->
+
+2. **Arrastre los archivos** a la zona de carga o pulse **"Seleccionar archivos"**.
+   - Formatos admitidos: **PDF, JPEG, PNG**
+   - Tamaño máximo por archivo: **50 MB**
+   - Puede subir hasta **20 archivos** por sesión
+
+   <!-- [Captura: zona de arrastrar y soltar con archivos cargándose] -->
+
+3. Espere a que la barra de progreso de cada archivo llegue al **100 %**.
+
+   <!-- [Captura: barras de progreso completadas] -->
+
+4. Una vez cargados todos los archivos, pulse **"Verificar"** para ejecutar la comprobación previa (*preflight*).
+
+   <!-- [Captura: botón "Verificar" activo] -->
+
+---
+
+## 3. Cómo agrupar páginas de un mismo albarán
+
+Si el albarán tiene **varias páginas** (por ejemplo, fotos de cada hoja):
+
+1. Suba todas las páginas/fotos del mismo albarán.
+2. En la pantalla de resumen, utilice el campo **"Grupo de albarán"** para asignar el mismo nombre o número a todas las páginas que pertenezcan al mismo documento.
+3. Indique el **número de página** de cada archivo si es relevante.
+
+> 💡 Esto ayuda al sistema a procesar todas las páginas juntas como un único albarán.
+
+<!-- [Captura: campo "Grupo de albarán" con varias páginas agrupadas] -->
+
+---
+
+## 4. Cómo confirmar y enviar
+
+1. Tras la verificación, revise los datos detectados:
+   - **Proveedor** detectado
+   - **Fecha** del albarán
+   - **Número de albarán**
+   - **Tienda** asociada
+
+   <!-- [Captura: pantalla de resumen con datos detectados] -->
+
+2. Si los datos son correctos, pulse **"Confirmar y enviar"**.
+3. Si necesita corregir la tienda, pulse **"Cambiar tienda"** y seleccione la correcta.
+4. Verá un mensaje de confirmación con el resumen de lo enviado.
+
+   <!-- [Captura: mensaje de confirmación exitosa] -->
+
+> ⚠️ Una vez confirmado, el albarán entra en el flujo de procesamiento automático. No se puede deshacer.
+
+---
+
+## 5. Cómo ver el estado de mis albaranes
+
+1. En el menú principal, pulse **"Mis albaranes"**.
+2. Verá una lista con todos los albaranes enviados y su estado:
+
+| Estado | Significado |
+|---|---|
+| **Subiendo** | Los archivos se están cargando |
+| **Verificado** | El preflight se ha completado |
+| **Confirmado** | Enviado al sistema de procesamiento |
+| **Procesando** | El sistema está extrayendo datos |
+| **Completado** | Albarán procesado y registrado en Business Central |
+| **Error** | Ha ocurrido un problema (ver detalles) |
+
+> 💡 Esta funcionalidad estará completamente disponible en próximas versiones. Mientras tanto, los albaranes confirmados se procesan automáticamente.
+
+---
+
+## 6. Qué hacer si hay errores
+
+### "Tipo de archivo no permitido"
+- Asegúrese de subir solo archivos **PDF, JPEG o PNG**.
+- Los archivos Word (.docx), Excel (.xlsx) u otros formatos no son compatibles.
+
+### "El archivo supera el tamaño máximo"
+- Reduzca el tamaño del archivo (por ejemplo, comprimiendo el PDF o reduciendo la resolución de las fotos).
+- El límite es **50 MB** por archivo.
+
+### "Error de conexión" o "Error del servidor"
+- Espere unos segundos y vuelva a intentarlo.
+- Si el problema persiste más de 5 minutos, contacte con el equipo de soporte.
+
+### "Sesión cerrada por inactividad"
+- La sesión se cierra automáticamente tras **30 minutos sin actividad**.
+- Vuelva a iniciar sesión; los archivos ya subidos (no confirmados) se mantienen.
+
+### "No tiene permisos para acceder"
+- Su cuenta no está en el grupo de usuarios autorizados.
+- Contacte con su coordinador o con soporte técnico.
+
+### La verificación no detecta el proveedor
+- Asegúrese de que el albarán es legible (buena calidad de foto/escaneo).
+- Puede continuar y confirmar igualmente; el sistema intentará detectar los datos en el procesamiento posterior.
+
+---
+
+## 7. Preguntas frecuentes
+
+### ¿Puedo subir varios albaranes a la vez?
+Sí, pero cada albarán debe estar en su propia **sesión de subida**. Suba los archivos de un albarán, confirme, y luego cree una nueva sesión para el siguiente.
+
+### ¿Qué pasa si cierro el navegador antes de confirmar?
+Los archivos ya subidos se conservan. Cuando vuelva a iniciar sesión, podrá retomar la sesión si no ha expirado.
+
+### ¿Puedo subir albaranes desde el móvil?
+Sí, la aplicación es compatible con navegadores móviles. Puede hacer fotos directamente desde la cámara y subirlas.
+
+### ¿Cuánto tarda en procesarse un albarán?
+Normalmente entre **1 y 5 minutos**. Si hay muchas subidas simultáneas o el albarán requiere revisión manual, puede tardar más.
+
+### ¿A quién contacto si tengo problemas?
+- **Soporte técnico**: soporte@verdecora.es
+- **Coordinador de tienda**: su responsable directo
+- **Horario de soporte**: lunes a viernes, 8:00 – 18:00
+
+---
+
+*Última actualización: 2025*

--- a/infra/dashboards/upload-web-workbook.json
+++ b/infra/dashboards/upload-web-workbook.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/Application-Insights-Workbooks/master/schema/workbook.json",
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Upload Web — Panel de Observabilidad\nMétricas operativas del portal de subida de albaranes."
+      },
+      "name": "title"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "name": "TimeRange",
+            "type": 4,
+            "defaultValue": {
+              "durationMs": 86400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                { "durationMs": 3600000, "displayName": "Última hora" },
+                { "durationMs": 14400000, "displayName": "Últimas 4 h" },
+                { "durationMs": 86400000, "displayName": "Últimas 24 h" },
+                { "durationMs": 604800000, "displayName": "Últimos 7 días" }
+              ]
+            }
+          }
+        ]
+      },
+      "name": "parameters"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name == 'upload_sessions_created'\n| where timestamp {TimeRange}\n| summarize Sessions = sum(valueCount) by bin(timestamp, 1h)\n| order by timestamp asc",
+        "size": 0,
+        "title": "Upload Volume per Hour",
+        "queryType": 0,
+        "visualization": "barchart"
+      },
+      "name": "upload-volume-hourly"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name == 'upload_sessions_created'\n| where timestamp {TimeRange}\n| summarize Sessions = sum(valueCount) by bin(timestamp, 1d)\n| order by timestamp asc",
+        "size": 0,
+        "title": "Upload Volume per Day",
+        "queryType": 0,
+        "visualization": "barchart"
+      },
+      "name": "upload-volume-daily"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let created = customMetrics\n| where name == 'upload_sessions_created'\n| where timestamp {TimeRange}\n| summarize Created = sum(valueCount);\nlet abandoned = customMetrics\n| where name == 'upload_session_abandoned'\n| where timestamp {TimeRange}\n| summarize Abandoned = sum(valueCount);\nlet errors = customMetrics\n| where name == 'upload_errors'\n| where timestamp {TimeRange}\n| summarize Errors = sum(valueCount);\ncreated | extend Abandoned = toscalar(abandoned | project Abandoned), Errors = toscalar(errors | project Errors)\n| extend Confirmed = Created - Abandoned\n| project Created, Confirmed, Abandoned, Errors",
+        "size": 3,
+        "title": "Success / Abandon / Error Rates",
+        "queryType": 0,
+        "visualization": "tiles"
+      },
+      "name": "rates-summary"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name == 'upload_preflight_duration_seconds'\n| where timestamp {TimeRange}\n| summarize P50 = percentile(value, 50), P95 = percentile(value, 95), P99 = percentile(value, 99) by bin(timestamp, 1h)\n| order by timestamp asc",
+        "size": 0,
+        "title": "Preflight Duration (p50 / p95 / p99)",
+        "queryType": 0,
+        "visualization": "linechart"
+      },
+      "name": "preflight-accuracy"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name == 'upload_files_processed'\n| where timestamp {TimeRange}\n| extend supplier = tostring(customDimensions['supplier'])\n| summarize Files = sum(valueCount) by supplier\n| top 10 by Files desc",
+        "size": 0,
+        "title": "Top Uploaders (by supplier)",
+        "queryType": 0,
+        "visualization": "table"
+      },
+      "name": "top-uploaders"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name == 'upload_confirm_duration_seconds'\n| where timestamp {TimeRange}\n| summarize AvgDuration = avg(value), P95 = percentile(value, 95) by bin(timestamp, 1h)\n| order by timestamp asc",
+        "size": 0,
+        "title": "Average Session Duration (confirm latency)",
+        "queryType": 0,
+        "visualization": "linechart"
+      },
+      "name": "session-duration"
+    }
+  ],
+  "fallbackResourceIds": [],
+  "fromTemplateId": "verdecora-upload-web-workbook"
+}

--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -363,5 +363,179 @@ resource agentProcessingTimeAlert 'Microsoft.Insights/scheduledQueryRules@2023-1
   }
 }
 
+// ── Upload Web alerts (#118) ────────────────────────────────────────────
+
+var uploadWeb5xxRateQuery = '''
+let windowStart = ago(15m);
+let totalRequests = toscalar(
+    AppRequests
+    | where TimeGenerated >= windowStart
+    | where AppRoleName has 'upload-web'
+    | count
+);
+let errorRequests = toscalar(
+    AppRequests
+    | where TimeGenerated >= windowStart
+    | where AppRoleName has 'upload-web'
+    | where toint(ResultCode) >= 500
+    | count
+);
+print ErrorRatePct = iff(totalRequests == 0, 0.0, todouble(errorRequests) * 100.0 / todouble(totalRequests))
+'''
+
+var uploadWebAbandonedRateQuery = '''
+let windowStart = ago(1h);
+let created = toscalar(
+    customMetrics
+    | where TimeGenerated >= windowStart
+    | where name == 'upload_sessions_created'
+    | summarize sum(valueCount)
+);
+let abandoned = toscalar(
+    customMetrics
+    | where TimeGenerated >= windowStart
+    | where name == 'upload_session_abandoned'
+    | summarize sum(valueCount)
+);
+print AbandonedRatePct = iff(created == 0, 0.0, todouble(abandoned) * 100.0 / todouble(created))
+'''
+
+var uploadWebAuthFailureQuery = '''
+AppRequests
+| where TimeGenerated >= ago(5m)
+| where AppRoleName has 'upload-web'
+| where toint(ResultCode) in (401, 403)
+| summarize AuthFailures = count()
+'''
+
+resource uploadWeb5xxAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-upload-web-5xx-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Critical: Upload Web 5xx error rate exceeds 5% over 15 minutes.'
+    displayName: 'Upload Web 5xx error rate'
+    enabled: true
+    severity: 0
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: uploadWeb5xxRateQuery
+          metricMeasureColumn: 'ErrorRatePct'
+          timeAggregation: 'Maximum'
+          operator: 'GreaterThan'
+          threshold: 5
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'upload-web-5xx-rate'
+        severity: 'critical'
+      }
+    }
+  }
+}
+
+resource uploadWebAbandonedAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-upload-web-abandoned-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Warning: Upload Web session abandonment rate exceeds 20% over 1 hour.'
+    displayName: 'Upload Web session abandonment rate'
+    enabled: true
+    severity: 2
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT1H'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: uploadWebAbandonedRateQuery
+          metricMeasureColumn: 'AbandonedRatePct'
+          timeAggregation: 'Maximum'
+          operator: 'GreaterThan'
+          threshold: 20
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'upload-web-abandoned-rate'
+        severity: 'warning'
+      }
+    }
+  }
+}
+
+resource uploadWebAuthFailureAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: 'la-verdecora-upload-web-auth-${environment}'
+  location: location
+  tags: tags
+  kind: 'LogAlert'
+  properties: {
+    description: 'Warning: Upload Web auth failures exceed 10 in 5 minutes (possible brute force).'
+    displayName: 'Upload Web auth failure spike'
+    enabled: true
+    severity: 2
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    scopes: [
+      logAnalyticsWorkspaceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: uploadWebAuthFailureQuery
+          metricMeasureColumn: 'AuthFailures'
+          timeAggregation: 'Total'
+          operator: 'GreaterThan'
+          threshold: 10
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    autoMitigate: true
+    actions: {
+      actionGroups: [
+        opsActionGroup.id
+      ]
+      customProperties: {
+        alert_key: 'upload-web-auth-failures'
+        severity: 'warning'
+      }
+    }
+  }
+}
+
 @description('Action group resource id.')
 output actionGroupId string = opsActionGroup.id

--- a/src/upload_web/middleware/__init__.py
+++ b/src/upload_web/middleware/__init__.py
@@ -1,5 +1,13 @@
 """Upload Web middleware exports."""
 
+from .rate_limiter import RateLimiterStore, rate_limit_check
+from .security_headers import SecurityHeadersMiddleware
 from .session_security import SessionSecurityMiddleware, get_upload_current_user
 
-__all__ = ["SessionSecurityMiddleware", "get_upload_current_user"]
+__all__ = [
+    "RateLimiterStore",
+    "SecurityHeadersMiddleware",
+    "SessionSecurityMiddleware",
+    "get_upload_current_user",
+    "rate_limit_check",
+]

--- a/src/upload_web/middleware/rate_limiter.py
+++ b/src/upload_web/middleware/rate_limiter.py
@@ -1,0 +1,120 @@
+"""In-memory sliding-window rate limiter for Upload Web (#119).
+
+Limits are per user (``oid`` from the authenticated session) and per
+action type.  When a limit is exceeded the middleware returns
+``429 Too Many Requests`` with a ``Retry-After`` header.
+
+No external store (Redis) is required — this is suitable for single-
+instance PoC deployments.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import JSONResponse
+
+
+@dataclass
+class _RateLimit:
+    max_requests: int
+    window_seconds: int
+
+
+# Action → limit definition
+RATE_LIMITS: dict[str, _RateLimit] = {
+    "sas_generation": _RateLimit(max_requests=30, window_seconds=60),
+    "file_upload": _RateLimit(max_requests=100, window_seconds=3600),
+    "session_creation": _RateLimit(max_requests=10, window_seconds=3600),
+}
+
+# Path pattern → action mapping
+_PATH_ACTION_MAP: list[tuple[str, str, str]] = [
+    # (method, path_suffix, action)
+    ("POST", "/sas", "sas_generation"),
+    ("POST", "/files", "file_upload"),
+    ("POST", "/sessions", "session_creation"),
+]
+
+
+@dataclass
+class _SlidingWindow:
+    timestamps: list[float] = field(default_factory=list)
+
+    def prune(self, window_seconds: int, now: float) -> None:
+        cutoff = now - window_seconds
+        self.timestamps = [t for t in self.timestamps if t > cutoff]
+
+    def count(self) -> int:
+        return len(self.timestamps)
+
+    def add(self, now: float) -> None:
+        self.timestamps.append(now)
+
+
+class RateLimiterStore:
+    """Thread-safe in-memory sliding-window store keyed by ``(oid, action)``."""
+
+    def __init__(self) -> None:
+        self._windows: dict[tuple[str, str], _SlidingWindow] = defaultdict(_SlidingWindow)
+
+    def check_and_record(self, oid: str, action: str) -> tuple[bool, int]:
+        """Return ``(allowed, retry_after_seconds)``."""
+        limit = RATE_LIMITS.get(action)
+        if limit is None:
+            return True, 0
+
+        key = (oid, action)
+        window = self._windows[key]
+        now = time.monotonic()
+        window.prune(limit.window_seconds, now)
+
+        if window.count() >= limit.max_requests:
+            retry_after = int(limit.window_seconds - (now - window.timestamps[0])) + 1
+            return False, max(retry_after, 1)
+
+        window.add(now)
+        return True, 0
+
+
+_store = RateLimiterStore()
+
+
+def _resolve_action(method: str, path: str) -> str | None:
+    upper_method = method.upper()
+    for m, suffix, action in _PATH_ACTION_MAP:
+        if upper_method == m and path.rstrip("/").endswith(suffix):
+            return action
+    return None
+
+
+def _get_user_oid(request: Request) -> str | None:
+    user: Any = getattr(request.state, "authenticated_user", None)
+    if user is not None:
+        return getattr(user, "oid", None)
+    return None
+
+
+async def rate_limit_check(request: Request) -> Response | None:
+    """Call from a middleware or dependency; returns a 429 response or ``None`` if allowed."""
+    action = _resolve_action(request.method, request.url.path)
+    if action is None:
+        return None
+
+    oid = _get_user_oid(request)
+    if oid is None:
+        return None
+
+    allowed, retry_after = _store.check_and_record(oid, action)
+    if allowed:
+        return None
+
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Rate limit exceeded. Please try again later."},
+        headers={"Retry-After": str(retry_after)},
+    )

--- a/src/upload_web/middleware/security_headers.py
+++ b/src/upload_web/middleware/security_headers.py
@@ -1,0 +1,51 @@
+"""Strict security headers middleware for Upload Web (#119).
+
+Adds CSP, HSTS, X-Content-Type-Options, X-Frame-Options and
+Referrer-Policy to every response.  The CSP is tuned to allow HTMX
+(inline scripts via nonce are NOT required because HTMX uses
+``unsafe-inline`` for hx-* attributes).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# CSP allows self + CDN hosts used by HTMX/Pico CSS; data: for inline images.
+SECURITY_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data: https://verdecora.es; "
+        "connect-src 'self'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "form-action 'self'"
+    ),
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Append security headers to every HTTP response."""
+
+    def __init__(self, app: Any, **kwargs: Any) -> None:
+        super().__init__(app, **kwargs)
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        response = await call_next(request)
+        for name, value in SECURITY_HEADERS.items():
+            response.headers.setdefault(name, value)
+        return response

--- a/src/upload_web/telemetry.py
+++ b/src/upload_web/telemetry.py
@@ -1,0 +1,135 @@
+"""OpenTelemetry custom metrics for Upload Web (#117).
+
+Emits counters and histograms for upload sessions, files, SAS tokens,
+preflight/confirm latency, abandonment, and errors.  Metrics are exported
+to Application Insights via the OTLP or Azure Monitor exporter when
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Generator
+
+from opentelemetry import metrics
+from opentelemetry.metrics import Meter
+
+logger = logging.getLogger(__name__)
+
+_METER_NAME = "verdecora.upload_web"
+_METER_VERSION = "1.0.0"
+
+_meter: Meter = metrics.get_meter(_METER_NAME, _METER_VERSION)
+
+# ── Counters ────────────────────────────────────────────────────────────
+
+upload_sessions_created = _meter.create_counter(
+    name="upload_sessions_created",
+    description="Total upload sessions created",
+    unit="{session}",
+)
+
+upload_files_processed = _meter.create_counter(
+    name="upload_files_processed",
+    description="Files registered in upload sessions",
+    unit="{file}",
+)
+
+upload_sas_generated = _meter.create_counter(
+    name="upload_sas_generated",
+    description="SAS URLs generated for blob uploads",
+    unit="{token}",
+)
+
+upload_session_abandoned = _meter.create_counter(
+    name="upload_session_abandoned",
+    description="Sessions started but never confirmed",
+    unit="{session}",
+)
+
+upload_errors = _meter.create_counter(
+    name="upload_errors",
+    description="Errors during upload operations",
+    unit="{error}",
+)
+
+# ── Histograms ──────────────────────────────────────────────────────────
+
+upload_preflight_duration_seconds = _meter.create_histogram(
+    name="upload_preflight_duration_seconds",
+    description="Duration of preflight checks",
+    unit="s",
+)
+
+upload_confirm_duration_seconds = _meter.create_histogram(
+    name="upload_confirm_duration_seconds",
+    description="Duration of session confirmation",
+    unit="s",
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def record_session_created() -> None:
+    upload_sessions_created.add(1)
+
+
+def record_file_processed(supplier: str = "unknown") -> None:
+    upload_files_processed.add(1, {"supplier": supplier})
+
+
+def record_sas_generated() -> None:
+    upload_sas_generated.add(1)
+
+
+def record_session_abandoned() -> None:
+    upload_session_abandoned.add(1)
+
+
+def record_error(error_type: str) -> None:
+    upload_errors.add(1, {"error_type": error_type})
+
+
+@contextmanager
+def measure_preflight() -> Generator[None, None, None]:
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        upload_preflight_duration_seconds.record(time.monotonic() - start)
+
+
+@contextmanager
+def measure_confirm() -> Generator[None, None, None]:
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        upload_confirm_duration_seconds.record(time.monotonic() - start)
+
+
+def configure_telemetry(connection_string: str) -> None:
+    """Bootstrap the Azure Monitor OTel exporter if a connection string is available."""
+    if not connection_string:
+        logger.info("No APPLICATIONINSIGHTS_CONNECTION_STRING set; OTel metrics are local only.")
+        return
+
+    try:
+        from azure.monitor.opentelemetry.exporter import AzureMonitorMetricExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+        exporter = AzureMonitorMetricExporter(connection_string=connection_string)
+        reader = PeriodicExportingMetricReader(exporter, export_interval_millis=60_000)
+        provider = MeterProvider(metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        logger.info("Azure Monitor metrics exporter configured for Upload Web.")
+    except ImportError:
+        logger.warning(
+            "azure-monitor-opentelemetry-exporter not installed; metrics will not be exported to Application Insights."
+        )
+    except Exception:
+        logger.exception("Failed to configure Azure Monitor metrics exporter.")

--- a/tests/load/upload-web-load-config.md
+++ b/tests/load/upload-web-load-config.md
@@ -1,0 +1,57 @@
+# Upload Web — Load Test Configuration
+
+## Overview
+
+Load test targeting 30 RPS sustained for 30 minutes against the Upload Web
+API.  Each virtual user executes the full upload flow (session → 3 files →
+preflight → confirm).
+
+## How to Run
+
+```bash
+# Start a local instance (or point to staging)
+export UPLOAD_WEB_HOST=http://localhost:8000
+
+# Run headless with 30 concurrent users, ramp-up of 5/s
+locust -f tests/load/upload_web_locustfile.py --headless \
+       -u 30 -r 5 --run-time 30m \
+       --host $UPLOAD_WEB_HOST \
+       --csv results/upload-web-load
+
+# With web UI (interactive)
+locust -f tests/load/upload_web_locustfile.py --host $UPLOAD_WEB_HOST
+```
+
+## Expected Thresholds
+
+| Metric | Target | Failure Threshold |
+|---|---|---|
+| **RPS** | ≥ 30 sustained | < 25 sustained |
+| **p50 response time** | < 200 ms | > 500 ms |
+| **p95 response time** | < 500 ms | > 1 500 ms |
+| **p99 response time** | < 1 000 ms | > 3 000 ms |
+| **Error rate** | < 0.1 % | > 1 % |
+| **SAS generation p95** | < 300 ms | > 800 ms |
+| **Preflight p95** | < 2 000 ms | > 5 000 ms |
+
+## Test Flow per User
+
+1. `POST /api/sessions` — create upload session
+2. `POST /api/sessions/{id}/sas?filename=…` × 3 — generate SAS URLs
+3. `POST /api/sessions/{id}/files` × 3 — register file metadata
+4. `POST /api/sessions/{id}/preflight` — run preflight check
+5. `POST /api/sessions/{id}/confirm` — confirm and publish
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `UPLOAD_WEB_HOST` | `http://localhost:8000` | Target host |
+| `UPLOAD_WEB_AUTH_TOKEN` | `Bearer test.jwt.token` | Auth header value |
+| `UPLOAD_WEB_CSRF_TOKEN` | `test-csrf-token` | CSRF token for POST requests |
+
+## Notes
+
+- All endpoints are mocked when running locally (no real Azure calls).
+- Results CSV files are written to `results/upload-web-load-*.csv`.
+- For CI, use `--check-fail-ratio 0.01 --check-avg-response-time 500`.

--- a/tests/load/upload_web_locustfile.py
+++ b/tests/load/upload_web_locustfile.py
@@ -1,0 +1,91 @@
+"""Locust load test for Upload Web — 30 RPS / 30 min (#120).
+
+Simulates 30 concurrent store users performing the full upload flow:
+create session → upload 3 files → preflight → confirm.
+
+All endpoints target the Upload Web API routes; no real Azure calls are
+made (set ``UPLOAD_WEB_HOST`` to a local/mock server).
+
+Run:
+    locust -f tests/load/upload_web_locustfile.py --headless \
+           -u 30 -r 5 --run-time 30m \
+           --host http://localhost:8000
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+from locust import HttpUser, between, task
+
+UPLOAD_WEB_HOST = os.getenv("UPLOAD_WEB_HOST", "http://localhost:8000")
+AUTH_TOKEN = os.getenv("UPLOAD_WEB_AUTH_TOKEN", "Bearer test.jwt.token")
+CSRF_TOKEN = os.getenv("UPLOAD_WEB_CSRF_TOKEN", "test-csrf-token")
+
+COMMON_HEADERS = {
+    "Authorization": AUTH_TOKEN,
+    "X-MS-TOKEN-AAD-ID-TOKEN": AUTH_TOKEN.removeprefix("Bearer "),
+    "X-CSRF-Token": CSRF_TOKEN,
+}
+
+
+class UploadWebUser(HttpUser):
+    """Simulates a store staff member uploading a delivery note."""
+
+    host = UPLOAD_WEB_HOST
+    wait_time = between(0.5, 1.5)
+
+    @task
+    def full_upload_flow(self) -> None:
+        # 1. Create session
+        with self.client.post(
+            "/api/sessions",
+            headers=COMMON_HEADERS,
+            name="POST /api/sessions",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 201:
+                resp.failure(f"Session creation failed: {resp.status_code}")
+                return
+            session_id = resp.json().get("session_id", uuid4().hex)
+
+        # 2. Upload 3 files (SAS generation + file registration)
+        for i in range(3):
+            filename = f"albaran-test-{uuid4().hex[:8]}-{i}.pdf"
+
+            self.client.post(
+                f"/api/sessions/{session_id}/sas?filename={filename}",
+                headers=COMMON_HEADERS,
+                name="POST /api/sessions/{id}/sas",
+            )
+
+            self.client.post(
+                f"/api/sessions/{session_id}/files",
+                headers=COMMON_HEADERS,
+                json={
+                    "filename": filename,
+                    "blob_path": f"uploads/{session_id}/{filename}",
+                    "mime_type": "application/pdf",
+                    "size_bytes": 204800,
+                },
+                name="POST /api/sessions/{id}/files",
+            )
+
+        # 3. Preflight
+        self.client.post(
+            f"/api/sessions/{session_id}/preflight",
+            headers=COMMON_HEADERS,
+            name="POST /api/sessions/{id}/preflight",
+        )
+
+        # 4. Confirm
+        self.client.post(
+            f"/api/sessions/{session_id}/confirm",
+            headers=COMMON_HEADERS,
+            name="POST /api/sessions/{id}/confirm",
+        )
+
+    @task(1)
+    def healthz(self) -> None:
+        self.client.get("/healthz", name="GET /healthz")


### PR DESCRIPTION
## Upload Web Wave 3 — Final Hardening

### Issues Implemented

| # | Title | Type |
|---|---|---|
| #117 | OTel custom metrics + dashboard | 📊 Observability |
| #118 | Alerts: 5xx, abandoned, auth failure | 📊 Observability |
| #119 | Rate limiting + CSP + security headers | 🔒 Security |
| #120 | Load tests 30 RPS / 30 min | 🧪 Testing |
| #121 | UAT checklist (2 pilot stores) | 📝 Documentation |
| #122 | End-user manual (Spanish) | 📝 Documentation |
| #123 | Operations runbook | 📝 Documentation |
| #124 | Rollout plan (25 stores) | 📝 Documentation |

### Files Changed

**Code (src/)**
- \\src/upload_web/telemetry.py\\ — OTel counters + histograms + Azure Monitor exporter
- \\src/upload_web/middleware/security_headers.py\\ — CSP, HSTS, X-Frame-Options, nosniff
- \\src/upload_web/middleware/rate_limiter.py\\ — Per-user sliding window rate limiter (SAS 30/min, files 100/h, sessions 10/h)
- \\src/upload_web/middleware/__init__.py\\ — Updated exports

**Infrastructure (infra/)**
- \\infra/modules/alerts.bicep\\ — 3 new KQL-based log alerts for Upload Web
- \\infra/dashboards/upload-web-workbook.json\\ — Azure Workbook with 7 panels

**Tests**
- \\	ests/load/upload_web_locustfile.py\\ — Locust load test (30 users, full flow)
- \\	ests/load/upload-web-load-config.md\\ — Thresholds and run instructions

**Documentation**
- \\docs/user/uat-checklist.md\\ — 7 UAT scenarios + feedback form (Spanish)
- \\docs/user/upload-web-manual.md\\ — Full user manual (Spanish)
- \\docs/operations/upload-web-runbook.md\\ — Incident response + KQL queries + scaling
- \\docs/operations/rollout-plan.md\\ — 3-phase rollout (2→10→25 stores)

### Validation
- ✅ \\uff check\\ — all checks passed
- ✅ \\uff format\\ — formatted
- ✅ \\pytest tests/unit/ tests/e2e/\\ — 222 passed (6 pre-existing failures unrelated to this PR)