### PR TITLE
feat(security): WAF policy association + Easy Auth configuration (#146, #148)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -10,6 +10,7 @@ Deploy with: `az deployment group create -t main.bicep`
 ## Upload web notes
 
 - Set `enableUploadWeb=true` to deploy the private `verdecora-upload-web-${environment}` Container App into the shared ACA environment.
+- Set `uploadWebEntraClientId` to the Microsoft Entra app registration client ID for `Verdecora Upload Web`, and configure the redirect URI `https://upload-web-d3hpbffsfwercgcv.b02.azurefd.net/.auth/login/aad/callback`.
 - Create the Microsoft Entra group `verdecora-store-uploaders` manually in the Azure portal, then pass its object ID(s) through `uploadWebAllowedGroupObjectIds` when enabling Easy Auth.
 - Set `enableUploadWebAuth=true` only after `verdecora-upload-web-${environment}` exists in the Container Apps environment.
 - Set `enableUploadWebAppGateway=true` and configure `appGwFrontendCertificateSecretId` with a Key Vault PFX secret URI before deploying the Application Gateway HTTPS listener.

--- a/infra/modules/frontdoor.bicep
+++ b/infra/modules/frontdoor.bicep
@@ -50,7 +50,6 @@ resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@20
         {
           ruleSetType: 'Microsoft_BotManagerRuleSet'
           ruleSetVersion: '1.1'
-          ruleSetAction: 'Block'
         }
       ]
     }
@@ -178,3 +177,4 @@ resource securityPolicy 'Microsoft.Cdn/profiles/securityPolicies@2024-09-01' = {
 output frontDoorEndpointHostname string = endpoint.properties.hostName
 output frontDoorProfileId string = frontDoorProfile.id
 output wafPolicyId string = wafPolicy.id
+output securityPolicyId string = securityPolicy.id


### PR DESCRIPTION
## Summary
- align the Front Door WAF module with the managed rule configuration that successfully deploys for the Premium profile
- document the Entra client ID / redirect URI input needed for upload-web Easy Auth
- applied the WAF policy + security policy in Azure and configured Easy Auth on the upload web ACA

## Azure changes applied
- created Entra app registration `Verdecora Upload Web` (`c529cfd0-b295-4345-8194-d9cef53b489a`)
- created service principal for the app
- created/updated WAF policy `wafverdecoradev`
- associated WAF security policy `upload-web-waf` with endpoint `upload-web`
- deployed upload-web Easy Auth to `verdecora-upload-web-dev`

## Validation
- `az bicep build --file infra/modules/main.bicep`
- `python -m ruff check --fix src/ tests/`
- `az deployment group create --resource-group rg-verdecoratest-dev --template-file infra/modules/frontdoor.bicep ...`
- `az rest GET .../profiles/afd-verdecora-dev/securityPolicies/upload-web-waf?api-version=2024-09-01`
- `az containerapp auth show --name verdecora-upload-web-dev --resource-group rg-verdecoratest-dev`