### PR TITLE
⬇️ ACR Premium→Standard + remove agent pool (#171)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   ACR_NAME: acralbaranesdev
-  ACR_AGENT_POOL: buildpool-dev
   RESOURCE_GROUP: rg-verdecoratest-dev
   ACA_ORCHESTRATOR: verdecora-orchestrator-dev
   ACA_HITL: verdecora-hitl-webform-dev
@@ -118,7 +117,6 @@ jobs:
         run: |
           az acr build \
             --registry ${{ env.ACR_NAME }} \
-            --agent-pool ${{ env.ACR_AGENT_POOL }} \
             --image verdecora-orchestrator:${{ github.sha }} \
             --image verdecora-orchestrator:latest \
             --file docker/orchestrator/Dockerfile \
@@ -142,7 +140,6 @@ jobs:
         run: |
           az acr build \
             --registry ${{ env.ACR_NAME }} \
-            --agent-pool ${{ env.ACR_AGENT_POOL }} \
             --image verdecora-hitl-webform:${{ github.sha }} \
             --image verdecora-hitl-webform:latest \
             --file docker/hitl-webform/Dockerfile \
@@ -166,7 +163,6 @@ jobs:
         run: |
           az acr build \
             --registry ${{ env.ACR_NAME }} \
-            --agent-pool ${{ env.ACR_AGENT_POOL }} \
             --image verdecora-flow0-dedup:${{ github.sha }} \
             --image verdecora-flow0-dedup:latest \
             --file docker/flow0-dedup/Dockerfile \
@@ -190,7 +186,6 @@ jobs:
         run: |
           az acr build \
             --registry ${{ env.ACR_NAME }} \
-            --agent-pool ${{ env.ACR_AGENT_POOL }} \
             --image verdecora-escalation-timer:${{ github.sha }} \
             --image verdecora-escalation-timer:latest \
             --file docker/escalation-timer/Dockerfile \
@@ -290,7 +285,6 @@ jobs:
         run: |
           az acr build \
             --registry ${{ env.ACR_NAME }} \
-            --agent-pool ${{ env.ACR_AGENT_POOL }} \
             --image verdecora-upload-web:${{ github.sha }} \
             --image verdecora-upload-web:latest \
             --file docker/upload-web/Dockerfile \

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -22,4 +22,5 @@
 - For private Service Bus namespaces, Event Grid delivery required trustedServiceAccessEnabled=true plus Azure Service Bus Data Sender on the queue for the system topic managed identity.
 - Azure CLI az eventgrid event-subscription create rejected managed-identity delivery for this system topic, so the working path was ARM REST with deliveryWithResourceIdentity against API version 2024-06-01-preview.
 - End-to-end smoke test succeeded: uploaded a PDF to albaranes-raw and observed albaran-incoming active message count increase from 0 to 1. Temporary Storage public access/CIDR allowlist and Storage Blob Data Contributor were granted only for the smoke test and then reverted.
-
+- Completed issue #171 ACR rollback in IaC + runtime: `acralbaranesdev` moved from Premium/private to Standard/public, `buildpool-dev` agent pool was removed, and the ACR private endpoint / `privatelink.azurecr.io` DNS assets were deleted.
+- Updated `build-deploy.yml` so all five `az acr build` invocations use the registry directly without `--agent-pool`; Container Apps keep pulling through managed identity + `AcrPull`.

--- a/.squad/decisions/inbox/dallas-acr-downgrade.md
+++ b/.squad/decisions/inbox/dallas-acr-downgrade.md
@@ -1,0 +1,7 @@
+# 2026-05-07 — Dallas — ACR downgrade follow-up for issue #171
+
+- Requested by Kiko de Angel to complete the ACR rollback from Premium/private to Standard/public for `acralbaranesdev` in `rg-verdecoratest-dev`.
+- IaC changes remove the ACR agent pool model and the ACR private endpoint / `privatelink.azurecr.io` DNS assets while keeping other private endpoints intact.
+- Workflow changes remove `ACR_AGENT_POOL` and all `--agent-pool` flags so `az acr build` uses the registry's default Standard capability set.
+- Runtime sequence executed in Azure: delete agent pool, delete ACR private endpoint, delete ACR private DNS VNet link, delete ACR private DNS zone, downgrade ACR SKU to Standard.
+- Verification target: ACR remains reachable for Container Apps through managed identity-based `AcrPull`, while the registry is now public (`publicNetworkAccess=Enabled`) and no ACR PE/DNS artifacts remain.

--- a/infra/modules/acr.bicep
+++ b/infra/modules/acr.bicep
@@ -6,38 +6,19 @@ param environment string
 @description('Azure region for Container Registry resources.')
 param location string
 
-@description('Optional subnet resource id used by the ACR dedicated build agent pool.')
-param agentPoolSubnetId string = ''
-
-@description('Name of the dedicated ACR build agent pool.')
-param agentPoolName string = 'buildpool-${environment}'
-
 resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   name: 'acralbaranes${environment}'
   location: location
   sku: {
-    name: 'Premium'
+    name: 'Standard'
   }
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     adminUserEnabled: false
-    publicNetworkAccess: 'Disabled'
-    networkRuleBypassOptions: 'AzureServices'
+    publicNetworkAccess: 'Enabled'
     dataEndpointEnabled: false
-  }
-}
-
-resource agentPool 'Microsoft.ContainerRegistry/registries/agentPools@2025-03-01-preview' = if (!empty(agentPoolSubnetId)) {
-  parent: acr
-  name: agentPoolName
-  location: location
-  properties: {
-    count: 1
-    os: 'Linux'
-    tier: 'S2'
-    virtualNetworkSubnetResourceId: agentPoolSubnetId
   }
 }
 
@@ -49,6 +30,3 @@ output acrName string = acr.name
 
 @description('Azure Container Registry login server.')
 output acrLoginServer string = acr.properties.loginServer
-
-@description('Dedicated ACR build agent pool name.')
-output agentPoolName string = !empty(agentPoolSubnetId) ? agentPool.name : ''

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -105,7 +105,6 @@ module acr './acr.bicep' = {
   params: {
     environment: environment
     location: location
-    agentPoolSubnetId: network.outputs.subnetEgressId
   }
   dependsOn: [
     rg
@@ -205,7 +204,6 @@ module privateEndpoints './private-endpoints.bicep' = if (enableNetworkHardening
     subnetId: network.outputs.subnetPeId
     storageResourceId: storage.outputs.storageAccountId
     cosmosResourceId: cosmos.outputs.cosmosAccountId
-    acrResourceId: acr.outputs.acrId
     keyVaultResourceId: keyVault.outputs.keyVaultId
     serviceBusResourceId: serviceBus.outputs.serviceBusNamespaceId
     aiServicesResourceId: aiFoundry.outputs.aiServicesId

--- a/infra/modules/private-endpoints.bicep
+++ b/infra/modules/private-endpoints.bicep
@@ -24,9 +24,6 @@ param keyVaultResourceId string = ''
 @description('Service Bus namespace resource id.')
 param serviceBusResourceId string = ''
 
-@description('Azure Container Registry resource id.')
-param acrResourceId string = ''
-
 @description('Azure AI Foundry resource id.')
 param aiServicesResourceId string = ''
 
@@ -76,12 +73,6 @@ resource serviceBusDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (
   tags: tags
 }
 
-resource acrDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (!empty(acrResourceId)) {
-  name: 'privatelink.azurecr.io'
-  location: 'global'
-  tags: tags
-}
-
 resource cognitiveServicesDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (!empty(aiServicesResourceId) || !empty(documentIntelligenceResourceId)) {
   name: 'privatelink.cognitiveservices.azure.com'
   location: 'global'
@@ -126,17 +117,6 @@ resource keyVaultDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@
 
 resource serviceBusDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = if (!empty(serviceBusResourceId)) {
   name: '${serviceBusDnsZone.name}/${virtualNetworkName}-link'
-  location: 'global'
-  properties: {
-    virtualNetwork: {
-      id: vnet.id
-    }
-    registrationEnabled: false
-  }
-}
-
-resource acrDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = if (!empty(acrResourceId)) {
-  name: '${acrDnsZone.name}/${virtualNetworkName}-link'
   location: 'global'
   properties: {
     virtualNetwork: {
@@ -299,43 +279,6 @@ resource serviceBusDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZo
         name: 'servicebus-namespace'
         properties: {
           privateDnsZoneId: serviceBusDnsZone.id
-        }
-      }
-    ]
-  }
-}
-
-resource acrPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' = if (!empty(acrResourceId)) {
-  name: 'pe-acr-${environment}'
-  location: location
-  tags: tags
-  properties: {
-    subnet: {
-      id: privateEndpointSubnetResourceId
-    }
-    privateLinkServiceConnections: [
-      {
-        name: 'acr-registry'
-        properties: {
-          privateLinkServiceId: acrResourceId
-          groupIds: [
-            'registry'
-          ]
-        }
-      }
-    ]
-  }
-}
-
-resource acrDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-04-01' = if (!empty(acrResourceId)) {
-  parent: acrPrivateEndpoint
-  name: 'default'
-  properties: {
-    privateDnsZoneConfigs: [
-      {
-        name: 'acr-registry'
-        properties: {
-          privateDnsZoneId: acrDnsZone.id
         }
       }
     ]


### PR DESCRIPTION
Closes #171

## Changes
- ACR: Premium → Standard (~€30/month savings)
- Removed: agent pool buildpool-dev (was stuck, never completing builds)
- Removed: Private Endpoint pe-acr-dev + DNS zone privatelink.azurecr.io
- Removed: --agent-pool from all 5 build commands in build-deploy.yml
- ACA image pull unchanged (Managed Identity + AcrPull role still works)

## Azure runtime changes applied
- Agent pool deleted
- Private Endpoint deleted
- DNS zone + VNet link deleted
- ACR SKU downgraded to Standard

## Verified
- ACR is Standard + public
- No PE/DNS remnants
- ACA registries config unchanged (MI-based pull)