### PR TITLE
🔗 Replace ALL url_for() with relative paths (#180, #179)

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -48,3 +48,8 @@
 - The upload page must create an `UploadSession` before the user selects files; `pages/upload.html` and the dropzone/button HTMX attributes depend on a concrete `session_id` and break when it renders empty.
 - The browser upload client must follow the backend contract exactly: request SAS with `POST /api/sessions/{session_id}/sas?filename=...`, use `upload_url` from the response, and register metadata with `mime_type`.
 - The analyze CTA should stay disabled until at least one file has finished SAS upload + backend registration, and the upload template must include the `#preflight-loading` HTMX indicator referenced by the button.
+
+### 2026-05-08T00:23:20.028+02:00 — Upload Web relative Front Door URLs
+- Upload Web templates must use literal relative paths for internal navigation/HTMX (`/dashboard`, `/upload`, `/mis-albaranes`, `/upload/{session_id}/status`, etc.); `url_for()` in Jinja can emit the ACA hostname and break Front Door cookie scope.
+- The only logout handler should be the auth route that clears the upload session cookie and redirects to `/.auth/logout?post_logout_redirect_uri=/`; placeholder `/logout` redirects are not acceptable behind Front Door.
+- `src/upload_web/static/js/upload.js` already follows the required pattern: all browser API calls stay relative under `/api/sessions/...`, so Front Door compatibility there is a verification point, not a new code path.

--- a/.squad/decisions/inbox/parker-relative-urls.md
+++ b/.squad/decisions/inbox/parker-relative-urls.md
@@ -1,0 +1,15 @@
+# Parker — Relative URL sweep
+
+**Date:** 2026-05-08T00:23:20.028+02:00
+**Issue:** #180, #179
+**Requested by:** Kiko de Angel
+
+## Decision summary
+- Replace every remaining template `url_for()` route reference in Upload Web with literal relative paths so navigation stays on the Front Door host.
+- Keep HTMX actions and browser API calls relative as well (`/mis-albaranes/filter`, `/upload/{session_id}/status`, `/api/sessions/...`) to preserve the Front Door-scoped auth cookie.
+- Remove the duplicate placeholder logout handler from `src/upload_web/routes/upload.py` so `/logout` is served only by the auth route that clears the app session cookie and redirects to `/.auth/logout?post_logout_redirect_uri=/`.
+
+## Why
+- `url_for()` was emitting absolute ACA-host URLs in templates, which caused users behind Azure Front Door to hop domains and lose authenticated behavior.
+- Logout needed to use the Easy Auth logout flow, not a placeholder redirect, or users could land on the wrong host / blank page.
+- A complete sweep was safer than piecemeal fixes because the breakage affected normal links, HTMX polling, and filtered table actions.

--- a/src/upload_web/routes/upload.py
+++ b/src/upload_web/routes/upload.py
@@ -162,11 +162,6 @@ async def my_uploads_partial(current_user: CurrentUser) -> dict[str, object]:
     }
 
 
-@router.get("/logout", include_in_schema=False, name="logout_placeholder")
-async def logout_placeholder() -> RedirectResponse:
-    return RedirectResponse(url="/", status_code=307)
-
-
 @router.get("/upload/{session_id}/status", response_class=HTMLResponse, name="upload_status")
 async def upload_status(request: Request, session_id: str, current_user: CurrentUser) -> HTMLResponse:
     """Show processing status with HTMX auto-refresh."""

--- a/src/upload_web/templates/components/_header.html
+++ b/src/upload_web/templates/components/_header.html
@@ -1,6 +1,6 @@
 <header class="bg-[var(--vc-nav-dark)] text-white shadow-sm">
   <div class="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-    <a href="{{ url_for('dashboard') if current_user else url_for('index') }}" class="flex items-center gap-3" aria-label="Inicio Verdecora Upload Web">
+    <a href="{{ '/dashboard' if current_user else '/' }}" class="flex items-center gap-3" aria-label="Inicio Verdecora Upload Web">
       <img src="/static/img/verdecora-logo.jpg" alt="Verdecora" class="h-10 w-auto sm:h-12">
       <div>
         <p class="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">Upload Web</p>
@@ -10,7 +10,7 @@
     <div class="flex flex-col gap-3 sm:items-end">
       {% if current_user %}
       <p class="text-sm text-white/80">Conectado como <span class="font-semibold text-white">{{ current_user.name if current_user else 'Usuario autenticado' }}</span></p>
-      <a href="{{ url_for('logout_placeholder') }}" class="inline-flex min-h-11 items-center justify-center rounded-full border border-white/25 px-5 py-2 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10">Cerrar sesión</a>
+      <a href="/logout" class="inline-flex min-h-11 items-center justify-center rounded-full border border-white/25 px-5 py-2 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10">Cerrar sesión</a>
       {% else %}
       <p class="text-sm text-white/80">Acceso interno para equipos de tienda Verdecora</p>
       <a href="{{ login_url if login_url is defined else '/.auth/login/aad?post_login_redirect_uri=/dashboard' }}" class="inline-flex min-h-11 items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-[var(--vc-nav-dark)] transition hover:bg-white/90">Iniciar sesión</a>

--- a/src/upload_web/templates/pages/confirm_store.html
+++ b/src/upload_web/templates/pages/confirm_store.html
@@ -43,11 +43,11 @@
   {% endif %}
 
   <div class="flex gap-3">
-    <a href="{{ url_for('upload_summary', session_id=session.session_id) }}"
+    <a href="/upload/{{ session.session_id }}/summary"
        class="inline-flex items-center rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
       Confirmar y continuar
     </a>
-    <a href="{{ url_for('upload_page') }}"
+    <a href="/upload"
        class="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">
       Cancelar
     </a>

--- a/src/upload_web/templates/pages/home.html
+++ b/src/upload_web/templates/pages/home.html
@@ -7,8 +7,8 @@
     <h1 class="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">Hola, {{ current_user.name }}</h1>
     <p class="mt-4 max-w-2xl text-base leading-7 text-slate-600">Sube tus albaranes de compra en pocos pasos. Esta pantalla está pensada para equipos de tienda: botones grandes, instrucciones claras y acceso rápido a lo importante.</p>
     <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
-      <a href="{{ url_for('upload_page') }}" class="inline-flex min-h-14 items-center justify-center rounded-full bg-[var(--vc-primary)] px-8 text-lg font-semibold text-white shadow-lg shadow-teal-900/10 transition hover:brightness-105">Subir albarán</a>
-      <a href="{{ url_for('my_uploads_page') }}" class="text-base font-semibold text-[var(--vc-nav-dark)] underline decoration-[var(--vc-accent)] decoration-2 underline-offset-4">Mis albaranes</a>
+      <a href="/upload" class="inline-flex min-h-14 items-center justify-center rounded-full bg-[var(--vc-primary)] px-8 text-lg font-semibold text-white shadow-lg shadow-teal-900/10 transition hover:brightness-105">Subir albarán</a>
+      <a href="/mis-albaranes" class="text-base font-semibold text-[var(--vc-nav-dark)] underline decoration-[var(--vc-accent)] decoration-2 underline-offset-4">Mis albaranes</a>
     </div>
   </article>
   <aside class="rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">

--- a/src/upload_web/templates/pages/my_albaranes.html
+++ b/src/upload_web/templates/pages/my_albaranes.html
@@ -9,13 +9,13 @@
 
     <!-- Filter buttons -->
     <div class="mt-6 flex flex-wrap gap-2">
-      <a href="{{ url_for('my_uploads_page') }}"
+      <a href="/mis-albaranes"
          class="rounded-full px-4 py-1.5 text-sm font-medium transition
                 {% if not status_filter %}bg-[var(--vc-primary)] text-white{% else %}bg-slate-100 text-slate-700 hover:bg-slate-200{% endif %}">
         Todos
       </a>
       {% for st in ['created', 'uploading', 'confirmed', 'processing', 'completed', 'failed'] %}
-      <a hx-get="{{ url_for('my_uploads_filter') }}?status_filter={{ st }}"
+      <a hx-get="/mis-albaranes/filter?status_filter={{ st }}"
          hx-target="#uploads-table"
          hx-swap="innerHTML"
          class="cursor-pointer rounded-full px-4 py-1.5 text-sm font-medium transition
@@ -41,7 +41,7 @@
         <tbody class="divide-y divide-slate-100">
           {% for u in uploads %}
           <tr class="cursor-pointer hover:bg-slate-50 transition"
-              onclick="window.location='{{ url_for('upload_status', session_id=u.session_id) }}'">
+              onclick="window.location='/upload/{{ u.session_id }}/status'">
             <td class="py-3 pr-4 text-slate-600">{{ u.uploaded_at }}</td>
             <td class="py-3 pr-4 font-medium text-slate-900">{{ u.filename }}</td>
             <td class="py-3 pr-4 text-slate-600">{{ u.albaran_group or '—' }}</td>
@@ -64,7 +64,7 @@
     {% else %}
     <div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
       <p class="text-base text-slate-500">No tienes albaranes enviados todavía.</p>
-      <a href="{{ url_for('upload_page') }}"
+      <a href="/upload"
          class="mt-4 inline-flex items-center rounded-full bg-[var(--vc-primary)] px-6 py-2 text-sm font-semibold text-white shadow transition hover:brightness-105">
         Subir albarán
       </a>

--- a/src/upload_web/templates/pages/status.html
+++ b/src/upload_web/templates/pages/status.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <section class="mx-auto max-w-3xl space-y-6"
-         hx-get="{{ url_for('upload_status', session_id=session.session_id) }}"
+         hx-get="/upload/{{ session.session_id }}/status"
          hx-trigger="every 5s"
          hx-select="section"
          hx-swap="outerHTML">
@@ -76,7 +76,7 @@
   <!-- Final state link -->
   {% if session.status == 'completed' %}
   <div class="text-center">
-    <a href="{{ url_for('my_uploads_page') }}"
+    <a href="/mis-albaranes"
        class="inline-flex items-center rounded-full bg-[var(--vc-primary)] px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:brightness-105">
       Ver mis albaranes
     </a>

--- a/src/upload_web/templates/pages/summary.html
+++ b/src/upload_web/templates/pages/summary.html
@@ -75,7 +75,7 @@
       class="inline-flex items-center rounded-md bg-green-700 px-4 py-2 text-sm font-semibold text-white hover:bg-green-800">
       Confirmar y procesar
     </button>
-    <a href="{{ url_for('upload_page') }}"
+    <a href="/upload"
        class="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">
       Volver
     </a>

--- a/src/upload_web/templates/pages/upload.html
+++ b/src/upload_web/templates/pages/upload.html
@@ -52,7 +52,7 @@
 
     {# Next: Preflight #}
     <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <a href="{{ url_for('dashboard') }}" class="btn-secondary">← Volver</a>
+      <a href="/dashboard" class="btn-secondary">← Volver</a>
       <button id="btn-next-preflight"
               type="button"
               class="btn-primary"

--- a/tests/unit/test_jinja_templates.py
+++ b/tests/unit/test_jinja_templates.py
@@ -6,6 +6,7 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
+from src.upload_web.models.upload import UploadFile
 from src.upload_web.app import create_app
 from src.upload_web.services import upload_session
 
@@ -66,6 +67,9 @@ def test_home_page_contains_expected_elements() -> None:
     assert "Hola, Parker Dev" in response.text
     assert "Subir albarán" in response.text
     assert "Mis albaranes" in response.text
+    assert 'href="/upload"' in response.text
+    assert 'href="/mis-albaranes"' in response.text
+    assert 'href="/logout"' in response.text
     assert "/static/css/tailwind.min.css" in response.text
     assert "/static/js/htmx.min.js" in response.text
 
@@ -97,5 +101,36 @@ def test_upload_page_creates_session_and_binds_preflight_urls() -> None:
     session_id = sessions[0].session_id
 
     assert f'data-session-id="{session_id}"' in response.text
+    assert 'href="/dashboard"' in response.text
     assert f'hx-post="/api/sessions/{session_id}/preflight"' in response.text
     assert 'id="preflight-loading"' in response.text
+
+
+@pytest.mark.unit
+def test_my_uploads_page_uses_relative_routes() -> None:
+    app = create_app()
+
+    with TestClient(app) as client:
+        headers = _auth_headers("Parker Flow")
+        client.get("/upload", headers=headers)
+
+        sessions = upload_session.get_all_user_sessions("oid-123")
+        assert len(sessions) == 1
+        session = sessions[0]
+        session_id = session.session_id
+        session.files.append(
+            UploadFile(
+                file_id="file-1",
+                filename="albaran.pdf",
+                blob_path=f"{session_id}/albaran.pdf",
+                content_type="application/pdf",
+                size_bytes=1024,
+            )
+        )
+
+        response = client.get("/mis-albaranes", headers=headers)
+
+    assert response.status_code == 200
+    assert 'href="/mis-albaranes"' in response.text
+    assert 'hx-get="/mis-albaranes/filter?status_filter=created"' in response.text
+    assert f"window.location='/upload/{session_id}/status'" in response.text


### PR DESCRIPTION
Closes #180
Closes #179

Replaces every url_for() in templates with relative paths. Fixes nav, logout, and API 401s behind Front Door.