### PR TITLE
🔐 Fix API auth: use session cookie fallback behind Front Door (#177)

### DIFF
--- a/src/upload_web/routes/api.py
+++ b/src/upload_web/routes/api.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from src.shared.auth.dependencies import get_current_user
 from src.shared.auth.entra import AuthenticatedUser
+from src.upload_web.middleware.session_security import get_upload_current_user
 from src.upload_web.models.file_metadata import FileMetadata
 from src.upload_web.models.preflight import PreflightResult
 from src.upload_web.models.upload import UploadFile, UploadSession
@@ -19,7 +19,7 @@ from src.upload_web.services.preflight import run_preflight
 from src.upload_web.services.upload_session import create_upload_session, get_upload_session
 
 router = APIRouter(prefix="/sessions", tags=["upload-web-api"])
-CurrentUser = Annotated[AuthenticatedUser, Depends(get_current_user)]
+CurrentUser = Annotated[AuthenticatedUser, Depends(get_upload_current_user)]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes #177 (remaining API 401 issue after URL fix)

API routes used get_current_user (Easy Auth headers only). Behind Front Door, Easy Auth cookie is domain-scoped to ACA — so API fetch calls get 401. Switched to get_upload_current_user which falls back to the app session cookie (upload_web_session) that IS set for the Front Door domain.