### PR TITLE
🔐 [Infra] Recreate Upload Web ACA Environment with VNet integration

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -24,3 +24,9 @@
 - End-to-end smoke test succeeded: uploaded a PDF to albaranes-raw and observed albaran-incoming active message count increase from 0 to 1. Temporary Storage public access/CIDR allowlist and Storage Blob Data Contributor were granted only for the smoke test and then reverted.
 - Completed issue #171 ACR rollback in IaC + runtime: `acralbaranesdev` moved from Premium/private to Standard/public, `buildpool-dev` agent pool was removed, and the ACR private endpoint / `privatelink.azurecr.io` DNS assets were deleted.
 - Updated `build-deploy.yml` so all five `az acr build` invocations use the registry directly without `--agent-pool`; Container Apps keep pulling through managed identity + `AcrPull`.
+
+## 2026-05-08
+- Issue #186: updated IaC so upload-web no longer targets the shared internal ACA environment. `upload-web-app.bicep` now creates its own external managed environment (`acae-upload-web-${environment}`) with VNet integration through a dedicated delegated subnet.
+- Added `snet-upload-web` (`10.10.6.0/23`) plus `nsg-upload-web-albaranes-${environment}` in `network.bicep`; this matches ACA custom-VNet sizing requirements without overlapping the existing subnet plan.
+- Switched Front Door origin wiring to consume the upload app FQDN directly and made Private Link optional in `frontdoor.bicep`, because this flow now uses an external ACA origin instead of an internal-only backend.
+- Kept Storage private and added parameterized Blob CORS origins (`uploadWebBlobCorsAllowedOrigins`) so browser uploads can be enabled for the exact Front Door/custom domain without introducing a dependency cycle on the generated Azure Front Door hostname.

--- a/.squad/decisions/inbox/dallas-upload-web-vnet.md
+++ b/.squad/decisions/inbox/dallas-upload-web-vnet.md
@@ -1,0 +1,16 @@
+# Dallas — Upload Web VNet recreation notes
+
+## Decision
+- Recreate `acae-upload-web-${environment}` as a dedicated **external** Container Apps managed environment on a new delegated subnet (`snet-upload-web`, `10.10.6.0/23`) instead of reusing the internal shared ACA environment.
+- Keep Front Door pointed at the upload app FQDN, but make Private Link optional in `frontdoor.bicep` so upload-web can use a public ACA origin while other patterns can still reuse the module with Private Link later.
+- Keep Storage private and add Blob CORS as an explicit parameter (`uploadWebBlobCorsAllowedOrigins`) rather than deriving the Front Door hostname inside Bicep, because the default `azurefd.net` hostname is generated only when Front Door is provisioned and would otherwise create a deployment cycle.
+
+## Why
+- Azure Container Apps managed environment VNet integration is immutable; the existing `acae-upload-web-dev` cannot be retrofitted with a subnet.
+- Upload Web needs public ingress for Front Door while still using VNet outbound to reach private endpoints for Storage, Cosmos, Key Vault, and Document Intelligence.
+- Storage must remain private, so browser uploads need a precise origin allow-list instead of reopening public access.
+
+## Validation
+- `az containerapp env list -g rg-verdecoratest-dev` showed `acae-upload-web-dev` without VNet settings, while `acae-verdecora-dev` and `acae-runners-dev` are VNet-integrated.
+- `az network vnet subnet list --vnet-name vnet-albaranes-dev -g rg-verdecoratest-dev` confirmed `10.10.6.0/23` is available for the new delegated subnet.
+- `az bicep build --file C:\repos\verdecoraTest\infra\modules\main.bicep` completed successfully after the changes (existing repo warnings remain).

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,7 +9,8 @@ Deploy with: `az deployment group create -t main.bicep`
 
 ## Upload web notes
 
-- Set `enableUploadWeb=true` to deploy the private `verdecora-upload-web-${environment}` Container App into the shared ACA environment.
+- Set `enableUploadWeb=true` to deploy `verdecora-upload-web-${environment}` into its own external ACA environment with VNet outbound through `snet-upload-web`.
+- Pass the exact Front Door/custom-domain origins through `uploadWebBlobCorsAllowedOrigins` so Blob CORS allows browser `PUT` uploads while Storage stays private.
 - Create the Microsoft Entra group `verdecora-store-uploaders` manually in the Azure portal, then pass its object ID(s) through `uploadWebAllowedGroupObjectIds` when enabling Easy Auth.
 - Set `enableUploadWebAuth=true` only after `verdecora-upload-web-${environment}` exists in the Container Apps environment.
 - Set `enableUploadWebAppGateway=true` and configure `appGwFrontendCertificateSecretId` with a Key Vault PFX secret URI before deploying the Application Gateway HTTPS listener.

--- a/infra/modules/frontdoor.bicep
+++ b/infra/modules/frontdoor.bicep
@@ -3,14 +3,11 @@ targetScope = 'resourceGroup'
 @description('Deployment environment name.')
 param environment string
 
-@description('Custom domain hostname for the upload web (e.g. upload.verdecora.example.com). Leave empty to use the default Front Door endpoint.')
-param customDomainHostname string = ''
-
-@description('Internal FQDN of the upload-web Container App used as the Private Link backend.')
+@description('FQDN of the upload-web Container App origin.')
 param backendFqdn string
 
-@description('Resource ID of the Container App Environment (for Private Link Service).')
-param containerAppEnvironmentId string
+@description('Optional resource ID of the Container App Environment when Front Door must use Private Link. Leave empty for public origins.')
+param containerAppEnvironmentId string = ''
 
 var tags = {
   project: 'verdecora-albaranes'
@@ -25,6 +22,27 @@ var originGroupName = 'upload-web-origins'
 var originName = 'aca-upload-web'
 var routeName = 'upload-web-route'
 var wafPolicyName = 'wafverdecora${environment}'
+var originBaseProperties = {
+  hostName: backendFqdn
+  httpPort: 80
+  httpsPort: 443
+  originHostHeader: backendFqdn
+  priority: 1
+  weight: 1000
+  enabledState: 'Enabled'
+  enforceCertificateNameCheck: true
+}
+var originPrivateLinkProperties = empty(containerAppEnvironmentId) ? {} : {
+  sharedPrivateLinkResource: {
+    privateLink: {
+      id: containerAppEnvironmentId
+    }
+    groupId: 'managedEnvironments'
+    privateLinkLocation: 'swedencentral'
+    requestMessage: 'Front Door Private Link for upload-web'
+    status: 'Approved'
+  }
+}
 
 // 1. WAF Policy (managed rules OWASP 3.2 + bot protection)
 resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2024-02-01' = {
@@ -98,29 +116,11 @@ resource originGroup 'Microsoft.Cdn/profiles/originGroups@2024-09-01' = {
   }
 }
 
-// 5. Origin (Private Link to ACA)
+// 5. Origin (public ACA ingress by default, optional Private Link)
 resource origin 'Microsoft.Cdn/profiles/originGroups/origins@2024-09-01' = {
   parent: originGroup
   name: originName
-  properties: {
-    hostName: backendFqdn
-    httpPort: 80
-    httpsPort: 443
-    originHostHeader: backendFqdn
-    priority: 1
-    weight: 1000
-    enabledState: 'Enabled'
-    sharedPrivateLinkResource: {
-      privateLink: {
-        id: containerAppEnvironmentId
-      }
-      groupId: 'managedEnvironments'
-      privateLinkLocation: 'swedencentral'
-      requestMessage: 'Front Door Private Link for upload-web'
-      status: 'Approved'
-    }
-    enforceCertificateNameCheck: true
-  }
+  properties: union(originBaseProperties, originPrivateLinkProperties)
 }
 
 // 6. Route

--- a/infra/modules/main.bicep
+++ b/infra/modules/main.bicep
@@ -39,6 +39,9 @@ param uploadWebAllowedAudiences array = []
 @description('Optional Microsoft Entra group object ids allowed to access upload-web.')
 param uploadWebAllowedGroupObjectIds array = []
 
+@description('Exact origins allowed to call Blob CORS for upload-web browser uploads (for example the Front Door custom domain).')
+param uploadWebBlobCorsAllowedOrigins array = []
+
 var resourceGroupName = 'rg-verdecoratest-${environment}'
 var storageAccountUrl = 'https://${storage.outputs.storageAccountName}.blob.${az.environment().suffixes.storage}/'
 
@@ -93,6 +96,7 @@ module storage './storage.bicep' = {
   params: {
     environment: environment
     location: location
+    blobCorsAllowedOrigins: uploadWebBlobCorsAllowedOrigins
   }
   dependsOn: [
     rg
@@ -275,7 +279,7 @@ module uploadWebApp './upload-web-app.bicep' = if (enableUploadWeb) {
   params: {
     environment: environment
     location: location
-    managedEnvironmentId: containerApps.outputs.managedEnvironmentId
+    infrastructureSubnetId: network.outputs.subnetUploadWebId
     acrLoginServer: acr.outputs.acrLoginServer
     storageAccountUrl: storageAccountUrl
     cosmosEndpoint: cosmos.outputs.cosmosEndpoint
@@ -285,20 +289,14 @@ module uploadWebApp './upload-web-app.bicep' = if (enableUploadWeb) {
 }
 
 var uploadWebAppName = 'verdecora-upload-web-${environment}'
-var uploadWebBackendFqdn = '${uploadWebAppName}.internal.${containerApps.outputs.managedEnvironmentDefaultDomain}'
 
 module frontDoor './frontdoor.bicep' = if (enableUploadWeb) {
   name: 'frontDoor'
   scope: az.resourceGroup(resourceGroupName)
   params: {
     environment: environment
-    backendFqdn: uploadWebBackendFqdn
-    containerAppEnvironmentId: containerApps.outputs.managedEnvironmentId
+    backendFqdn: enableUploadWeb ? uploadWebApp.outputs.uploadWebFqdn : ''
   }
-  dependsOn: [
-    rg
-    uploadWebApp
-  ]
 }
 
 module uploadWebAuth './upload-web-auth.bicep' = if (enableUploadWebAuth && !empty(uploadWebEntraClientId)) {

--- a/infra/modules/main.json
+++ b/infra/modules/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "10029017399487487059"
+      "templateHash": "1687351293734880345"
     }
   },
   "parameters": {
@@ -97,6 +97,13 @@
       "defaultValue": [],
       "metadata": {
         "description": "Optional Microsoft Entra group object ids allowed to access upload-web."
+      }
+    },
+    "uploadWebBlobCorsAllowedOrigins": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Exact origins allowed to call Blob CORS for upload-web browser uploads (for example the Front Door custom domain)."
       }
     }
   },
@@ -218,7 +225,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "14441465333506807893"
+              "templateHash": "13286296208291160148"
             }
           },
           "parameters": {
@@ -283,6 +290,13 @@
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2023-04-01",
               "name": "[format('nsg-egress-albaranes-{0}', parameters('environment'))]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2023-04-01",
+              "name": "[format('nsg-upload-web-albaranes-{0}', parameters('environment'))]",
               "location": "[parameters('location')]",
               "tags": "[variables('tags')]"
             },
@@ -360,6 +374,23 @@
                         "id": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]"
                       }
                     }
+                  },
+                  {
+                    "name": "snet-upload-web",
+                    "properties": {
+                      "addressPrefix": "10.10.6.0/23",
+                      "networkSecurityGroup": {
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-upload-web-albaranes-{0}', parameters('environment')))]"
+                      },
+                      "delegations": [
+                        {
+                          "name": "acaDelegation",
+                          "properties": {
+                            "serviceName": "Microsoft.App/environments"
+                          }
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -368,7 +399,8 @@
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-functions-albaranes-{0}', parameters('environment')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-pe-albaranes-{0}', parameters('environment')))]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-runners-albaranes-{0}', parameters('environment')))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-runners-albaranes-{0}', parameters('environment')))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-upload-web-albaranes-{0}', parameters('environment')))]"
               ]
             }
           ],
@@ -415,6 +447,13 @@
               },
               "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2023-04-01').subnets[4].id]"
             },
+            "subnetUploadWebId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web ACA environment subnet id."
+              },
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2023-04-01').subnets[5].id]"
+            },
             "nsgAcaId": {
               "type": "string",
               "metadata": {
@@ -449,6 +488,13 @@
                 "description": "Egress NSG id."
               },
               "value": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-egress-albaranes-{0}', parameters('environment')))]"
+            },
+            "nsgUploadWebId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web ACA environment NSG id."
+              },
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', format('nsg-upload-web-albaranes-{0}', parameters('environment')))]"
             }
           }
         }
@@ -935,6 +981,9 @@
           },
           "location": {
             "value": "[parameters('location')]"
+          },
+          "blobCorsAllowedOrigins": {
+            "value": "[parameters('uploadWebBlobCorsAllowedOrigins')]"
           }
         },
         "template": {
@@ -944,7 +993,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "6455998563186825921"
+              "templateHash": "7678531613096411402"
             }
           },
           "parameters": {
@@ -958,6 +1007,13 @@
               "type": "string",
               "metadata": {
                 "description": "Azure region for Storage resources."
+              }
+            },
+            "blobCorsAllowedOrigins": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Exact origins allowed to call Blob service CORS. Pass the Front Door/custom-domain origins explicitly because the default azurefd.net hostname is generated at deploy time."
               }
             }
           },
@@ -999,7 +1055,10 @@
               "apiVersion": "2023-01-01",
               "name": "[format('{0}/default', variables('storageAccountName'))]",
               "properties": {
-                "isVersioningEnabled": true
+                "isVersioningEnabled": true,
+                "cors": {
+                  "corsRules": "[if(equals(length(parameters('blobCorsAllowedOrigins')), 0), createArray(), createArray(createObject('allowedOrigins', parameters('blobCorsAllowedOrigins'), 'allowedMethods', createArray('PUT'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('ETag', 'x-ms-request-id', 'x-ms-version'), 'maxAgeInSeconds', 3600)))]"
+                }
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
@@ -1138,9 +1197,6 @@
           },
           "location": {
             "value": "[parameters('location')]"
-          },
-          "agentPoolSubnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.subnetEgressId.value]"
           }
         },
         "template": {
@@ -1150,7 +1206,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "13902642366212421110"
+              "templateHash": "2527109446244967685"
             }
           },
           "parameters": {
@@ -1165,20 +1221,6 @@
               "metadata": {
                 "description": "Azure region for Container Registry resources."
               }
-            },
-            "agentPoolSubnetId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional subnet resource id used by the ACR dedicated build agent pool."
-              }
-            },
-            "agentPoolName": {
-              "type": "string",
-              "defaultValue": "[format('buildpool-{0}', parameters('environment'))]",
-              "metadata": {
-                "description": "Name of the dedicated ACR build agent pool."
-              }
             }
           },
           "resources": [
@@ -1188,33 +1230,16 @@
               "name": "[format('acralbaranes{0}', parameters('environment'))]",
               "location": "[parameters('location')]",
               "sku": {
-                "name": "Premium"
+                "name": "Standard"
               },
               "identity": {
                 "type": "SystemAssigned"
               },
               "properties": {
                 "adminUserEnabled": false,
-                "publicNetworkAccess": "Disabled",
-                "networkRuleBypassOptions": "AzureServices",
+                "publicNetworkAccess": "Enabled",
                 "dataEndpointEnabled": false
               }
-            },
-            {
-              "condition": "[not(empty(parameters('agentPoolSubnetId')))]",
-              "type": "Microsoft.ContainerRegistry/registries/agentPools",
-              "apiVersion": "2025-03-01-preview",
-              "name": "[format('{0}/{1}', format('acralbaranes{0}', parameters('environment')), parameters('agentPoolName'))]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "count": 1,
-                "os": "Linux",
-                "tier": "S2",
-                "virtualNetworkSubnetResourceId": "[parameters('agentPoolSubnetId')]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ContainerRegistry/registries', format('acralbaranes{0}', parameters('environment')))]"
-              ]
             }
           ],
           "outputs": {
@@ -1238,19 +1263,11 @@
                 "description": "Azure Container Registry login server."
               },
               "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', format('acralbaranes{0}', parameters('environment'))), '2023-07-01').loginServer]"
-            },
-            "agentPoolName": {
-              "type": "string",
-              "metadata": {
-                "description": "Dedicated ACR build agent pool name."
-              },
-              "value": "[if(not(empty(parameters('agentPoolSubnetId'))), parameters('agentPoolName'), '')]"
             }
           }
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network')]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]"
       ]
     },
@@ -2195,9 +2212,6 @@
           "cosmosResourceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos'), '2025-04-01').outputs.cosmosAccountId.value]"
           },
-          "acrResourceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr'), '2025-04-01').outputs.acrId.value]"
-          },
           "keyVaultResourceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'keyVault'), '2025-04-01').outputs.keyVaultId.value]"
           },
@@ -2218,7 +2232,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "3019912691098139228"
+              "templateHash": "2873149454633588090"
             }
           },
           "parameters": {
@@ -2272,13 +2286,6 @@
               "defaultValue": "",
               "metadata": {
                 "description": "Service Bus namespace resource id."
-              }
-            },
-            "acrResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Azure Container Registry resource id."
               }
             },
             "aiServicesResourceId": {
@@ -2345,14 +2352,6 @@
               "type": "Microsoft.Network/privateDnsZones",
               "apiVersion": "2020-06-01",
               "name": "privatelink.servicebus.windows.net",
-              "location": "global",
-              "tags": "[variables('tags')]"
-            },
-            {
-              "condition": "[not(empty(parameters('acrResourceId')))]",
-              "type": "Microsoft.Network/privateDnsZones",
-              "apiVersion": "2020-06-01",
-              "name": "privatelink.azurecr.io",
               "location": "global",
               "tags": "[variables('tags')]"
             },
@@ -2426,22 +2425,6 @@
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.servicebus.windows.net')]"
-              ]
-            },
-            {
-              "condition": "[not(empty(parameters('acrResourceId')))]",
-              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-              "apiVersion": "2020-06-01",
-              "name": "[format('{0}/{1}-link', 'privatelink.azurecr.io', variables('virtualNetworkName'))]",
-              "location": "global",
-              "properties": {
-                "virtualNetwork": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
-                },
-                "registrationEnabled": false
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.azurecr.io')]"
               ]
             },
             {
@@ -2637,50 +2620,6 @@
               ]
             },
             {
-              "condition": "[not(empty(parameters('acrResourceId')))]",
-              "type": "Microsoft.Network/privateEndpoints",
-              "apiVersion": "2023-04-01",
-              "name": "[format('pe-acr-{0}', parameters('environment'))]",
-              "location": "[parameters('location')]",
-              "tags": "[variables('tags')]",
-              "properties": {
-                "subnet": {
-                  "id": "[variables('privateEndpointSubnetResourceId')]"
-                },
-                "privateLinkServiceConnections": [
-                  {
-                    "name": "acr-registry",
-                    "properties": {
-                      "privateLinkServiceId": "[parameters('acrResourceId')]",
-                      "groupIds": [
-                        "registry"
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "condition": "[not(empty(parameters('acrResourceId')))]",
-              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-              "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', format('pe-acr-{0}', parameters('environment')), 'default')]",
-              "properties": {
-                "privateDnsZoneConfigs": [
-                  {
-                    "name": "acr-registry",
-                    "properties": {
-                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.azurecr.io')]"
-                    }
-                  }
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.azurecr.io')]",
-                "[resourceId('Microsoft.Network/privateEndpoints', format('pe-acr-{0}', parameters('environment')))]"
-              ]
-            },
-            {
               "condition": "[not(empty(parameters('aiServicesResourceId')))]",
               "type": "Microsoft.Network/privateEndpoints",
               "apiVersion": "2023-04-01",
@@ -2781,7 +2720,6 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'aiFoundry')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'docIntell')]",
@@ -4144,8 +4082,8 @@
           "location": {
             "value": "[parameters('location')]"
           },
-          "managedEnvironmentId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentId.value]"
+          "infrastructureSubnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.subnetUploadWebId.value]"
           },
           "acrLoginServer": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr'), '2025-04-01').outputs.acrLoginServer.value]"
@@ -4170,7 +4108,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "5620655351156105687"
+              "templateHash": "3579874189970852996"
             }
           },
           "parameters": {
@@ -4186,10 +4124,17 @@
                 "description": "Azure region for Container Apps resources."
               }
             },
-            "managedEnvironmentId": {
+            "infrastructureSubnetId": {
               "type": "string",
               "metadata": {
-                "description": "Existing Container Apps managed environment resource id used by upload-web."
+                "description": "Subnet resource ID delegated to the upload-web Container Apps environment."
+              }
+            },
+            "logAnalyticsWorkspaceName": {
+              "type": "string",
+              "defaultValue": "[format('log-albaranes-{0}', parameters('environment'))]",
+              "metadata": {
+                "description": "Name of the Log Analytics workspace used by the upload-web Container Apps environment."
               }
             },
             "acrLoginServer": {
@@ -4231,9 +4176,42 @@
               "service": "upload-web",
               "managed-by": "bicep"
             },
-            "resolvedUploadWebImage": "[if(empty(parameters('uploadWebImage')), format('{0}/verdecora-upload-web:latest', parameters('acrLoginServer')), parameters('uploadWebImage'))]"
+            "managedEnvironmentName": "[format('acae-upload-web-{0}', parameters('environment'))]",
+            "resolvedUploadWebImage": "[if(empty(parameters('uploadWebImage')), format('{0}/verdecora-upload-web:latest', parameters('acrLoginServer')), parameters('uploadWebImage'))]",
+            "docIntellEndpoint": "[format('https://verdecora-docintell-{0}.cognitiveservices.azure.com/', parameters('environment'))]",
+            "keyVaultUrl": "[format('https://kv-albaranes-{0}.vault.azure.net/', parameters('environment'))]",
+            "rawBlobContainerName": "albaranes-raw",
+            "serviceBusFullyQualifiedNamespace": "[format('sb-albaranes-{0}.servicebus.windows.net', parameters('environment'))]",
+            "serviceBusTopicName": "albaran-events",
+            "uploadSessionsContainerName": "upload-sessions"
           },
           "resources": [
+            {
+              "type": "Microsoft.App/managedEnvironments",
+              "apiVersion": "2025-01-01",
+              "name": "[variables('managedEnvironmentName')]",
+              "location": "[parameters('location')]",
+              "tags": "[variables('tags')]",
+              "properties": {
+                "appLogsConfiguration": {
+                  "destination": "log-analytics",
+                  "logAnalyticsConfiguration": {
+                    "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+                    "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]"
+                  }
+                },
+                "vnetConfiguration": {
+                  "infrastructureSubnetId": "[parameters('infrastructureSubnetId')]",
+                  "internal": false
+                },
+                "workloadProfiles": [
+                  {
+                    "name": "Consumption",
+                    "workloadProfileType": "Consumption"
+                  }
+                ]
+              }
+            },
             {
               "type": "Microsoft.App/containerApps",
               "apiVersion": "2025-01-01",
@@ -4244,7 +4222,7 @@
                 "type": "SystemAssigned"
               },
               "properties": {
-                "environmentId": "[parameters('managedEnvironmentId')]",
+                "environmentId": "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]",
                 "configuration": {
                   "activeRevisionsMode": "Single",
                   "registries": [
@@ -4254,7 +4232,7 @@
                     }
                   ],
                   "ingress": {
-                    "external": false,
+                    "external": true,
                     "allowInsecure": false,
                     "targetPort": 8000,
                     "transport": "Auto"
@@ -4271,11 +4249,39 @@
                           "value": "[parameters('storageAccountUrl')]"
                         },
                         {
+                          "name": "RAW_BLOB_CONTAINER",
+                          "value": "[variables('rawBlobContainerName')]"
+                        },
+                        {
+                          "name": "UPLOAD_SESSIONS_CONTAINER",
+                          "value": "[variables('uploadSessionsContainerName')]"
+                        },
+                        {
                           "name": "COSMOS_ENDPOINT",
                           "value": "[parameters('cosmosEndpoint')]"
                         },
                         {
-                          "name": "APPINSIGHTS_CONNECTION_STRING",
+                          "name": "DOCINTELL_ENDPOINT",
+                          "value": "[variables('docIntellEndpoint')]"
+                        },
+                        {
+                          "name": "SERVICEBUS_FQ_NAMESPACE",
+                          "value": "[variables('serviceBusFullyQualifiedNamespace')]"
+                        },
+                        {
+                          "name": "SERVICEBUS_TOPIC",
+                          "value": "[variables('serviceBusTopicName')]"
+                        },
+                        {
+                          "name": "KEY_VAULT_URL",
+                          "value": "[variables('keyVaultUrl')]"
+                        },
+                        {
+                          "name": "AZURE_TENANT_ID",
+                          "value": "[subscription().tenantId]"
+                        },
+                        {
+                          "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
                           "value": "[parameters('applicationInsightsConnectionString')]"
                         }
                       ],
@@ -4301,7 +4307,10 @@
                     "maxReplicas": 5
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -4312,12 +4321,33 @@
               },
               "value": "[resourceId('Microsoft.App/containerApps', format('verdecora-upload-web-{0}', parameters('environment')))]"
             },
+            "managedEnvironmentId": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web managed environment id."
+              },
+              "value": "[resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName'))]"
+            },
+            "managedEnvironmentDefaultDomain": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web managed environment default domain."
+              },
+              "value": "[reference(resourceId('Microsoft.App/managedEnvironments', variables('managedEnvironmentName')), '2025-01-01').defaultDomain]"
+            },
             "uploadWebAppName": {
               "type": "string",
               "metadata": {
                 "description": "Upload-web container app name."
               },
               "value": "[format('verdecora-upload-web-{0}', parameters('environment'))]"
+            },
+            "uploadWebFqdn": {
+              "type": "string",
+              "metadata": {
+                "description": "Upload-web public FQDN."
+              },
+              "value": "[reference(resourceId('Microsoft.App/containerApps', format('verdecora-upload-web-{0}', parameters('environment'))), '2025-01-01').configuration.ingress.fqdn]"
             },
             "uploadWebPrincipalId": {
               "type": "string",
@@ -4331,9 +4361,9 @@
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'acr')]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'cosmos')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'monitoring')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'network')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'storage')]"
       ]
     },
@@ -4352,12 +4382,7 @@
           "environment": {
             "value": "[parameters('environment')]"
           },
-          "backendFqdn": {
-            "value": "[format('{0}.internal.{1}', variables('uploadWebAppName'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentDefaultDomain.value)]"
-          },
-          "containerAppEnvironmentId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps'), '2025-04-01').outputs.managedEnvironmentId.value]"
-          }
+          "backendFqdn": "[if(parameters('enableUploadWeb'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'uploadWebApp'), '2025-04-01').outputs.uploadWebFqdn.value), createObject('value', ''))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -4366,7 +4391,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "2960699383250144279"
+              "templateHash": "3453708429512750682"
             }
           },
           "parameters": {
@@ -4376,23 +4401,17 @@
                 "description": "Deployment environment name."
               }
             },
-            "customDomainHostname": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Custom domain hostname for the upload web (e.g. upload.verdecora.example.com). Leave empty to use the default Front Door endpoint."
-              }
-            },
             "backendFqdn": {
               "type": "string",
               "metadata": {
-                "description": "Internal FQDN of the upload-web Container App used as the Private Link backend."
+                "description": "FQDN of the upload-web Container App origin."
               }
             },
             "containerAppEnvironmentId": {
               "type": "string",
+              "defaultValue": "",
               "metadata": {
-                "description": "Resource ID of the Container App Environment (for Private Link Service)."
+                "description": "Optional resource ID of the Container App Environment when Front Door must use Private Link. Leave empty for public origins."
               }
             }
           },
@@ -4408,7 +4427,18 @@
             "originGroupName": "upload-web-origins",
             "originName": "aca-upload-web",
             "routeName": "upload-web-route",
-            "wafPolicyName": "[format('wafverdecora{0}', parameters('environment'))]"
+            "wafPolicyName": "[format('wafverdecora{0}', parameters('environment'))]",
+            "originBaseProperties": {
+              "hostName": "[parameters('backendFqdn')]",
+              "httpPort": 80,
+              "httpsPort": 443,
+              "originHostHeader": "[parameters('backendFqdn')]",
+              "priority": 1,
+              "weight": 1000,
+              "enabledState": "Enabled",
+              "enforceCertificateNameCheck": true
+            },
+            "originPrivateLinkProperties": "[if(empty(parameters('containerAppEnvironmentId')), createObject(), createObject('sharedPrivateLinkResource', createObject('privateLink', createObject('id', parameters('containerAppEnvironmentId')), 'groupId', 'managedEnvironments', 'privateLinkLocation', 'swedencentral', 'requestMessage', 'Front Door Private Link for upload-web', 'status', 'Approved')))]"
           },
           "resources": [
             {
@@ -4491,25 +4521,7 @@
               "type": "Microsoft.Cdn/profiles/originGroups/origins",
               "apiVersion": "2024-09-01",
               "name": "[format('{0}/{1}/{2}', variables('profileName'), variables('originGroupName'), variables('originName'))]",
-              "properties": {
-                "hostName": "[parameters('backendFqdn')]",
-                "httpPort": 80,
-                "httpsPort": 443,
-                "originHostHeader": "[parameters('backendFqdn')]",
-                "priority": 1,
-                "weight": 1000,
-                "enabledState": "Enabled",
-                "sharedPrivateLinkResource": {
-                  "privateLink": {
-                    "id": "[parameters('containerAppEnvironmentId')]"
-                  },
-                  "groupId": "managedEnvironments",
-                  "privateLinkLocation": "swedencentral",
-                  "requestMessage": "Front Door Private Link for upload-web",
-                  "status": "Approved"
-                },
-                "enforceCertificateNameCheck": true
-              },
+              "properties": "[union(variables('originBaseProperties'), variables('originPrivateLinkProperties'))]",
               "dependsOn": [
                 "[resourceId('Microsoft.Cdn/profiles/originGroups', variables('profileName'), variables('originGroupName'))]"
               ]
@@ -4588,8 +4600,6 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'containerApps')]",
-        "[subscriptionResourceId('Microsoft.Resources/deployments', 'resourceGroup')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'uploadWebApp')]"
       ]
     },
@@ -4945,7 +4955,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "2956969929273550838"
+              "templateHash": "288928943340083084"
             }
           },
           "parameters": {
@@ -5040,7 +5050,7 @@
           },
           "variables": {
             "cosmosBuiltInDataContributorRoleDefinitionId": "00000000-0000-0000-0000-000000000002",
-            "serviceBusDataSenderRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+            "serviceBusDataSenderRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')]",
             "serviceBusDataReceiverRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')]",
             "storageBlobDataReaderRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1')]",
             "storageBlobDataContributorRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
@@ -5381,6 +5391,42 @@
                 "principalId": "[parameters('uploadWebPrincipalId')]",
                 "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosAccountName')), variables('cosmosBuiltInDataContributorRoleDefinitionId'))]",
                 "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosAccountName'))]"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('uploadWebPrincipalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
+              "name": "[guid(resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName')), parameters('uploadWebPrincipalId'), variables('serviceBusDataSenderRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('serviceBusDataSenderRoleDefinitionId')]"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('uploadWebPrincipalId'))), not(empty(parameters('docIntellAccountName'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('docIntellAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('docIntellAccountName')), parameters('uploadWebPrincipalId'), variables('cognitiveServicesUserRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('cognitiveServicesUserRoleDefinitionId')]"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('uploadWebPrincipalId'))), not(empty(parameters('keyVaultName'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+              "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('uploadWebPrincipalId'), variables('keyVaultSecretsUserRoleDefinitionId'), 'system')]",
+              "properties": {
+                "principalId": "[parameters('uploadWebPrincipalId')]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]"
               }
             },
             {

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -47,6 +47,12 @@ resource nsgEgress 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
   tags: tags
 }
 
+resource nsgUploadWeb 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+  name: 'nsg-upload-web-albaranes-${environment}'
+  location: location
+  tags: tags
+}
+
 resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   name: vnetName
   location: location
@@ -120,6 +126,23 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
           }
         }
       }
+      {
+        name: 'snet-upload-web'
+        properties: {
+          addressPrefix: '10.10.6.0/23'
+          networkSecurityGroup: {
+            id: nsgUploadWeb.id
+          }
+          delegations: [
+            {
+              name: 'acaDelegation'
+              properties: {
+                serviceName: 'Microsoft.App/environments'
+              }
+            }
+          ]
+        }
+      }
     ]
   }
 }
@@ -142,6 +165,9 @@ output subnetRunnersId string = vnet.properties.subnets[3].id
 @description('Egress subnet id.')
 output subnetEgressId string = vnet.properties.subnets[4].id
 
+@description('Upload-web ACA environment subnet id.')
+output subnetUploadWebId string = vnet.properties.subnets[5].id
+
 @description('ACA NSG id.')
 output nsgAcaId string = nsgAca.id
 
@@ -156,3 +182,6 @@ output nsgRunnersId string = nsgRunners.id
 
 @description('Egress NSG id.')
 output nsgEgressId string = nsgEgress.id
+
+@description('Upload-web ACA environment NSG id.')
+output nsgUploadWebId string = nsgUploadWeb.id

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -6,6 +6,9 @@ param environment string
 @description('Azure region for Storage resources.')
 param location string
 
+@description('Exact origins allowed to call Blob service CORS. Pass the Front Door/custom-domain origins explicitly because the default azurefd.net hostname is generated at deploy time.')
+param blobCorsAllowedOrigins array = []
+
 var tags = {
   project: 'verdecora-albaranes'
   env: environment
@@ -41,6 +44,25 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01'
   name: '${storageAccount.name}/default'
   properties: {
     isVersioningEnabled: true
+    cors: {
+      corsRules: length(blobCorsAllowedOrigins) == 0 ? [] : [
+        {
+          allowedOrigins: blobCorsAllowedOrigins
+          allowedMethods: [
+            'PUT'
+          ]
+          allowedHeaders: [
+            '*'
+          ]
+          exposedHeaders: [
+            'ETag'
+            'x-ms-request-id'
+            'x-ms-version'
+          ]
+          maxAgeInSeconds: 3600
+        }
+      ]
+    }
   }
 }
 

--- a/infra/modules/upload-web-app.bicep
+++ b/infra/modules/upload-web-app.bicep
@@ -6,8 +6,11 @@ param environment string
 @description('Azure region for Container Apps resources.')
 param location string
 
-@description('Existing Container Apps managed environment resource id used by upload-web.')
-param managedEnvironmentId string
+@description('Subnet resource ID delegated to the upload-web Container Apps environment.')
+param infrastructureSubnetId string
+
+@description('Name of the Log Analytics workspace used by the upload-web Container Apps environment.')
+param logAnalyticsWorkspaceName string = 'log-albaranes-${environment}'
 
 @description('Azure Container Registry login server used for the upload-web image.')
 param acrLoginServer string
@@ -30,7 +33,43 @@ var tags = {
   service: 'upload-web'
   'managed-by': 'bicep'
 }
+var managedEnvironmentName = 'acae-upload-web-${environment}'
 var resolvedUploadWebImage = empty(uploadWebImage) ? '${acrLoginServer}/verdecora-upload-web:latest' : uploadWebImage
+var docIntellEndpoint = 'https://verdecora-docintell-${environment}.cognitiveservices.azure.com/'
+var keyVaultUrl = 'https://kv-albaranes-${environment}.vault.azure.net/'
+var rawBlobContainerName = 'albaranes-raw'
+var serviceBusFullyQualifiedNamespace = 'sb-albaranes-${environment}.servicebus.windows.net'
+var serviceBusTopicName = 'albaran-events'
+var uploadSessionsContainerName = 'upload-sessions'
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-01-01' = {
+  name: managedEnvironmentName
+  location: location
+  tags: tags
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+    vnetConfiguration: {
+      infrastructureSubnetId: infrastructureSubnetId
+      internal: false
+    }
+    workloadProfiles: [
+      {
+        name: 'Consumption'
+        workloadProfileType: 'Consumption'
+      }
+    ]
+  }
+}
 
 resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
   name: 'verdecora-upload-web-${environment}'
@@ -40,7 +79,7 @@ resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    environmentId: managedEnvironmentId
+    environmentId: managedEnvironment.id
     configuration: {
       activeRevisionsMode: 'Single'
       registries: [
@@ -50,7 +89,7 @@ resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
         }
       ]
       ingress: {
-        external: false // Internal — only accessible via Front Door Private Link
+        external: true
         allowInsecure: false
         targetPort: 8000
         transport: 'Auto'
@@ -67,11 +106,39 @@ resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
               value: storageAccountUrl
             }
             {
+              name: 'RAW_BLOB_CONTAINER'
+              value: rawBlobContainerName
+            }
+            {
+              name: 'UPLOAD_SESSIONS_CONTAINER'
+              value: uploadSessionsContainerName
+            }
+            {
               name: 'COSMOS_ENDPOINT'
               value: cosmosEndpoint
             }
             {
-              name: 'APPINSIGHTS_CONNECTION_STRING'
+              name: 'DOCINTELL_ENDPOINT'
+              value: docIntellEndpoint
+            }
+            {
+              name: 'SERVICEBUS_FQ_NAMESPACE'
+              value: serviceBusFullyQualifiedNamespace
+            }
+            {
+              name: 'SERVICEBUS_TOPIC'
+              value: serviceBusTopicName
+            }
+            {
+              name: 'KEY_VAULT_URL'
+              value: keyVaultUrl
+            }
+            {
+              name: 'AZURE_TENANT_ID'
+              value: subscription().tenantId
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: applicationInsightsConnectionString
             }
           ]
@@ -103,8 +170,17 @@ resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
 @description('Upload-web container app id.')
 output uploadWebAppId string = uploadWebApp.id
 
+@description('Upload-web managed environment id.')
+output managedEnvironmentId string = managedEnvironment.id
+
+@description('Upload-web managed environment default domain.')
+output managedEnvironmentDefaultDomain string = managedEnvironment.properties.defaultDomain
+
 @description('Upload-web container app name.')
 output uploadWebAppName string = uploadWebApp.name
+
+@description('Upload-web public FQDN.')
+output uploadWebFqdn string = uploadWebApp.properties.configuration.ingress.fqdn
 
 @description('Upload-web managed identity principal id.')
 output uploadWebPrincipalId string = uploadWebApp.identity.principalId


### PR DESCRIPTION
## Summary
- add a dedicated upload-web ACA subnet/NSG and recreate upload-web in its own external VNet-integrated ACA environment
- point Front Door at the upload-web app FQDN while keeping Private Link optional in the module
- keep Storage private and add parameterized Blob CORS origins for browser PUT uploads

## Validation
- az containerapp env list -g rg-verdecoratest-dev
- az network vnet subnet list --vnet-name vnet-albaranes-dev -g rg-verdecoratest-dev
- az bicep build --file C:\repos\verdecoraTest\infra\modules\network.bicep
- az bicep build --file C:\repos\verdecoraTest\infra\modules\upload-web-app.bicep
- az bicep build --file C:\repos\verdecoraTest\infra\modules\frontdoor.bicep
- az bicep build --file C:\repos\verdecoraTest\infra\modules\storage.bicep
- az bicep build --file C:\repos\verdecoraTest\infra\modules\main.bicep

Closes #186