### PR TITLE
fix(infra): restore upload web MI access

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -26,6 +26,11 @@
 - Wired Upload Web to use middleware-backed auth/session state, moved logout to `src/upload_web/routes/auth.py`, and redirect logout through Easy Auth after clearing the app cookie.
 - Updated `src/upload_web/templates/base.html` and `src/upload_web/static/css/verdecora.css` so the logout control is highly visible and HTMX requests automatically send the server-rendered CSRF token.
 - Added `tests/unit/test_session_security.py` and extended dependency config (`itsdangerous`) to cover idle timeout, CSRF, headers, and logout cookie clearing.
+
+### 2026-05-08 — Issue #185 upload-web MI RBAC + env repair
+- `verdecora-upload-web-dev` was missing live ACA env vars beyond blob storage, so Upload Web had no runtime wiring for Document Intelligence preflight, Service Bus publish, Cosmos endpoint access, Key Vault URL, tenant ID, or Application Insights telemetry.
+- Updated `infra/modules/identity.bicep` so Upload Web gets `Cognitive Services User`, `Key Vault Secrets User`, `Cosmos DB Built-in Data Contributor`, and `Azure Service Bus Data Sender`; also corrected the shared Service Bus sender role GUID, which had mistakenly pointed at `Key Vault Secrets Officer`.
+- Updated `infra/modules/upload-web-app.bicep` to codify the required Upload Web env vars (`DOCINTELL_ENDPOINT`, `SERVICEBUS_FQ_NAMESPACE`, `SERVICEBUS_TOPIC`, `KEY_VAULT_URL`, `AZURE_TENANT_ID`, `APPLICATIONINSIGHTS_CONNECTION_STRING`, plus the blob container names) and applied the missing roles/env vars directly in Azure so dev testing is unblocked immediately.
 ## Decisions (Team Integration — 2026-05-07)
 
 ### 2026-05-07 — Merged from decisions/inbox/lambert-security-audit.md

--- a/.squad/decisions/inbox/lambert-rbac-envvars.md
+++ b/.squad/decisions/inbox/lambert-rbac-envvars.md
@@ -1,0 +1,8 @@
+# 2026-05-08 — Upload Web MI RBAC + env var remediation
+
+- Confirmed `verdecora-upload-web-dev` runtime drift: the ACA only had `STORAGE_ACCOUNT_URL`, `RAW_BLOB_CONTAINER`, and `UPLOAD_SESSIONS_CONTAINER` configured, so Document Intelligence preflight, Service Bus publish, Cosmos endpoint wiring, Key Vault URL, tenant ID, and Application Insights connection string were absent at runtime.
+- Updated `infra/modules/identity.bicep` so the Upload Web system-assigned MI receives the missing least-privilege access on Document Intelligence (`Cognitive Services User`), Key Vault (`Key Vault Secrets User`), Cosmos SQL RBAC (`Cosmos DB Built-in Data Contributor`), and Service Bus (`Azure Service Bus Data Sender`).
+- Corrected a tightly-coupled IaC bug in `identity.bicep`: the shared `serviceBusDataSenderRoleDefinitionId` constant pointed to `Key Vault Secrets Officer` instead of `Azure Service Bus Data Sender`. This would have produced wrong sender assignments for every workload using that helper.
+- Updated `infra/modules/upload-web-app.bicep` to codify the Upload Web runtime env vars required by `src/upload_web/config.py`, including `DOCINTELL_ENDPOINT`, `SERVICEBUS_FQ_NAMESPACE`, `SERVICEBUS_TOPIC`, `KEY_VAULT_URL`, `AZURE_TENANT_ID`, the blob container names, and the correctly named `APPLICATIONINSIGHTS_CONNECTION_STRING`.
+- Applied the missing RBAC assignments immediately in Azure for `verdecora-upload-web-dev` and updated the live ACA env vars so testing is unblocked before the PR merges.
+- Kept the change additive inside `identity.bicep` and `upload-web-app.bicep` to minimize overlap with Dallas's broader networking/front door work.

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -40,7 +40,7 @@ param escalationTimerPrincipalId string = ''
 param uploadWebPrincipalId string = ''
 
 var cosmosBuiltInDataContributorRoleDefinitionId = '00000000-0000-0000-0000-000000000002'
-var serviceBusDataSenderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
+var serviceBusDataSenderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')
 var serviceBusDataReceiverRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
 var storageBlobDataReaderRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1')
 var storageBlobDataContributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
@@ -361,6 +361,36 @@ resource uploadWebSystemAssignedCosmosRoleAssignment 'Microsoft.DocumentDB/datab
     principalId: uploadWebPrincipalId
     roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosBuiltInDataContributorRoleDefinitionId}'
     scope: cosmosAccount.id
+  }
+}
+
+resource uploadWebSystemAssignedServiceBusSenderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId)) {
+  name: guid(serviceBusNamespace.id, uploadWebPrincipalId, serviceBusDataSenderRoleDefinitionId, 'system')
+  scope: serviceBusNamespace
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataSenderRoleDefinitionId
+  }
+}
+
+resource uploadWebSystemAssignedDocIntellRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId) && !empty(docIntellAccountName)) {
+  name: guid(docIntellAccount.id, uploadWebPrincipalId, cognitiveServicesUserRoleDefinitionId, 'system')
+  scope: docIntellAccount
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: cognitiveServicesUserRoleDefinitionId
+  }
+}
+
+resource uploadWebSystemAssignedKeyVaultSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(uploadWebPrincipalId) && !empty(keyVaultName)) {
+  name: guid(keyVault.id, uploadWebPrincipalId, keyVaultSecretsUserRoleDefinitionId, 'system')
+  scope: keyVault
+  properties: {
+    principalId: uploadWebPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: keyVaultSecretsUserRoleDefinitionId
   }
 }
 

--- a/infra/modules/upload-web-app.bicep
+++ b/infra/modules/upload-web-app.bicep
@@ -31,6 +31,12 @@ var tags = {
   'managed-by': 'bicep'
 }
 var resolvedUploadWebImage = empty(uploadWebImage) ? '${acrLoginServer}/verdecora-upload-web:latest' : uploadWebImage
+var docIntellEndpoint = 'https://verdecora-docintell-${environment}.cognitiveservices.azure.com/'
+var keyVaultUrl = 'https://kv-albaranes-${environment}.vault.azure.net/'
+var rawBlobContainerName = 'albaranes-raw'
+var serviceBusFullyQualifiedNamespace = 'sb-albaranes-${environment}.servicebus.windows.net'
+var serviceBusTopicName = 'albaran-events'
+var uploadSessionsContainerName = 'upload-sessions'
 
 resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
   name: 'verdecora-upload-web-${environment}'
@@ -67,11 +73,39 @@ resource uploadWebApp 'Microsoft.App/containerApps@2025-01-01' = {
               value: storageAccountUrl
             }
             {
+              name: 'RAW_BLOB_CONTAINER'
+              value: rawBlobContainerName
+            }
+            {
+              name: 'UPLOAD_SESSIONS_CONTAINER'
+              value: uploadSessionsContainerName
+            }
+            {
               name: 'COSMOS_ENDPOINT'
               value: cosmosEndpoint
             }
             {
-              name: 'APPINSIGHTS_CONNECTION_STRING'
+              name: 'DOCINTELL_ENDPOINT'
+              value: docIntellEndpoint
+            }
+            {
+              name: 'SERVICEBUS_FQ_NAMESPACE'
+              value: serviceBusFullyQualifiedNamespace
+            }
+            {
+              name: 'SERVICEBUS_TOPIC'
+              value: serviceBusTopicName
+            }
+            {
+              name: 'KEY_VAULT_URL'
+              value: keyVaultUrl
+            }
+            {
+              name: 'AZURE_TENANT_ID'
+              value: subscription().tenantId
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: applicationInsightsConnectionString
             }
           ]


### PR DESCRIPTION
## Summary\n- add the missing Upload Web MI role assignments for Doc Intelligence, Key Vault, Cosmos SQL RBAC, and Service Bus\n- codify the Upload Web runtime env vars needed for Document Intelligence, Service Bus, Key Vault, telemetry, and blob containers\n- document Lambert's findings and note the shared Service Bus sender role GUID fix\n\n## Runtime applied\n- assigned the missing RBAC roles directly to \\erdecora-upload-web-dev\\\n- updated the live ACA env vars so dev testing is unblocked immediately\n\n## Validation\n- \\z bicep build --file infra/modules/identity.bicep\\\n- \\z bicep build --file infra/modules/upload-web-app.bicep\\\n- \\python -m pytest tests/unit/test_session_security.py tests/unit/test_upload_session.py tests/unit/test_upload_flow.py tests/unit/test_upload_backend.py tests/unit/config/test_security.py\\\n\nCloses #185